### PR TITLE
Tydeliggjør docker-instruksjoner i README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
 # [Backstage](https://backstage.io)
 
-To run Backstage locally, run these commands:
+To run Backstage locally, you only need to run these commands:
+
 ```sh
 yarn install
 yarn dev
 ```
 
-### Docker
+---
+
+### Docker (Alternative)
+
+> [!WARNING]  
+> Simply running `yarn dev` should be sufficient for local development, but some may prefer to run applications through Docker.
+> As this is less frequently used, these instructions may be outdated and no longer function properply.
 
 To build the Docker image, run this command:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ yarn install
 yarn dev
 ```
 
-Backstage should now be running on http://localhost:3000/, and you may set up [the plugin backend](https://github.com/kartverket/backstage-plugin-risk-scorecard-backend).
+The Backstage frontend should now be running on http://localhost:3000/, while the Backstage backend should be running on http://localhost:7007/.
+
+You may now set up [the plugin backend](https://github.com/kartverket/backstage-plugin-risk-scorecard-backend). Keep in mind that Backstage needs to be running for the plugin backend to run.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@ yarn install
 yarn dev
 ```
 
+Backstage should now be running on http://localhost:3000/, and you may set up [the plugin backend](https://github.com/kartverket/backstage-plugin-risk-scorecard-backend).
+
 ---
 
-### Docker (Alternative)
+### Docker (alternative)
 
 > [!WARNING]  
 > Simply running `yarn dev` should be sufficient for local development, but some may prefer to run applications through Docker.
-> As this is less frequently used, these instructions may be outdated and no longer function properply.
+> As this is less frequently used, these instructions may be outdated and no longer function properly.
 
 To build the Docker image, run this command:
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Backstage should now be running on http://localhost:3000/, and you may set up [t
 
 > [!WARNING]  
 > Simply running `yarn dev` should be sufficient for local development, but some may prefer to run applications through Docker.
-> As this is less frequently used, these instructions may be outdated and no longer function properly.
+> As this is less frequently used, these instructions may be outdated and may no longer function properly.
 
 To build the Docker image, run this command:
 


### PR DESCRIPTION
Diff'en snakker litt for seg selv, prøver bare å tydeliggjøre at alt skal være i boks med de første par linjene og at docker er en alternativ løsning