### PR TITLE
fix/scenario-dropdowns

### DIFF
--- a/plugins/ros/src/components/scenarioWizard/steps/ScenarioStep.tsx
+++ b/plugins/ros/src/components/scenarioWizard/steps/ScenarioStep.tsx
@@ -50,7 +50,6 @@ export const ScenarioStep = () => {
         style={{
           display: 'flex',
           flexDirection: 'column',
-          justifyContent: 'space-between',
         }}
       >
         <Box>
@@ -75,7 +74,6 @@ export const ScenarioStep = () => {
         style={{
           display: 'flex',
           flexDirection: 'column',
-          justifyContent: 'space-between',
         }}
       >
         <Box>


### PR DESCRIPTION
Selecting or deselecting items wont affect the neighboring dropdown menus position. 

Previous: 

![image](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/assets/25055844/cecadca3-0055-480b-8a7c-065d62454027)

Now: 

![image](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/assets/25055844/18bda11d-be10-4202-bd24-d776d28b5acb)
