### PR TITLE
design/action-edit-background-color

### DIFF
--- a/plugins/ros/src/components/scenarioDrawer/components/ActionsSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionsSection.tsx
@@ -27,7 +27,7 @@ export const ActionsSection = () => {
             marginBottom: '12px',
           }}
         >
-          <Typography className={h3} gutterBottom>
+          <Typography className={h3}>
             {t('scenarioDrawer.measureTab.actionsTitle')}
           </Typography>
           <Button

--- a/plugins/ros/src/components/utils/style.ts
+++ b/plugins/ros/src/components/utils/style.ts
@@ -105,7 +105,7 @@ export const useInputFieldStyles = makeStyles((theme: Theme) => ({
   paper: {
     padding: theme.spacing(2),
     marginBottom: theme.spacing(2),
-    backgroundColor: theme.palette.type === 'dark' ? '#404040' : '#e0e0e0',
+    backgroundColor: theme.palette.type === 'dark' ? '#404040' : '#FFFFFF',
   },
   root: {
     '&.Mui-disabled': {


### PR DESCRIPTION
They previous grey background made the impression that actions was not editable. 

Before: 
![image](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/assets/25055844/c6198345-ca9a-4571-9df1-baa0e6c92a70)

Now:
![image](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/assets/25055844/85bf0b06-3b1d-4d60-8dc0-443f7ff490a1)
