### PR TITLE
Add interactive click on scenariolist and fix react keys

### DIFF
--- a/plugins/ros/src/components/riskMatrix/EstimatedRiskInfoDialog.tsx
+++ b/plugins/ros/src/components/riskMatrix/EstimatedRiskInfoDialog.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -44,10 +44,10 @@ export const EstimatedRiskInfoDialog = ({
           </Typography>
           <DialogContentText className={text}>
             {consequenceOptions.map((option, index) => (
-              <>
+              <Fragment key={option}>
                 {index + 1}: {formatNOK(option)}
                 <br />
-              </>
+              </Fragment>
             ))}
           </DialogContentText>
           <Typography style={{ fontWeight: 'bold' }}>
@@ -55,11 +55,11 @@ export const EstimatedRiskInfoDialog = ({
           </Typography>
           <DialogContentText className={text}>
             {probabilityOptions.map((option, index) => (
-              <>
+              <Fragment key={option}>
                 {index + 1}: {option}, {/* @ts-ignore */}
                 {t(`infoDialog.probabilityDescription.${index}`)}
                 <br />
-              </>
+              </Fragment>
             ))}
           </DialogContentText>
 

--- a/plugins/ros/src/components/riskMatrix/RiskMatrix.tsx
+++ b/plugins/ros/src/components/riskMatrix/RiskMatrix.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { Fragment, useState } from 'react';
 import { Typography } from '@material-ui/core';
 import { InfoCard } from '@backstage/core-components';
 import Box from '@mui/material/Box';
@@ -54,7 +54,7 @@ export const RiskMatrix = ({ riSc }: { riSc: RiSc }) => {
               </Typography>
             </Box>
             {riskMatrix.map((_, row) => (
-              <>
+              <Fragment key={row}>
                 <Box className={centered}>
                   <Typography className={text}>{5 - row}</Typography>
                 </Box>
@@ -62,6 +62,7 @@ export const RiskMatrix = ({ riSc }: { riSc: RiSc }) => {
                   <Box
                     className={`${square} ${centered}`}
                     style={{ backgroundColor: riskMatrix[row][col] }}
+                    key={col}
                   >
                     <RiskMatrixScenarioCount
                       riSc={riSc}
@@ -71,12 +72,12 @@ export const RiskMatrix = ({ riSc }: { riSc: RiSc }) => {
                     />
                   </Box>
                 ))}
-              </>
+              </Fragment>
             ))}
             <Box className={centered} />
             <Box className={centered} />
             {riskMatrix.map((_, col) => (
-              <Box className={centered}>
+              <Box className={centered} key={col}>
                 <Typography className={text}>{col + 1}</Typography>
               </Box>
             ))}

--- a/plugins/ros/src/components/riskMatrix/RiskMatrixScenarioCount.tsx
+++ b/plugins/ros/src/components/riskMatrix/RiskMatrixScenarioCount.tsx
@@ -8,13 +8,14 @@ import {
   Tooltip,
   Typography,
 } from '@material-ui/core';
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import CircleIcon from '@material-ui/icons/FiberManualRecord';
 import { consequenceOptions, probabilityOptions } from '../utils/constants';
 import { RiSc } from '../utils/types';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { pluginRiScTranslationRef } from '../utils/translations';
 import { useRiskMatrixStyles } from './riskMatrixStyle';
+import { ScenarioContext } from '../riScPlugin/ScenarioContext';
 
 interface ScenarioCountProps {
   riSc: RiSc;
@@ -41,6 +42,13 @@ export const RiskMatrixScenarioCount = ({
   } = useRiskMatrixStyles();
 
   const [tooltipOpen, setTooltipOpen] = useState(false);
+  const { openScenario } = useContext(ScenarioContext)!!;
+
+  const handleScenarioClick = (ID: string) => {
+    setTooltipOpen(false);
+    openScenario(ID);
+  }
+
 
   const scenarios = riSc.scenarios.filter(
     scenario =>
@@ -67,14 +75,18 @@ export const RiskMatrixScenarioCount = ({
           {t('riskMatrix.tooltip.title')}
         </Typography>
       </ListSubheader>
+      HEI
       {scenarios.map(s => (
-        <ListItem button disableGutters className={tooltipText}>
+        <ListItem key={s.ID} button disableGutters className={tooltipText} onClick={() => {
+          handleScenarioClick(s.ID);
+        }}>
           <CircleIcon className={tooltipText} style={{ width: '10px' }} />
           <ListItemText
+            
             className={tooltipText}
             style={{ paddingLeft: '0.6rem' }}
           >
-            <span>{s.title}</span>
+            <span >{s.title}</span>
           </ListItemText>
         </ListItem>
       ))}
@@ -84,6 +96,7 @@ export const RiskMatrixScenarioCount = ({
   return (
     <ClickAwayListener onClickAway={() => setTooltipOpen(false)}>
       <Tooltip
+        interactive
         classes={{ tooltip: tooltip, arrow: tooltipArrow }}
         title={tooltipList}
         placement="right"

--- a/plugins/ros/src/components/riskMatrix/RiskMatrixScenarioCount.tsx
+++ b/plugins/ros/src/components/riskMatrix/RiskMatrixScenarioCount.tsx
@@ -75,7 +75,6 @@ export const RiskMatrixScenarioCount = ({
           {t('riskMatrix.tooltip.title')}
         </Typography>
       </ListSubheader>
-      HEI
       {scenarios.map(s => (
         <ListItem key={s.ID} button disableGutters className={tooltipText} onClick={() => {
           handleScenarioClick(s.ID);

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionsSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionsSection.tsx
@@ -2,7 +2,7 @@ import { Button, Divider, Grid, Paper, Typography } from '@material-ui/core';
 import EditIcon from '@mui/icons-material/Edit';
 import { ActionBox } from './ActionBox';
 import Box from '@mui/material/Box';
-import React, { useContext } from 'react';
+import React, { Fragment, useContext } from 'react';
 import { useScenarioDrawerStyles } from '../scenarioDrawerStyle';
 import { useFontStyles } from '../../utils/style';
 import { ScenarioContext } from '../../riScPlugin/ScenarioContext';
@@ -39,7 +39,7 @@ export const ActionsSection = () => {
           />
         </Grid>
         {scenario.actions.map((action, index) => (
-          <>
+          <Fragment key={action.ID}>
             <ActionBox
               action={action}
               index={index + 1}
@@ -49,7 +49,7 @@ export const ActionsSection = () => {
             {index !== scenario.actions.length - 1 && (
               <Divider variant="fullWidth" />
             )}
-          </>
+          </Fragment>
         ))}
       </Paper>
     </Box>

--- a/plugins/ros/src/components/scenarioDrawer/components/ScopeSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ScopeSection.tsx
@@ -53,7 +53,7 @@ export const ScopeSection = () => {
               {t('dictionary.threatActors')}
             </Typography>
             {scenario.threatActors.map(threatActor => (
-              <Typography className={body2}>{threatActor}</Typography>
+              <Typography key={threatActor} className={body2}>{threatActor}</Typography>
             ))}
           </Grid>
 
@@ -62,7 +62,7 @@ export const ScopeSection = () => {
               {t('dictionary.vulnerabilities')}
             </Typography>
             {scenario.vulnerabilities.map(vulnerability => (
-              <Typography className={body2}>{vulnerability}</Typography>
+              <Typography key={vulnerability} className={body2}>{vulnerability}</Typography>
             ))}
           </Grid>
         </Grid>


### PR DESCRIPTION
You can now open scenario drawer by clicking on it in scenariolist from matrix:
<img width="368" alt="image" src="https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/assets/10416357/99fc9d98-6b69-46e7-9f02-642f9faf9c59">
