### PR TITLE
Feature/edit-actionstatus-in-view

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -38,7 +38,7 @@
     "@backstage/plugin-techdocs-module-addons-contrib": "^1.1.3",
     "@backstage/plugin-techdocs-react": "^1.1.14",
     "@backstage/plugin-user-settings": "^0.7.14",
-    "@kartverket/backstage-plugin-risk-scorecard": "1.0.0",
+    "@kartverket/backstage-plugin-risk-scorecard": "^1.0.4",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "react": "^17.0.2",

--- a/plugins/ros/src/components/scenarioDrawer/view/ScenarioDrawerView.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/view/ScenarioDrawerView.tsx
@@ -14,7 +14,8 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { pluginRiScTranslationRef } from '../../utils/translations';
 
 export const ScenarioDrawerView = () => {
-  const { buttons, titleAndButton, section, editIcon } = useScenarioDrawerContentStyles();
+  const { buttons, titleAndButton, section, editIcon } =
+    useScenarioDrawerContentStyles();
 
   const { h3, button } = useFontStyles();
 
@@ -24,6 +25,7 @@ export const ScenarioDrawerView = () => {
     openDeleteConfirmation,
     closeScenario,
     editScenario,
+    updateTiltak,
   } = useContext(ScenarioContext)!!;
 
   const { t } = useTranslationRef(pluginRiScTranslationRef);
@@ -86,13 +88,20 @@ export const ScenarioDrawerView = () => {
               variant="text"
               color="primary"
               onClick={() => editScenario('measure')}
-              startIcon={<EditIcon className={editIcon} aria-label='Edit' />}
-            ></Button>
+              startIcon={<EditIcon className={editIcon} aria-label="Edit" />}
+            />
           </Grid>
           {scenario.actions.map((action, index) => (
             <>
-              <TiltakView tiltak={action} index={index + 1} />
-              {index !== (scenario.actions.length - 1) && <Divider variant="fullWidth" />}
+              <TiltakView
+                tiltak={action}
+                index={index + 1}
+                updateTiltak={updateTiltak}
+                saveScenario={saveScenario}
+              />
+              {index !== scenario.actions.length - 1 && (
+                <Divider variant="fullWidth" />
+              )}
             </>
           ))}
         </Paper>

--- a/plugins/ros/src/components/scenarioDrawer/view/TiltakView.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/view/TiltakView.tsx
@@ -1,28 +1,51 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Action as ITiltak } from '../../utils/types';
-import { Divider, Grid, Paper, Typography } from '@material-ui/core';
+import { Grid, Typography } from '@material-ui/core';
 import { useFontStyles, useScenarioDrawerContentStyles } from '../style';
 import { useTiltakViewStyles } from './style';
 import { formatDate } from '../../utils/utilityfunctions';
-import Chip from '@material-ui/core/Chip';
 import { pluginRiScTranslationRef } from '../../utils/translations';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+
+import { ChipDropdown } from '../../utils/ChipDropdown';
+import { actionStatusOptions } from '../../utils/constants';
 
 interface TiltakProps {
   tiltak: ITiltak;
   index: number;
+  updateTiltak: (tiltak: ITiltak) => void;
+  saveScenario: () => void;
 }
 
-export const TiltakView = ({ tiltak, index }: TiltakProps) => {
+export const TiltakView = ({
+  tiltak,
+  index,
+  updateTiltak,
+  saveScenario,
+}: TiltakProps) => {
   const { measure } = useScenarioDrawerContentStyles();
   const { alignCenter, justifyEnd } = useTiltakViewStyles();
   const { body2, label } = useFontStyles();
   const { t } = useTranslationRef(pluginRiScTranslationRef);
+  const [previousTiltak, setPreviousTiltak] = useState(tiltak);
+
+  useEffect(() => {
+    if (previousTiltak !== tiltak) {
+      saveScenario();
+      setPreviousTiltak(tiltak);
+    }
+  }, [tiltak, saveScenario, previousTiltak]);
+
+  const setStatus = (status: string) => {
+    updateTiltak({
+      ...tiltak,
+      status: status,
+    });
+  };
 
   return (
-
     <Grid container className={measure}>
-      <Grid item xs={12} className={alignCenter} >
+      <Grid item xs={12} className={alignCenter}>
         <Grid item xs={6}>
           <Typography className={label}>
             {t('dictionary.measure')} {index}
@@ -30,15 +53,10 @@ export const TiltakView = ({ tiltak, index }: TiltakProps) => {
         </Grid>
 
         <Grid item xs={6} className={justifyEnd}>
-          <Chip
-            label={tiltak.status}
-            size="small"
-            style={{
-              margin: 0,
-              padding: 0,
-              backgroundColor: '#D9D9D9',
-              color: '#000000',
-            }}
+          <ChipDropdown
+            options={actionStatusOptions}
+            selectedValue={tiltak.status}
+            handleChange={setStatus}
           />
         </Grid>
       </Grid>
@@ -56,9 +74,7 @@ export const TiltakView = ({ tiltak, index }: TiltakProps) => {
 
       <Grid item xs={4}>
         <Typography className={label}>{t('dictionary.deadline')}</Typography>
-        <Typography className={body2}>
-          {formatDate(tiltak.deadline)}
-        </Typography>
+        <Typography className={body2}>{formatDate(tiltak.deadline)}</Typography>
       </Grid>
     </Grid>
   );

--- a/plugins/ros/src/components/utils/ChipDropdown.tsx
+++ b/plugins/ros/src/components/utils/ChipDropdown.tsx
@@ -1,0 +1,50 @@
+import Chip from '@material-ui/core/Chip';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import React, { useState } from 'react';
+
+interface ChipDropdownProps {
+  selectedValue: string;
+  handleChange: (value: string) => void;
+  options: string[];
+}
+
+export const ChipDropdown = ({
+  options,
+  selectedValue,
+  handleChange,
+}: ChipDropdownProps) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
+  const handleClick = (item: string) => {
+    setAnchorEl(null);
+    handleChange(item);
+  };
+
+  return (
+    <>
+      <Chip
+        style={{
+          margin: 0,
+          padding: 0,
+          backgroundColor: '#D9D9D9',
+          color: '#000000',
+        }}
+        label={selectedValue}
+        onClick={e => setAnchorEl(e.currentTarget)}
+        icon={<KeyboardArrowDownIcon style={{ color: '#000000' }} />}
+      />
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={() => setAnchorEl(null)}
+      >
+        {options.map(item => (
+          <MenuItem key={item} onClick={() => handleClick(item)}>
+            {item}
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+};

--- a/plugins/ros/src/components/utils/ChipDropdown.tsx
+++ b/plugins/ros/src/components/utils/ChipDropdown.tsx
@@ -16,6 +16,7 @@ export const ChipDropdown = ({
   handleChange,
 }: ChipDropdownProps) => {
   const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
+  const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLDivElement | null>(null);
   const handleClick = (item: string) => {
     setAnchorEl(null);
     handleChange(item);
@@ -31,13 +32,25 @@ export const ChipDropdown = ({
           color: '#000000',
         }}
         label={selectedValue}
-        onClick={e => setAnchorEl(e.currentTarget)}
+        onClick={e => {
+          setAnchorEl(e.currentTarget);
+          setMenuAnchorEl(e.currentTarget);
+        }}
         icon={<KeyboardArrowDownIcon style={{ color: '#000000' }} />}
       />
       <Menu
-        anchorEl={anchorEl}
+        anchorEl={menuAnchorEl}
         open={Boolean(anchorEl)}
         onClose={() => setAnchorEl(null)}
+        getContentAnchorEl={null}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}
       >
         {options.map(item => (
           <MenuItem key={item} onClick={() => handleClick(item)}>

--- a/plugins/ros/src/components/utils/hooks.ts
+++ b/plugins/ros/src/components/utils/hooks.ts
@@ -349,6 +349,22 @@ export const useScenarioDrawer = (
     setSearchParams({ step: step });
   };
 
+  const validateScenario = () => {
+    if (scenario.title === '') {
+      setScenarioErrors({
+        ...scenarioErrors,
+        tittel: true,
+      });
+      return false;
+    }
+    setScenarioErrors({
+      ...scenarioErrors,
+      tittel: false,
+    });
+
+    return true;
+  };
+
   const saveScenario = () => {
     if (riSc) {
       if (validateScenario()) {
@@ -453,11 +469,15 @@ export const useScenarioDrawer = (
   const addTiltak = () =>
     setScenario({ ...scenario, actions: [...scenario.actions, emptyTiltak()] });
 
-  const updateTiltak = (tiltak: Action) => {
+  const updateTiltak = (tiltak: Action, callback?: () => void) => {
     const updatedTiltak = scenario.actions.some(t => t.ID === tiltak.ID)
       ? scenario.actions.map(t => (t.ID === tiltak.ID ? tiltak : t))
       : [...scenario.actions, tiltak];
     setScenario({ ...scenario, actions: updatedTiltak });
+
+    if (callback !== undefined) {
+      callback();
+    }
   };
 
   const deleteTiltak = (tiltak: Action) => {
@@ -485,22 +505,6 @@ export const useScenarioDrawer = (
         consequence: consequenceOptions[konsekvensLevel - 1],
       },
     });
-
-  const validateScenario = () => {
-    if (scenario.title === '') {
-      setScenarioErrors({
-        ...scenarioErrors,
-        tittel: true,
-      });
-      return false;
-    } else {
-      setScenarioErrors({
-        ...scenarioErrors,
-        tittel: false,
-      });
-    }
-    return true;
-  };
 
   return {
     scenarioDrawerState,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5586,27 +5586,6 @@
   resolved "https://registry.yarnpkg.com/@kamilkisiela/fast-url-parser/-/fast-url-parser-1.1.4.tgz#9d68877a489107411b953c54ea65d0658b515809"
   integrity sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew==
 
-"@kartverket/backstage-plugin-risk-scorecard@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@kartverket/backstage-plugin-risk-scorecard/-/backstage-plugin-risk-scorecard-1.0.0.tgz#b5632dc5cd91f5ce08129588a81b0daf8c559788"
-  integrity sha512-2cfVTqkz9R3Tco5AAZycXsUJqcrOyeM7K09qQp6uHyYu07MsHR+bGOqR+Fb4id8RXAFArtENyYyycFw0PgwPKQ==
-  dependencies:
-    "@backstage/core-components" "^0.13.9"
-    "@backstage/core-plugin-api" "^1.8.1"
-    "@backstage/plugin-catalog-backend-module-msgraph" "^0.5.16"
-    "@backstage/plugin-catalog-react" "^1.9.3"
-    "@backstage/theme" "^0.5.0"
-    "@emotion/react" "^11.11.3"
-    "@emotion/styled" "^11.11.0"
-    "@material-ui/core" "^4.12.2"
-    "@material-ui/icons" "^4.9.1"
-    "@material-ui/lab" "4.0.0-alpha.61"
-    "@mui/icons-material" "^5.15.8"
-    "@mui/material" "^5.15.7"
-    "@mui/x-date-pickers" "^6.19.8"
-    date-fns "^3.3.1"
-    react-use "^17.2.4"
-
 "@keyv/memcache@^1.3.5":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@keyv/memcache/-/memcache-1.4.0.tgz#89108a5f0ec8ed301d77291f2b485afbd34a6bff"
@@ -10395,7 +10374,7 @@ anymatch@^3.0.3, anymatch@~3.1.2:
     "@backstage/plugin-techdocs-module-addons-contrib" "^1.1.3"
     "@backstage/plugin-techdocs-react" "^1.1.14"
     "@backstage/plugin-user-settings" "^0.7.14"
-    "@kartverket/backstage-plugin-risk-scorecard" "1.0.0"
+    "@kartverket/backstage-plugin-risk-scorecard" "^1.0.4"
     "@material-ui/core" "^4.12.2"
     "@material-ui/icons" "^4.9.1"
     react "^17.0.2"


### PR DESCRIPTION
You can now edit status for an acion directly in the drawer: 

![image](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/assets/25055844/314079cd-dac5-47a1-b58c-942fb4bba4bf)
