### PR TITLE
feat: use latest schema version for new RiSc

### DIFF
--- a/plugins/ros/src/components/utils/hooks.ts
+++ b/plugins/ros/src/components/utils/hooks.ts
@@ -80,6 +80,7 @@ const useFetch = () => {
   const uriToFetchAllRoses = () => `${rosUri}/all`;
   const uriToFetchRos = (id: string) => `${rosUri}/${id}`;
   const uriToPublishROS = (id: string) => `${rosUri}/publish/${id}`;
+  const uriToFetchLatestJSONSchema = () => `${baseUri}/api/ros/schemas/latest`;
 
   const [response, setResponse] = useResponse();
 
@@ -127,6 +128,19 @@ const useFetch = () => {
       setResponse({
         statusMessage: 'Failed to fetch ROSes',
         status: ProcessingStatus.ErrorWhenFetchingROSes,
+      });
+    });
+
+  const fetchLatestJSONSchema = (
+    onSuccess: (response: string) => void,
+    onError?: () => void,
+  ) =>
+    fetch<string>(uriToFetchLatestJSONSchema(), 'GET', onSuccess, () => {
+      if (onError) onError();
+      setResponse({
+        statusMessage:
+          'Failed to fetch JSON schema. Fallback value 3.2 for schema version used',
+        status: ProcessingStatus.ErrorWhenFetchingJSONSchema,
       });
     });
 
@@ -186,7 +200,15 @@ const useFetch = () => {
       },
     );
 
-  return { fetchRoses, postROS, putROS, publishROS, response, setResponse };
+  return {
+    fetchRoses,
+    postROS,
+    putROS,
+    publishROS,
+    response,
+    setResponse,
+    fetchLatestJSONSchema,
+  };
 };
 
 export interface ScenarioDrawerProps {
@@ -480,8 +502,15 @@ export const useFetchRoses = (
   const navigate = useNavigate();
   const getRosPath = useRouteRef(rosRouteRef);
 
-  const { fetchRoses, postROS, putROS, publishROS, response, setResponse } =
-    useFetch();
+  const {
+    fetchRoses,
+    postROS,
+    putROS,
+    publishROS,
+    response,
+    setResponse,
+    fetchLatestJSONSchema,
+  } = useFetch();
 
   const [roses, setRoses] = useState<ROSWithMetadata[] | null>(null);
   const [selectedROS, setSelectedROS] = useState<ROSWithMetadata | null>(null);
@@ -557,28 +586,45 @@ export const useFetchRoses = (
   const createNewROS = (ros: ROS) => {
     setIsFetching(true);
     setSelectedROS(null);
-    postROS(
-      ros,
-      res => {
-        if (!res.rosId) throw new Error('No ROS ID returned');
+    fetchLatestJSONSchema(res => {
+      const resString = JSON.stringify(res);
+      const schema = JSON.parse(resString);
+      const schemaVersion = schema.properties.schemaVersion.default.replace(
+        /'/g,
+        '',
+      );
+      const newROS = {
+        ...ros,
+        skjemaVersjon: schemaVersion ? schemaVersion : '3.2',
+      };
 
-        const newROS = {
-          id: res.rosId,
-          status: RosStatus.Draft,
-          content: ros,
-          schemaVersion: ros.skjemaVersjon,
-        };
+      postROS(
+        newROS,
+        res2 => {
+          if (!res2.rosId) throw new Error('No ROS ID returned');
 
-        setRoses(roses ? [...roses, newROS] : [newROS]);
-        setSelectedROS(newROS);
-        setIsFetching(false);
-        navigate(getRosPath({ rosId: res.rosId }));
-      },
-      () => {
-        setSelectedROS(selectedROS);
-        setIsFetching(false);
-      },
-    );
+          const ROSWithLatestSchemaVersion = {
+            id: res2.rosId,
+            status: RosStatus.Draft,
+            content: ros,
+            schemaVersion: ros.skjemaVersjon,
+          };
+
+          setRoses(
+            roses
+              ? [...roses, ROSWithLatestSchemaVersion]
+              : [ROSWithLatestSchemaVersion],
+          );
+          setSelectedROS(ROSWithLatestSchemaVersion);
+          setIsFetching(false);
+          navigate(getRosPath({ rosId: res2.rosId }));
+        },
+        () => {
+          setSelectedROS(selectedROS);
+          setIsFetching(false);
+        },
+      );
+    });
   };
 
   const updateROS = (ros: ROS) => {

--- a/plugins/ros/src/components/utils/types.ts
+++ b/plugins/ros/src/components/utils/types.ts
@@ -76,4 +76,5 @@ export enum ProcessingStatus {
   ErrorWhenPublishingROS = 'ErrorWhenPublishingROS',
   ErrorWhenFetchingROSes = 'ErrorWhenFetchingROSes',
   ErrorWhenCreatingPullRequest = 'ErrorWhenCreatingPullRequest',
+  ErrorWhenFetchingJSONSchema = 'ErrorWhenFetchingJSONSchema',
 }

--- a/plugins/ros/src/components/utils/utilityfunctions.ts
+++ b/plugins/ros/src/components/utils/utilityfunctions.ts
@@ -56,7 +56,7 @@ export const getKonsekvensLevel = (risiko: Risiko) =>
   konsekvensOptions.indexOf(risiko.konsekvens) + 1;
 
 export const emptyROS = (): ROS => ({
-  skjemaVersjon: '3.2',
+  skjemaVersjon: '3.1',
   tittel: '',
   omfang: '',
   verdivurderinger: [],


### PR DESCRIPTION
Fetches the json schema and uses the latest version instead of a hardcoded value. Depends on: https://github.com/kartverket/backstage-plugin-risk-scorecard-backend/pull/103