### PR TITLE
feat: Display predicted yearly cost of risks in risk matrix

### DIFF
--- a/plugins/ros/src/components/riskMatrix/AggregatedCost.tsx
+++ b/plugins/ros/src/components/riskMatrix/AggregatedCost.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+import { ROS } from '../interface/interfaces';
+import { useRiskMatrixStyles} from "./style";
+
+interface aggregatedCostProps {
+    ros: ROS;
+}
+
+export const AggregatedCost = ({
+    ros,
+}: aggregatedCostProps) => {
+
+    const riskConsequenceCosts = [5000, 50000, 500000, 5000000, 50000000]
+    const riskProbabilityFactors = [1/2, 1, 365/12, 365/52, 365] //Expected yearly occurrences
+
+    let cost = 0
+    ros.scenarier.forEach((scenario) => {
+        cost = cost + (riskConsequenceCosts[scenario.risiko.konsekvens-1]*riskProbabilityFactors[scenario.risiko.sannsynlighet-1])
+    })
+
+    return (
+        <h1>Scenariene i denne matrisen har en årlig kostnad på {cost} kroner og øre</h1>
+    )
+}

--- a/plugins/ros/src/components/riskMatrix/RiskMatrix.tsx
+++ b/plugins/ros/src/components/riskMatrix/RiskMatrix.tsx
@@ -5,6 +5,7 @@ import Box from '@mui/material/Box';
 import { ROS } from '../interface/interfaces';
 import { useRiskMatrixStyles } from './style';
 import { RiskMatrixScenarioCount } from './RiskMatrixScenarioCount';
+import { AggregatedCost} from "./AggregatedCost";
 
 export const RiskMatrix = ({ ros }: { ros: ROS }) => {
   const indices = [0, 1, 2, 3, 4];
@@ -59,6 +60,11 @@ export const RiskMatrix = ({ ros }: { ros: ROS }) => {
           <Box className={rightColumn}>
             <Typography variant="h6">Konsekvens</Typography>
           </Box>
+        </Box>
+        <Box>
+          <Paper>
+            <AggregatedCost ros={ros} />
+          </Paper>
         </Box>
       </InfoCard>
     </Box>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8554,7 +8554,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
-"@types/react-dom@*", "@types/react-dom@<18.0.0":
+"@types/react-dom@*", "@types/react-dom@<18.0.0", "@types/react-dom@^17":
   version "17.0.25"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.25.tgz#e0e5b3571e1069625b3a3da2b279379aa33a0cb5"
   integrity sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==


### PR DESCRIPTION
Veldig basic måte for å vise kostnad i kroner og øre.

Har en map over kostnad i kroner og sannsynlighet pr år, og summerer produkter av disse.

Dette er jo logikk som vel skal i backend, men for MVP-demo-formål så funker det.