### PR TITLE
fix/github-icon-size

### DIFF
--- a/plugins/ros/src/components/riScInfo/riScStatus/StatusChip.tsx
+++ b/plugins/ros/src/components/riScInfo/riScStatus/StatusChip.tsx
@@ -1,8 +1,5 @@
 import Chip from '@material-ui/core/Chip';
-import React, {
-  useEffect,
-  useState,
-} from 'react';
+import React, { useEffect, useState } from 'react';
 import { RiScStatus } from '../../utils/types';
 import { useStatusChipStyles, useStatusTextStyles } from './statusChipStyle';
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
@@ -43,7 +40,7 @@ const useChipText = (status: RiScStatus): string => {
 
 type ChipTextStatusProps = {
   status: RiScStatus;
-}
+};
 
 function ChipTextStatus({ status }: ChipTextStatusProps) {
   const { statusChipText } = useStatusChipStyles();
@@ -55,19 +52,16 @@ function ChipTextStatus({ status }: ChipTextStatusProps) {
 type PRStatusProps = {
   status: RiScStatus;
   classes: ClassNameMap;
-}
+};
 
-function PRStatus({
-  status,
-  classes,
-}: PRStatusProps) {
+function PRStatus({ status, classes }: PRStatusProps) {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
 
   switch (status) {
     case RiScStatus.SentForApproval:
       return (
         <Typography className={classes.prStatus}>
-          <GitHubIcon className={classes.prIcon} />
+          <GitHubIcon fontSize="inherit" className={classes.prIcon} />
           {t('rosStatus.prStatus')}
         </Typography>
       );
@@ -106,7 +100,9 @@ export const StatusChip = ({ currentRiScStatus }: ChipProps) => {
           className={[chipColorClass, chipClasses.statusChip].join(' ')}
         />
       </Grid>
-      <Grid item><PRStatus status={currentRiScStatus} classes={textClasses} /></Grid>
+      <Grid item>
+        <PRStatus status={currentRiScStatus} classes={textClasses} />
+      </Grid>
     </Grid>
   );
 };

--- a/plugins/ros/src/components/riScInfo/riScStatus/statusChipStyle.ts
+++ b/plugins/ros/src/components/riScInfo/riScStatus/statusChipStyle.ts
@@ -38,9 +38,9 @@ export const useStatusTextStyles = makeStyles(() => ({
     wrap: 'wrap',
   },
   prIcon: {
-    fontSize: '12px',
     margin: '0px',
     padding: '0px',
+    marginBottom: '-1px',
     marginRight: '2px',
     marginLeft: '2px',
   },


### PR DESCRIPTION
Before: 

![image](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/assets/25055844/92ba6ebc-e13e-4765-aaaf-e05e743acb8d)

Now: 

![image](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/assets/25055844/b793b075-671f-4784-b934-111f3a5a09c9)
