### PR TITLE
design/green-chip-on-completed-action

### DIFF
--- a/plugins/ros/src/components/utils/ChipDropdown.tsx
+++ b/plugins/ros/src/components/utils/ChipDropdown.tsx
@@ -28,7 +28,8 @@ export const ChipDropdown = ({
         style={{
           margin: 0,
           padding: 0,
-          backgroundColor: '#D9D9D9',
+          backgroundColor:
+            selectedValue === 'Completed' ? '#6BC6A4' : '#D9D9D9',
           color: '#000000',
         }}
         label={selectedValue}


### PR DESCRIPTION
Show a green status chip if status is completed.

Now: 
![image](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/assets/25055844/371a5fe2-f2bb-4577-975f-561af8125a94)
