### PR TITLE
fix: styling adjustments for all screen sizes

### DIFF
--- a/plugins/ros/src/components/rosInfo/ROSInfo.tsx
+++ b/plugins/ros/src/components/rosInfo/ROSInfo.tsx
@@ -7,6 +7,7 @@ import { InfoCard } from '@backstage/core-components';
 import BorderColorOutlinedIcon from '@mui/icons-material/BorderColorOutlined';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { pluginRiScTranslationRef } from '../utils/translations';
+import { useRosInfoStyles } from './rosInfoStyle';
 
 interface RosInfoProps {
   ros: ROSWithMetadata;
@@ -16,6 +17,7 @@ interface RosInfoProps {
 
 export const ROSInfo = ({ ros, approveROS, edit }: RosInfoProps) => {
   const { h2, subtitle1, body2 } = useFontStyles();
+  const { infoCard } = useRosInfoStyles();
 
   const { t } = useTranslationRef(pluginRiScTranslationRef);
 
@@ -27,8 +29,17 @@ export const ROSInfo = ({ ros, approveROS, edit }: RosInfoProps) => {
           <BorderColorOutlinedIcon />
         </IconButton>
       </Grid>
-      <Grid item xs={6} style={{ display: 'flex', flexDirection: 'column' }}>
-        <InfoCard>
+      <Grid
+        item
+        xs={12}
+        sm={6}
+        md={8}
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <InfoCard className={infoCard}>
           <Box
             style={{
               display: 'flex',
@@ -47,7 +58,7 @@ export const ROSInfo = ({ ros, approveROS, edit }: RosInfoProps) => {
           <Typography className={body2}>{ros.content.omfang}</Typography>
         </InfoCard>
       </Grid>
-      <Grid item xs={6}>
+      <Grid item xs={12} sm={6} md={4}>
         <ROSStatusComponent selectedROS={ros} publishRosFn={approveROS} />
       </Grid>
     </Grid>

--- a/plugins/ros/src/components/rosInfo/rosInfoStyle.ts
+++ b/plugins/ros/src/components/rosInfo/rosInfoStyle.ts
@@ -1,0 +1,7 @@
+import { makeStyles } from '@material-ui/core';
+
+export const useRosInfoStyles = makeStyles(() => ({
+  infoCard: {
+    maxWidth: '600px',
+  },
+}));

--- a/plugins/ros/src/components/rosPlugin/ROSPlugin.tsx
+++ b/plugins/ros/src/components/rosPlugin/ROSPlugin.tsx
@@ -87,9 +87,17 @@ const Plugin = () => {
               </div>
             )}
 
-            <Grid container spacing={3}>
+            <Grid container spacing={4}>
               {roses !== null && roses.length !== 0 && (
-                <Grid item xs={3}>
+                <Grid
+                  item
+                  xs={12}
+                  sm={6}
+                  style={{
+                    maxWidth: '600px',
+                    minWidth: '300px',
+                  }}
+                >
                   <Dropdown<string>
                     options={roses.map(ros => ros.content.tittel) ?? []}
                     selectedValues={selectedROS?.content.tittel ?? ''}
@@ -107,6 +115,9 @@ const Plugin = () => {
                     color="primary"
                     onClick={openCreateRosDialog}
                     className={button}
+                    style={{
+                      minWidth: '205px',
+                    }}
                   >
                     {t('contentHeader.createNewButton')}
                   </Button>
@@ -122,10 +133,10 @@ const Plugin = () => {
                       edit={openEditRosDialog}
                     />
                   </Grid>
-                  <Grid item xs={6} md={7} lg={8}>
+                  <Grid item xs md={7} lg={8}>
                     <ScenarioTable ros={selectedROS.content} />
                   </Grid>
-                  <Grid item xs={6} md={5} lg={4}>
+                  <Grid item xs md={5} lg={4}>
                     <RiskMatrix ros={selectedROS.content} />
                   </Grid>
                 </>

--- a/plugins/ros/src/components/scenarioTable/ScenarioTable.tsx
+++ b/plugins/ros/src/components/scenarioTable/ScenarioTable.tsx
@@ -21,7 +21,7 @@ interface ScenarioTableProps {
 
 export const ScenarioTable = ({ ros }: ScenarioTableProps) => {
   const { newScenario, openScenario } = useContext(ScenarioContext)!!;
-  const { titleBox, rowBorder } = useTableStyles();
+  const { titleBox, rowBorder, tableCell } = useTableStyles();
 
   const { t } = useTranslationRef(pluginRiScTranslationRef);
 
@@ -72,16 +72,15 @@ export const ScenarioTable = ({ ros }: ScenarioTableProps) => {
             </Button>
           </Box>
         ) : (
-          <TableContainer component={Paper}>
+          <TableContainer style={{ overflow: 'auto' }} component={Paper}>
             <Table>
               <TableHead>
                 <TableRow className={rowBorder}>
                   <TableCell
+                    className={tableCell}
                     style={{
-                      display: 'flex',
                       width: '40%',
-                      paddingTop: '0.1rem',
-                      paddingBottom: '0.1rem',
+                      minWidth: '200px',
                     }}
                   >
                     <Typography
@@ -91,14 +90,7 @@ export const ScenarioTable = ({ ros }: ScenarioTableProps) => {
                       {t('dictionary.title')}
                     </Typography>
                   </TableCell>
-                  <TableCell
-                    style={{
-                      display: 'flex',
-                      width: '20%',
-                      paddingTop: '0.1rem',
-                      paddingBottom: '0.1rem',
-                    }}
-                  >
+                  <TableCell className={tableCell}>
                     <Typography
                       variant="subtitle1"
                       style={{ fontWeight: 'bold', textTransform: 'uppercase' }}
@@ -106,14 +98,7 @@ export const ScenarioTable = ({ ros }: ScenarioTableProps) => {
                       {t('dictionary.initialRisk')}
                     </Typography>
                   </TableCell>
-                  <TableCell
-                    style={{
-                      display: 'flex',
-                      width: '20%',
-                      paddingTop: '0.1rem',
-                      paddingBottom: '0.1rem',
-                    }}
-                  >
+                  <TableCell className={tableCell}>
                     <Typography
                       variant="subtitle1"
                       style={{ fontWeight: 'bold', textTransform: 'uppercase' }}
@@ -121,14 +106,7 @@ export const ScenarioTable = ({ ros }: ScenarioTableProps) => {
                       {t('dictionary.restRisk')}
                     </Typography>
                   </TableCell>
-                  <TableCell
-                    style={{
-                      display: 'flex',
-                      width: '20%',
-                      paddingTop: '0.1rem',
-                      paddingBottom: '0.1rem',
-                    }}
-                  >
+                  <TableCell className={tableCell}>
                     <Typography
                       variant="subtitle1"
                       style={{ fontWeight: 'bold', textTransform: 'uppercase' }}

--- a/plugins/ros/src/components/scenarioTable/ScenarioTableRow.tsx
+++ b/plugins/ros/src/components/scenarioTable/ScenarioTableRow.tsx
@@ -29,7 +29,7 @@ export const ScenarioTableRow = ({
     tiltak => tiltak.status === 'Fullført',
   ).length;
 
-  const { riskColor, rowBackground, rowBorder } = useTableStyles();
+  const { riskColor, rowBackground, rowBorder, tableCell } = useTableStyles();
 
   const { t } = useTranslationRef(pluginRiScTranslationRef);
 
@@ -43,22 +43,22 @@ export const ScenarioTableRow = ({
           alignItems: 'center',
           width: '100%',
           border: 'none',
+          padding: 0,
         }}
       >
-        <TableCell style={{ display: 'flex', width: '40%' }}>
+        <TableCell
+          className={tableCell}
+          style={{
+            width: '40%',
+            minWidth: '200px',
+          }}
+        >
           <Typography color="primary" style={{ fontWeight: 600 }}>
             {scenario.tittel}
           </Typography>
         </TableCell>
 
-        <TableCell
-          style={{
-            display: 'flex',
-            width: '20%',
-            alignItems: 'center',
-            gap: '0.4rem',
-          }}
-        >
+        <TableCell className={tableCell}>
           <Paper
             className={riskColor}
             style={{
@@ -69,15 +69,7 @@ export const ScenarioTableRow = ({
           {t('scenarioTable.columns.probabilityChar')}:{sannsynlighet}
         </TableCell>
 
-        <TableCell
-          style={{
-            display: 'flex',
-            width: '20%',
-            alignItems: 'center',
-            justifyContent: 'flex-start',
-            gap: '0.4rem',
-          }}
-        >
+        <TableCell className={tableCell}>
           <Paper
             className={riskColor}
             style={{
@@ -87,7 +79,7 @@ export const ScenarioTableRow = ({
           {t('scenarioTable.columns.consequenceChar')}:{restKonsekvens}{' '}
           {t('scenarioTable.columns.probabilityChar')}:{restSannsynlighet}
         </TableCell>
-        <TableCell style={{ display: 'flex', width: '20%' }}>
+        <TableCell className={tableCell}>
           {fullførteTiltak}/{scenario.tiltak.length}{' '}
           {t('scenarioTable.columns.completed')}
         </TableCell>

--- a/plugins/ros/src/components/scenarioTable/ScenarioTableStyles.ts
+++ b/plugins/ros/src/components/scenarioTable/ScenarioTableStyles.ts
@@ -31,4 +31,11 @@ export const useTableStyles = makeStyles((theme: Theme) => ({
         ? '1px solid #616161'
         : '1px solid #0000001f',
   },
+  tableCell: {
+    display: 'flex',
+    width: '20%',
+    minWidth: '120px',
+    padding: '20px 10px 20px 16px',
+    gap: '0.4rem',
+  },
 }));


### PR DESCRIPTION
![Screenshot 2024-04-19 at 11 02 20](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/assets/3618008/297d3e25-5aec-419a-98ce-b70e7d3119dc)
![Screenshot 2024-04-19 at 11 02 27](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/assets/3618008/7c2af1ef-114c-4832-954c-46bb79667578)
![Screenshot 2024-04-19 at 11 02 42](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/assets/3618008/a1502308-ee6b-478f-b5fd-efc7daed36c1)
![Screenshot 2024-04-19 at 11 02 53](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/assets/3618008/4541a785-491b-416e-85b2-173872e33c4b)
