### PR TITLE
feat: show actions as 'x planned' or 'completed' in scenario table

### DIFF
--- a/plugins/ros/src/components/scenarioTable/ScenarioTableRow.tsx
+++ b/plugins/ros/src/components/scenarioTable/ScenarioTableRow.tsx
@@ -25,9 +25,9 @@ export const ScenarioTableRow = ({
     probabilityOptions.indexOf(scenario.remainingRisk.probability) + 1;
   const restKonsekvens =
     consequenceOptions.indexOf(scenario.remainingRisk.consequence) + 1;
-  const fullførteTiltak = scenario.actions.filter(
-    tiltak => tiltak.status === 'Fullført',
-  ).length;
+  const remainingActions = scenario.actions.filter(
+    a => a.status !== 'Completed',
+  );
 
   const { riskColor, rowBackground, rowBorder, tableCell } = useTableStyles();
 
@@ -69,8 +69,13 @@ export const ScenarioTableRow = ({
           {t('scenarioTable.columns.probabilityChar')}:{sannsynlighet}
         </TableCell>
         <TableCell className={tableCell}>
-          {fullførteTiltak}/{scenario.actions.length}{' '}
-          {t('scenarioTable.columns.completed')}
+          {remainingActions.length > 0 ? (
+            <>
+              {remainingActions.length} {t('dictionary.planned').toLowerCase()}
+            </>
+          ) : (
+            t('dictionary.completed')
+          )}
         </TableCell>
         <TableCell className={tableCell}>
           <Paper

--- a/plugins/ros/src/components/utils/translations.ts
+++ b/plugins/ros/src/components/utils/translations.ts
@@ -13,6 +13,7 @@ export const pluginRiScTranslationRef = createTranslationRef({
     dictionary: {
       cancel: 'Cancel',
       close: 'Close',
+      completed: 'Completed',
       confirm: 'Confirm',
       consequence: 'Consequence', // Severity, Impact, Effect or Consequence
       deadline: 'Deadline', // Deadline or Due date
@@ -25,6 +26,7 @@ export const pluginRiScTranslationRef = createTranslationRef({
       measure: 'Actions', // Measure, Action or Initiative
       measureOwner: 'Responsible', // Responsible? Measure owner? Initiative owner?
       next: 'Next',
+      planned: 'Planned',
       previous: 'Previous',
       probability: 'Probability', // Likelihood or Probability
       restRisk: 'Remaining risk', // Residual or Remaining risk
@@ -246,6 +248,7 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
 
           'dictionary.cancel': 'Avbryt',
           'dictionary.close': 'Lukk',
+          'dictionary.completed': 'Fullført',
           'dictionary.confirm': 'Bekreft',
           'dictionary.consequence': 'Konsekvens',
           'dictionary.deadline': 'Frist',
@@ -258,6 +261,7 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
           'dictionary.measure': 'Tiltak',
           'dictionary.measureOwner': 'Tiltakseier',
           'dictionary.next': 'Neste',
+          'dictionary.planned': 'Planlagt',
           'dictionary.previous': 'Forrige',
           'dictionary.probability': 'Sannsynlighet',
           'dictionary.restRisk': 'Restrisiko',


### PR DESCRIPTION
![image](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/assets/43824602/3a6d3e7b-3f66-4516-a529-884821d3710f)
