### PR TITLE
Better error handling for fetch all riscs

### DIFF
--- a/plugins/ros/src/components/utils/types.ts
+++ b/plugins/ros/src/components/utils/types.ts
@@ -77,4 +77,5 @@ export enum ProcessingStatus {
   ErrorWhenFetchingRiScs = 'ErrorWhenFetchingRiScs',
   ErrorWhenCreatingPullRequest = 'ErrorWhenCreatingPullRequest',
   ErrorWhenFetchingJSONSchema = 'ErrorWhenFetchingJSONSchema',
+  Success = 'Success',
 }


### PR DESCRIPTION
Instead of only showing error if some of the fetched riscs was returned with an error, handle every item properly so that the successful retrieved riscs can be showed. 