### PR TITLE
Use proxy to route backend requests

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -18,6 +18,12 @@ backend:
     keys:
       - secret: ${BACKEND_AUTH_KEY}
 
+proxy:
+  endpoints:
+    '/risc-proxy':
+      target: https://kv-ros-backend-245zlcbrnq-lz.a.run.app
+      allowedHeaders: ['Authorization', 'GCP-Access-Token']
+
 auth:
   environment: development
   providers:

--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -1,9 +1,6 @@
 app:
   baseUrl: https://kv-ros-backstage-245zlcbrnq-lz.a.run.app
 
-riskAssessment:
-  baseUrl: https://kv-ros-backend-245zlcbrnq-lz.a.run.app
-
 backend:
   baseUrl: https://kv-ros-backstage-245zlcbrnq-lz.a.run.app
   listen:

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -10,11 +10,14 @@ app:
           - url: https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/issues
             title: 'Github Issues'
 
-riskAssessment:
-  baseUrl: http://localhost:8080
-
 organization:
   name: Rosene
+
+proxy:
+  endpoints:
+    '/risc-proxy':
+      target: http://localhost:8080
+      allowedHeaders: ['Authorization', 'GCP-Access-Token']
 
 backend:
   baseUrl: http://localhost:7007

--- a/plugins/ros/README.md
+++ b/plugins/ros/README.md
@@ -4,11 +4,14 @@ This is a plugin for Backstage that helps you and your team when working continu
 The plugin is dependent on a backend service in order to decrypt and communicate with GitHub, and some configuration is
 necessary for them to communicate.
 
-Add the root url to your running backend service to the app-config:
+Add the following configuration to the proxy-block in your app-config. Modify the `target` to the root url of your running backend service.
 
-``` yaml
-app:
-  backendUrl: http://localhost:8080
+```yaml
+proxy:
+  endpoints:
+    '/risc-proxy':
+      target: http://localhost:8080
+      allowedHeaders: ['Authorization', 'GCP-Access-Token']
 ```
 
 The backend uses EntraID id-tokens to validate the user, and GCP access tokens to federate access to the GCP KMS.

--- a/plugins/ros/src/components/utils/hooks.ts
+++ b/plugins/ros/src/components/utils/hooks.ts
@@ -75,12 +75,13 @@ const useFetch = () => {
   const googleApi = useApi(googleAuthApiRef);
   const identityApi = useApi(identityApiRef);
   const { fetch: fetchApi } = useApi(fetchApiRef);
-  const baseUri = useApi(configApiRef).getString('riskAssessment.baseUrl');
-  const riScUri = `${baseUri}/api/risc/${repoInformation.owner}/${repoInformation.name}`;
+  const backendUrl = useApi(configApiRef).getString('backend.baseUrl');
+  const riScUri = `${backendUrl}/api/proxy/risc-proxy/api/risc/${repoInformation.owner}/${repoInformation.name}`;
   const uriToFetchAllRiScs = () => `${riScUri}/all`;
   const uriToFetchRiSc = (id: string) => `${riScUri}/${id}`;
   const uriToPublishRiSc = (id: string) => `${riScUri}/publish/${id}`;
-  const uriToFetchLatestJSONSchema = () => `${baseUri}/api/risc/schemas/latest`;
+  const uriToFetchLatestJSONSchema = () =>
+    `${backendUrl}/api/proxy/risc-proxy/api/risc/schemas/latest`;
 
   const [response, setResponse] = useResponse();
 


### PR DESCRIPTION
Switch to using the Backstage backend's HTTP proxy to access the RISC backend APIs.
Revise the plugin's README to detail the new method for API communication.