### PR TITLE
Fikser uendelig loop for nye scenarier

### DIFF
--- a/plugins/ros/src/components/scenarioWizard/components/ConsequenceTable.tsx
+++ b/plugins/ros/src/components/scenarioWizard/components/ConsequenceTable.tsx
@@ -17,15 +17,13 @@ export const ConsequenceTable = ({
   const { t } = useTranslationRef(pluginRiScTranslationRef);
   const { table, labelCell, cell, voidCell, radio } = useTableStyles();
 
-  const handleChangeRow = (row: number) => () => handleChange(row);
-
   const getRadioCell = (row: number) => {
     return (
       <th scope="col">
         <div className={radio}>
           <Radio
             checked={selectedValue === row}
-            onChange={handleChangeRow(row)}
+            onChange={() => handleChange(row)}
             style={{
               padding: 0,
               color:

--- a/plugins/ros/src/components/scenarioWizard/components/ProbabilityTable.tsx
+++ b/plugins/ros/src/components/scenarioWizard/components/ProbabilityTable.tsx
@@ -18,14 +18,12 @@ export const ProbabilityTable = ({
   const { t } = useTranslationRef(pluginRiScTranslationRef);
   const { table, cell, radio } = useTableStyles();
 
-  const handleChangeRow = (row: number) => () => handleChange(row);
-
   const radioCell = (row: number) => (
     <th scope="col">
       <div className={radio}>
         <Radio
           checked={selectedValue === row}
-          onChange={handleChangeRow(row)}
+          onChange={() => handleChange(row)}
           style={{
             padding: 0,
             color:

--- a/plugins/ros/src/components/scenarioWizard/steps/RiskStep.tsx
+++ b/plugins/ros/src/components/scenarioWizard/steps/RiskStep.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useContext, useEffect } from 'react';
+import React, { Fragment, useContext } from 'react';
 import {
   getConsequenceLevel,
   getProbabilityLevel,
@@ -28,36 +28,37 @@ export const RiskStep = ({ riskType, restEqualsInitial }: RiskStepProps) => {
     setProbability,
     setRemainingConsequence,
     setRemainingProbability,
+    setProbabilityAndRemainingProbability,
+    setConsequenceAndRemainingConsequence,
   } = useContext(ScenarioContext)!!;
 
   const resourceKey =
     riskType === 'initial' ? 'initialRiskStep' : 'restRiskStep';
   const risk = riskType === 'initial' ? scenario.risk : scenario.remainingRisk;
 
-  useEffect(() => {
-    if (restEqualsInitial)
-      setRemainingConsequence(getConsequenceLevel(scenario.risk));
-  }, [
-    restEqualsInitial,
-    scenario.risk,
-    scenario.risk.consequence,
-    setRemainingConsequence,
-  ]);
+  const handleProbabilityChange = (probabilityLevel: number) => {
+    if (riskType === 'initial') {
+      if (restEqualsInitial) {
+        setProbabilityAndRemainingProbability(probabilityLevel);
+      } else {
+        setProbability(probabilityLevel);
+      }
+    } else {
+      setRemainingProbability(probabilityLevel);
+    }
+  };
 
-  useEffect(() => {
-    if (restEqualsInitial)
-      setRemainingProbability(getProbabilityLevel(scenario.risk));
-  }, [
-    restEqualsInitial,
-    scenario.risk,
-    scenario.risk.probability,
-    setRemainingProbability,
-  ]);
-
-  const setC =
-    riskType === 'initial' ? setConsequence : setRemainingConsequence;
-  const setP =
-    riskType === 'initial' ? setProbability : setRemainingProbability;
+  const handleConsequenceChange = (consequenceLevel: number) => {
+    if (riskType === 'initial') {
+      if (restEqualsInitial) {
+        setConsequenceAndRemainingConsequence(consequenceLevel);
+      } else {
+        setConsequence(consequenceLevel);
+      }
+    } else {
+      setRemainingConsequence(consequenceLevel);
+    }
+  };
 
   return (
     <Fragment>
@@ -78,7 +79,7 @@ export const RiskStep = ({ riskType, restEqualsInitial }: RiskStepProps) => {
       <Box className={box}>
         <ProbabilityTable
           selectedValue={getProbabilityLevel(risk)}
-          handleChange={setP}
+          handleChange={handleProbabilityChange}
         />
       </Box>
       <Box className={box}>
@@ -90,7 +91,7 @@ export const RiskStep = ({ riskType, restEqualsInitial }: RiskStepProps) => {
       <Box className={box}>
         <ConsequenceTable
           selectedValue={getConsequenceLevel(risk)}
-          handleChange={setC}
+          handleChange={handleConsequenceChange}
         />
       </Box>
     </Fragment>

--- a/plugins/ros/src/components/utils/hooks.ts
+++ b/plugins/ros/src/components/utils/hooks.ts
@@ -258,6 +258,8 @@ export interface ScenarioDrawerProps {
   updateRemainingRisk: (remainingRisk: Risk) => void;
   setRemainingProbability: (probabilityLevel: number) => void;
   setRemainingConsequence: (consequenceLevel: number) => void;
+  setProbabilityAndRemainingProbability: (probabilityLevel: number) => void;
+  setConsequenceAndRemainingConsequence: (consequenceLevel: number) => void;
 }
 
 export enum ScenarioDrawerState {
@@ -506,6 +508,32 @@ export const useScenarioDrawer = (
       },
     });
 
+  const setProbabilityAndRemainingProbability = (probabilityLevel: number) =>
+    setScenario({
+      ...scenario,
+      risk: {
+        ...scenario.risk,
+        probability: probabilityOptions[probabilityLevel - 1],
+      },
+      remainingRisk: {
+        ...scenario.remainingRisk,
+        probability: probabilityOptions[probabilityLevel - 1],
+      },
+    });
+
+  const setConsequenceAndRemainingConsequence = (consequenceLevel: number) =>
+    setScenario({
+      ...scenario,
+      risk: {
+        ...scenario.risk,
+        consequence: consequenceOptions[consequenceLevel - 1],
+      },
+      remainingRisk: {
+        ...scenario.remainingRisk,
+        consequence: consequenceOptions[consequenceLevel - 1],
+      },
+    });
+
   return {
     scenarioDrawerState,
 
@@ -540,6 +568,8 @@ export const useScenarioDrawer = (
     updateRemainingRisk,
     setRemainingProbability,
     setRemainingConsequence,
+    setProbabilityAndRemainingProbability,
+    setConsequenceAndRemainingConsequence,
   };
 };
 


### PR DESCRIPTION
Dersom man oppretter et nytt scenario og går til steg 2 (initial risk) får man en uendelig loop. Antar ingen har gjort det på en stund fordi denne buggen ser ut som at den har ligget i koden i en måneds tid, men jeg kan ta feil.

Synderen her er misbruk av useEffect og useState. To effekter utløser seg selv og hverandre i det uendelige. Det effektene prøver å gjøre er å sette startverdien for "remaining risk" til det man har satt i initial risk, men dette er en veldig lang omvei for å få det til. Jeg gjør det litt mer direkte nå med en egen funksjon som oppdaterer state, men ser myyyye forbedringspotensiale i logikken som ligger rundt her. Ett steg om gangen