### PR TITLE
Dynamic schemaVersion

### DIFF
--- a/plugins/ros/src/components/utils/hooks.ts
+++ b/plugins/ros/src/components/utils/hooks.ts
@@ -495,6 +495,7 @@ export const useFetchRoses = (
             id: rosDTO.rosId,
             content: content,
             status: rosDTO.rosStatus,
+            schemaVersion: content.skjemaVersjon,
           };
         });
 
@@ -555,6 +556,7 @@ export const useFetchRoses = (
           id: res.rosId,
           status: RosStatus.Draft,
           content: ros,
+          schemaVersion: ros.skjemaVersjon,
         };
 
         setRoses(roses ? [...roses, newROS] : [newROS]);
@@ -583,6 +585,7 @@ export const useFetchRoses = (
             ? RosStatus.Draft
             : selectedROS.status,
         isRequiresNewApproval: isRequiresNewApproval,
+        schemaVersion: ros.skjemaVersjon,
       };
       setSelectedROS(updatedROS);
       setRoses(roses.map(r => (r.id === selectedROS.id ? updatedROS : r)));

--- a/plugins/ros/src/components/utils/types.ts
+++ b/plugins/ros/src/components/utils/types.ts
@@ -3,6 +3,7 @@ export type ROSWithMetadata = {
   status: RosStatus;
   content: ROS;
   isRequiresNewApproval?: boolean;
+  schemaVersion: string;
 };
 
 export type ROS = {


### PR DESCRIPTION
Skjemaversjon inngår nå som et felt på ROSWithMetadata.

Se tilhørende PR i backend: https://github.com/bekk/kv-ros-backend/pull/new/feature/dynamic-schema-version
