### PR TITLE
feature: dark overlay when drawer is open

### DIFF
--- a/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
@@ -17,7 +17,7 @@ export const ScenarioDrawer = () => {
   return (
     <Drawer
       classes={{ paper: editMode ? paperEdit : paperView }}
-      variant="persistent"
+      variant="temporary"
       anchor="right"
       open={isOpen}
       onClose={closeScenario}

--- a/plugins/ros/src/components/utils/hooks.ts
+++ b/plugins/ros/src/components/utils/hooks.ts
@@ -287,7 +287,7 @@ export const useScenarioDrawer = (
     if (ros) {
       // If there is no scenario ID in the URL, close the drawer and reset the scenario to an empty state
       if (!scenarioIdFromParams) {
-        // setScenarioDrawerState(ScenarioDrawerState.Closed);
+        setScenarioDrawerState(ScenarioDrawerState.Closed);
         setScenarioWizardStep(null);
         const s = emptyScenario();
         setScenario(s);


### PR DESCRIPTION
- Dark overlay is outside a open drawer. 
- Drawer can be closed by clicking outside of it, and by "esc". 
