### PR TITLE
Style/edit icons

### DIFF
--- a/plugins/ros/src/components/scenarioDrawer/style.ts
+++ b/plugins/ros/src/components/scenarioDrawer/style.ts
@@ -66,6 +66,9 @@ export const useScenarioDrawerContentStyles = makeStyles((theme: Theme) => ({
     padding: theme.spacing(2),
     marginBottom: theme.palette.type === 'dark' ? theme.spacing(1) : '7px',
     backgroundColor: theme.palette.type === 'dark' ? '#55555519' : '#e0e0e019',
+  },
+  editIcon: {
+    color: theme.palette.type === 'dark' ? '#fff' : 'rgba(0, 0, 0, 0.54)'
   }
 }));
 

--- a/plugins/ros/src/components/scenarioDrawer/view/RiskView.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/view/RiskView.tsx
@@ -42,7 +42,7 @@ export const RiskView = () => {
                             variant="text"
                             color="primary"
                             onClick={() => editScenario('initialRisk')}
-                            startIcon={<EditIcon />}
+                            startIcon={<EditIcon style={{ color: 'rgba(0, 0, 0, 0.54)' }} aria-label='Edit' />}
                         />
                     </Grid>
 
@@ -119,7 +119,7 @@ export const RiskView = () => {
                             variant="text"
                             color="primary"
                             onClick={() => editScenario('restRisk')}
-                            startIcon={<EditIcon />}
+                            startIcon={<EditIcon style={{ color: 'rgba(0, 0, 0, 0.54)' }} aria-label='Edit' />}
                         />
                     </Grid>
 

--- a/plugins/ros/src/components/scenarioDrawer/view/RiskView.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/view/RiskView.tsx
@@ -15,7 +15,7 @@ import { ScenarioContext } from '../../riScPlugin/ScenarioContext';
 import EditIcon from '@mui/icons-material/Edit';
 
 export const RiskView = () => {
-    const { risikoBadge, titleAndButton, section } =
+    const { risikoBadge, titleAndButton, section, editIcon } =
         useScenarioDrawerContentStyles();
     const { h3, body1, label, button } = useFontStyles();
 
@@ -42,7 +42,7 @@ export const RiskView = () => {
                             variant="text"
                             color="primary"
                             onClick={() => editScenario('initialRisk')}
-                            startIcon={<EditIcon style={{ color: 'rgba(0, 0, 0, 0.54)' }} aria-label='Edit' />}
+                            startIcon={<EditIcon className={editIcon} aria-label='Edit' />}
                         />
                     </Grid>
 
@@ -119,7 +119,7 @@ export const RiskView = () => {
                             variant="text"
                             color="primary"
                             onClick={() => editScenario('restRisk')}
-                            startIcon={<EditIcon style={{ color: 'rgba(0, 0, 0, 0.54)' }} aria-label='Edit' />}
+                            startIcon={<EditIcon className={editIcon} aria-label='Edit' />}
                         />
                     </Grid>
 

--- a/plugins/ros/src/components/scenarioDrawer/view/ScenarioDrawerView.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/view/ScenarioDrawerView.tsx
@@ -86,7 +86,7 @@ export const ScenarioDrawerView = () => {
               variant="text"
               color="primary"
               onClick={() => editScenario('measure')}
-              startIcon={<EditIcon />}
+              startIcon={<EditIcon style={{ color: 'rgba(0, 0, 0, 0.54)' }} aria-label='Edit' />}
             ></Button>
           </Grid>
           {scenario.actions.map((action, index) => (

--- a/plugins/ros/src/components/scenarioDrawer/view/ScenarioDrawerView.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/view/ScenarioDrawerView.tsx
@@ -14,7 +14,7 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { pluginRiScTranslationRef } from '../../utils/translations';
 
 export const ScenarioDrawerView = () => {
-  const { buttons, titleAndButton, section } = useScenarioDrawerContentStyles();
+  const { buttons, titleAndButton, section, editIcon } = useScenarioDrawerContentStyles();
 
   const { h3, button } = useFontStyles();
 
@@ -86,7 +86,7 @@ export const ScenarioDrawerView = () => {
               variant="text"
               color="primary"
               onClick={() => editScenario('measure')}
-              startIcon={<EditIcon style={{ color: 'rgba(0, 0, 0, 0.54)' }} aria-label='Edit' />}
+              startIcon={<EditIcon className={editIcon} aria-label='Edit' />}
             ></Button>
           </Grid>
           {scenario.actions.map((action, index) => (

--- a/plugins/ros/src/components/scenarioDrawer/view/ScenarioView.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/view/ScenarioView.tsx
@@ -9,7 +9,7 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import EditIcon from '@mui/icons-material/Edit';
 
 export const ScenarioView = () => {
-    const { header, titleAndButton, section } = useScenarioDrawerContentStyles();
+    const { header, titleAndButton, section, editIcon } = useScenarioDrawerContentStyles();
 
     const { h1, h3, body2, label, button } = useFontStyles();
 
@@ -30,7 +30,7 @@ export const ScenarioView = () => {
                             variant="text"
                             color="primary"
                             onClick={() => editScenario('scenario')}
-                            startIcon={<EditIcon style={{ color: 'rgba(0, 0, 0, 0.54)' }} aria-label='Edit' />}
+                            startIcon={<EditIcon className={editIcon} aria-label='Edit' />}
                         />
                     </Grid>
 

--- a/plugins/ros/src/components/scenarioDrawer/view/ScenarioView.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/view/ScenarioView.tsx
@@ -30,7 +30,7 @@ export const ScenarioView = () => {
                             variant="text"
                             color="primary"
                             onClick={() => editScenario('scenario')}
-                            startIcon={<EditIcon />}
+                            startIcon={<EditIcon style={{ color: 'rgba(0, 0, 0, 0.54)' }} aria-label='Edit' />}
                         />
                     </Grid>
 


### PR DESCRIPTION
Endrer farge på Edit-ikon slik at det matcher andre forekomster av ikonet
Også lagt på aria-label

<img width="555" alt="image" src="https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/assets/29568022/d5a1a307-b513-4955-b052-09d5acfb7cd1">


Merk at hover-effekten ikke er løst enda.