### PR TITLE
fix: styling adjustments for status chip

### DIFF
--- a/plugins/ros/src/components/rosInfo/rosStatus/StatusChip.tsx
+++ b/plugins/ros/src/components/rosInfo/rosStatus/StatusChip.tsx
@@ -1,5 +1,10 @@
 import Chip from '@material-ui/core/Chip';
-import React, { ReactComponentElement, useEffect, useState } from 'react';
+import React, {
+  ReactComponentElement,
+  ReactNode,
+  useEffect,
+  useState,
+} from 'react';
 import { RosStatus } from '../../utils/types';
 import { useStatusChipStyles, useStatusTextStyles } from './statusChipStyle';
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
@@ -25,9 +30,8 @@ const getChipColor = (status: RosStatus, classes: ClassNameMap): string => {
   }
 };
 
-const getChipTextStatus = (status: RosStatus): string => {
+const chipText = (status: RosStatus): string => {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
-
   switch (status) {
     case RosStatus.Draft:
       return t('rosStatus.statusBadge.missing');
@@ -37,6 +41,11 @@ const getChipTextStatus = (status: RosStatus): string => {
     default:
       return t('rosStatus.statusBadge.error');
   }
+};
+
+const getChipTextStatus = (status: RosStatus): ReactNode => {
+  const { statusChipText } = useStatusChipStyles();
+  return <span className={statusChipText}>{chipText(status)}</span>;
 };
 
 const getPRStatus = (
@@ -56,7 +65,12 @@ const getPRStatus = (
     case RosStatus.Draft:
     case RosStatus.Published:
     default:
-      return null;
+      return (
+        <Typography className={classes.prStatus}>
+          <GitHubIcon className={classes.prIcon} />
+          {t('rosStatus.prStatus')}
+        </Typography>
+      );
   }
 };
 export const StatusChip = ({ currentRosStatus }: ChipProps) => {
@@ -71,7 +85,12 @@ export const StatusChip = ({ currentRosStatus }: ChipProps) => {
   }, [currentRosStatus, chipClasses]);
 
   return (
-    <Grid container direction="column" spacing={0}>
+    <Grid
+      container
+      direction="column"
+      spacing={0}
+      style={{ alignItems: 'end' }}
+    >
       <Grid item>
         <Chip
           color="primary"

--- a/plugins/ros/src/components/rosInfo/rosStatus/statusChipStyle.ts
+++ b/plugins/ros/src/components/rosInfo/rosStatus/statusChipStyle.ts
@@ -3,7 +3,13 @@ import { makeStyles } from '@material-ui/core';
 export const useStatusChipStyles = makeStyles(() => ({
   statusChip: {
     borderRadius: '7px',
-    maxHeight: '25px',
+    maxHeight: 'fit-content',
+    height: 'fit-content',
+    margin: '0px',
+  },
+
+  statusChipText: {
+    whiteSpace: 'normal',
   },
 
   statusIcon: {
@@ -28,7 +34,7 @@ export const useStatusChipStyles = makeStyles(() => ({
 
 export const useStatusTextStyles = makeStyles(() => ({
   prStatus: {
-    fontSize: '12px',
+    fontSize: '14px',
     wrap: 'wrap',
   },
   prIcon: {


### PR DESCRIPTION
<img width="1156" alt="Screenshot 2024-04-22 at 13 14 28" src="https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/assets/3618008/fbfb8d70-a6bf-4335-9ca1-ea3368a02789">
![Uploading Screenshot 2024-04-22 at 13.15.01.png…]()
