### PR TITLE
fix: min width for wizard tables

### DIFF
--- a/plugins/ros/src/components/scenarioDrawer/edit/tabs/konsekvens/KonsekvensTable.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/edit/tabs/konsekvens/KonsekvensTable.tsx
@@ -5,10 +5,11 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 
 export const useTableStyles = makeStyles((theme: Theme) => ({
   table: {
+    display: 'flex',
     borderCollapse: 'separate',
     borderSpacing: '0.3rem 0',
     width: '100%',
-    tableLayout: 'fixed',
+    overflowX: 'auto',
   },
   labelCell: {
     writingMode: 'vertical-rl',
@@ -22,6 +23,7 @@ export const useTableStyles = makeStyles((theme: Theme) => ({
     border: '1px solid grey',
     textAlign: 'left',
     verticalAlign: 'top',
+    minWidth: '135px',
   },
   voidCell: {
     padding: theme.spacing(1.5),

--- a/plugins/ros/src/components/scenarioWizard/ScenarioWizard.tsx
+++ b/plugins/ros/src/components/scenarioWizard/ScenarioWizard.tsx
@@ -27,6 +27,7 @@ const useStyle = makeStyles((theme: Theme) => ({
     width: '100%',
   },
   container: {
+    width: '100%',
     maxWidth: theme.spacing(100),
   },
   header: {


### PR DESCRIPTION
![Screenshot 2024-04-23 at 10 21 02](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/assets/3618008/b8aa24b4-4999-46a1-9412-fa026f3f7fcf)
