### PR TITLE
Legger til tsc og lint i lokal utvikling og action

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -6,6 +6,20 @@ on:
       - main
 
 jobs:
+  compile_and_lint:
+    defaults:
+      run:
+        working-directory: plugins/ros
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+      - run: yarn install --frozen-lockfile
+      - run: yarn tsc
+      - run: yarn lint
+      - run: yarn prettier:check
   docker_build_push_gcp:
     name: 'Docker build and push to GCP'
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "concurrently \"yarn start\" \"yarn start-backend\"",
-    "start": "yarn workspace app start",
+    "start": "yarn workspace app start --check",
     "start-backend": "yarn workspace backend start",
     "build:backend": "yarn workspace backend build",
     "build:all": "backstage-cli repo build --all",


### PR DESCRIPTION
Usikker på om action'en er skrevet riktig, men nå får man i hvertfall beskjed i nettleseren og i terminalen dersom man bryter med typesikringen. Man fikk få (les: ingen) konfigurasjonsmuligheter her, så vi får se an hvor streng den er