### PR TITLE
Bruk riktig handler ved lukking av dialog for endring av scorecard

### DIFF
--- a/plugins/ros/src/components/riScDialog/RiScDialog.tsx
+++ b/plugins/ros/src/components/riScDialog/RiScDialog.tsx
@@ -109,7 +109,7 @@ export const RiScDialog = ({
     <Dialog
       classes={{ paper: paper }}
       open={dialogState !== RiScDialogStates.Closed}
-      onClose={handleSave}
+      onClose={handleCancel}
       {...props}
     >
       <DialogContent>


### PR DESCRIPTION
Hvis man klikket utenfor modalen ble endringer lagret, fy fy