### PR TITLE
Flytt linting ut til egen jobb som kjører ved push til plugin

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -6,20 +6,6 @@ on:
       - main
 
 jobs:
-  compile_and_lint:
-    defaults:
-      run:
-        working-directory: plugins/ros
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-      - run: yarn install --frozen-lockfile
-      - run: yarn tsc
-      - run: yarn lint
-      - run: yarn prettier:check
   docker_build_push_gcp:
     name: 'Docker build and push to GCP'
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Compile and lint TypeScript
+
+on:
+  push:
+    paths:
+      - 'plugins/ros'
+
+jobs:
+  compile_and_lint:
+    defaults:
+      run:
+        working-directory: plugins/ros
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+      - run: yarn install --frozen-lockfile
+      - run: yarn tsc
+      - run: yarn lint
+      - run: yarn prettier:check

--- a/plugins/ros/package.json
+++ b/plugins/ros/package.json
@@ -24,7 +24,8 @@
     "test": "backstage-cli package test",
     "clean": "backstage-cli package clean",
     "prepack": "backstage-cli package prepack",
-    "postpack": "backstage-cli package postpack"
+    "postpack": "backstage-cli package postpack",
+    "prettier:check": "prettier --check ."
   },
   "dependencies": {
     "@backstage/core-components": "^0.13.9",


### PR DESCRIPTION
Innså litt sent at jobben i #272 kun kjører ved push til main, som blir litt lang feedback loop. Med denne endringen kjører den hver gang man pusher til en branch med endringer i ros-mappen