### PR TITLE
Fix state when saving risk scenario fails

### DIFF
--- a/plugins/ros/src/components/utils/hooks.ts
+++ b/plugins/ros/src/components/utils/hooks.ts
@@ -407,11 +407,11 @@ export const useScenarioDrawer = (
     });
 
   const setEksisterendeTiltak = (eksisterendeTiltak: string) => {
-      setScenario({
-        ...scenario,
-        eksisterendeTiltak: eksisterendeTiltak
-      });
-  }
+    setScenario({
+      ...scenario,
+      eksisterendeTiltak: eksisterendeTiltak,
+    });
+  };
 
   const addTiltak = () =>
     setScenario({ ...scenario, tiltak: [...scenario.tiltak, emptyTiltak()] });
@@ -597,9 +597,11 @@ export const useFetchRoses = (
         isRequiresNewApproval: isRequiresNewApproval,
         schemaVersion: ros.skjemaVersjon,
       };
-      setSelectedROS(updatedROS);
-      setRoses(roses.map(r => (r.id === selectedROS.id ? updatedROS : r)));
-      putROS(updatedROS);
+
+      putROS(updatedROS, () => {
+        setSelectedROS(updatedROS);
+        setRoses(roses.map(r => (r.id === selectedROS.id ? updatedROS : r)));
+      });
     }
   };
 


### PR DESCRIPTION
only update risk score card state in frontend if risk scenario is saved successfully