### PR TITLE
add simple form validation

### DIFF
--- a/plugins/ros/src/components/scenarioWizard/ScenarioWizard.tsx
+++ b/plugins/ros/src/components/scenarioWizard/ScenarioWizard.tsx
@@ -67,6 +67,7 @@ export const ScenarioWizard = ({
     closeScenario,
     editScenario,
     validateScenario,
+    hasFormErrors,
   } = useContext(ScenarioContext)!!;
 
   const [showCloseConfirmation, setShowCloseConfirmation] = useState(false);
@@ -93,6 +94,10 @@ export const ScenarioWizard = ({
   }, [canCloseIfSuccessfull, close, updateStatus]);
 
   const saveAndClose = () => {
+    if (hasFormErrors()) {
+      return;
+    }
+
     saveScenario();
     setCanCloseIfSuccessfull(true);
   };

--- a/plugins/ros/src/components/scenarioWizard/components/ActionEdit.tsx
+++ b/plugins/ros/src/components/scenarioWizard/components/ActionEdit.tsx
@@ -29,6 +29,11 @@ export const ActionEdit = ({
   const setActionField = (field: keyof Action, value: string) =>
     updateAction({ ...action, [field]: value });
 
+  const validateUrl = (value: string) => {
+    const urlRegex = /^https?:\/\/([\da-z.-]+)\.([a-z.]{2,6})([/\w .-]*)*\/?$/;
+    return urlRegex.test(value);
+  };
+
   return (
     <Paper className={paper}>
       <Grid container style={{ display: 'flex', rowGap: '0.7rem' }}>
@@ -60,6 +65,8 @@ export const ActionEdit = ({
             label={t('dictionary.description')}
             value={action.description}
             handleChange={value => setActionField('description', value)}
+            errorMessage={t('scenarioDrawer.action.descriptionError')}
+            errorKey={`${index}-action-description`}
             minRows={1}
             required
           />
@@ -70,7 +77,10 @@ export const ActionEdit = ({
             label={t('dictionary.url')}
             value={action.url}
             handleChange={value => setActionField('url', value)}
+            validateInput={validateUrl}
+            errorMessage={t('scenarioDrawer.action.urlError')}
             minRows={1}
+            errorKey={`${index}-action-url`}
           />
         </Grid>
 
@@ -81,7 +91,6 @@ export const ActionEdit = ({
           style={{
             display: 'flex',
             flexDirection: 'column',
-            justifyContent: 'flex-end',
           }}
         >
           <Dropdown<string>

--- a/plugins/ros/src/components/scenarioWizard/components/ActionEdit.tsx
+++ b/plugins/ros/src/components/scenarioWizard/components/ActionEdit.tsx
@@ -30,7 +30,7 @@ export const ActionEdit = ({
     updateAction({ ...action, [field]: value });
 
   const validateUrl = (value: string) => {
-    const urlRegex = /^https?:\/\/([\da-z.-]+)\.([a-z.]{2,6})([/\w .-]*)*\/?$/;
+    const urlRegex = /^https?:\/\/[a-z\d.-]+\.[a-z]{2,6}(\/[\w .-]*)*\/?$/;
     return urlRegex.test(value);
   };
 

--- a/plugins/ros/src/components/scenarioWizard/steps/ScenarioStep.tsx
+++ b/plugins/ros/src/components/scenarioWizard/steps/ScenarioStep.tsx
@@ -16,7 +16,6 @@ export const ScenarioStep = () => {
   const { labelSubtitle, label, h2, subtitle2 } = useFontStyles();
   const {
     scenario,
-    scenarioErrors,
     setTitle,
     setDescription,
     setThreatActors,
@@ -53,7 +52,8 @@ export const ScenarioStep = () => {
         <TextField
           label={t('dictionary.title')}
           value={scenario.title}
-          error={scenarioErrors.title ? t('scenarioDrawer.titleError') : ''}
+          errorMessage={t('scenarioDrawer.titleError')}
+          errorKey="scenario-title"
           required
           minRows={1}
           handleChange={setTitle}

--- a/plugins/ros/src/components/utils/Textfield.tsx
+++ b/plugins/ros/src/components/utils/Textfield.tsx
@@ -107,7 +107,7 @@ export const TextField = ({
         onBlur={onBlur}
         InputProps={{ className: root }}
       />
-      {fieldError && <FormHelperText>{errorMessage}</FormHelperText>}
+      {fieldError && <FormHelperText error>{errorMessage}</FormHelperText>}
     </FormControl>
   );
 };

--- a/plugins/ros/src/components/utils/Textfield.tsx
+++ b/plugins/ros/src/components/utils/Textfield.tsx
@@ -4,33 +4,84 @@ import {
   FormLabel,
   TextField as MUITextField,
 } from '@material-ui/core';
-import React, { ChangeEvent } from 'react';
+import React, { ChangeEvent, useContext, useState } from 'react';
 import { useFontStyles, useInputFieldStyles } from './style';
+import { ScenarioContext } from '../riScPlugin/ScenarioContext';
 
-interface TextFieldProps {
+type ErrorProps = {
+  errorKey?: string;
+  errorMessage?: string;
+}
+
+type TextFieldProps = {
   label?: string;
   subtitle?: string;
   value: string | number;
   error?: string | boolean | null;
-  required?: boolean;
   minRows?: number;
   handleChange?: (value: string) => void;
-}
+} & (
+    | {
+      validateInput: (value: string) => boolean;
+      required?: boolean;
+    } & ErrorProps
+    | {
+      required?: undefined;
+      validateInput?: undefined;
+    } & ErrorProps
+    | {
+      required: boolean;
+      validateInput?: (value: string) => boolean;
+    } & ErrorProps
+  );
 
 export const TextField = ({
   label,
   subtitle,
   value,
-  error,
   required,
   minRows = 1,
   handleChange,
+  validateInput,
+  errorMessage,
+  errorKey,
 }: TextFieldProps) => {
+  const [hasError, setHasError] = useState(false);
+  const { setFormError, removeFormError, formFieldHasErrors } =
+    useContext(ScenarioContext)!!;
   const { formLabel, formControl, root } = useInputFieldStyles();
   const { labelSubtitle } = useFontStyles();
 
-  const onChange = (event: ChangeEvent<{ value: string }>) =>
-    handleChange && handleChange(event.target.value);
+  const onChange = (event: ChangeEvent<{ value: string }>) => {
+    if (handleChange) {
+      handleChange(event.target.value);
+    }
+  };
+
+  const onBlur = (event: ChangeEvent<{ value: string }>) => {
+    if (!validateInput && !required) {
+      return;
+    }
+
+    const isValid = validateInput ? validateInput(event.target.value) : true;
+    const requiredValid = required ? event.target.value.length > 0 : true;
+
+    const validationResult = isValid && requiredValid
+    setHasError(!validationResult);
+
+    if (!errorKey) {
+      return;
+    }
+
+    if (validationResult) {
+      removeFormError(errorKey);
+    } else {
+      setFormError(errorKey);
+    }
+  };
+
+  const fieldError =
+    hasError || (errorKey ? formFieldHasErrors(errorKey) : false);
 
   return (
     <FormControl className={formControl}>
@@ -52,10 +103,11 @@ export const TextField = ({
         minRows={minRows}
         variant="outlined"
         onChange={onChange}
-        error={!!error}
+        error={fieldError}
+        onBlur={onBlur}
         InputProps={{ className: root }}
       />
-      {error && <FormHelperText error>{error}</FormHelperText>}
+      {fieldError && <FormHelperText>{errorMessage}</FormHelperText>}
     </FormControl>
   );
 };

--- a/plugins/ros/src/components/utils/Textfield.tsx
+++ b/plugins/ros/src/components/utils/Textfield.tsx
@@ -11,7 +11,7 @@ import { ScenarioContext } from '../riScPlugin/ScenarioContext';
 type ErrorProps = {
   errorKey?: string;
   errorMessage?: string;
-}
+};
 
 type TextFieldProps = {
   label?: string;
@@ -21,19 +21,19 @@ type TextFieldProps = {
   minRows?: number;
   handleChange?: (value: string) => void;
 } & (
-    | {
+  | ({
       validateInput: (value: string) => boolean;
       required?: boolean;
-    } & ErrorProps
-    | {
+    } & ErrorProps)
+  | ({
       required?: undefined;
       validateInput?: undefined;
-    } & ErrorProps
-    | {
+    } & ErrorProps)
+  | ({
       required: boolean;
       validateInput?: (value: string) => boolean;
-    } & ErrorProps
-  );
+    } & ErrorProps)
+);
 
 export const TextField = ({
   label,
@@ -66,7 +66,7 @@ export const TextField = ({
     const isValid = validateInput ? validateInput(event.target.value) : true;
     const requiredValid = required ? event.target.value.length > 0 : true;
 
-    const validationResult = isValid && requiredValid
+    const validationResult = isValid && requiredValid;
     setHasError(!validationResult);
 
     if (!errorKey) {

--- a/plugins/ros/src/components/utils/hooks.ts
+++ b/plugins/ros/src/components/utils/hooks.ts
@@ -260,6 +260,11 @@ export interface ScenarioDrawerProps {
   setRemainingConsequence: (consequenceLevel: number) => void;
   setProbabilityAndRemainingProbability: (probabilityLevel: number) => void;
   setConsequenceAndRemainingConsequence: (consequenceLevel: number) => void;
+
+  setFormError: (key: string) => void;
+  removeFormError: (key: string) => void;
+  hasFormErrors: () => boolean;
+  formFieldHasErrors: (key: string) => boolean;
 }
 
 export enum ScenarioDrawerState {
@@ -287,6 +292,7 @@ export const useScenarioDrawer = (
   );
 
   const [isNewScenario, setIsNewScenario] = useState(false);
+  const [formErrors, _setFormErrors] = useState<{ [key: string]: boolean }>({});
   const [scenario, setScenario] = useState(emptyScenario());
   const [originalScenario, setOriginalScenario] = useState(emptyScenario());
   const [deleteConfirmationIsOpen, setDeleteConfirmationIsOpen] =
@@ -536,6 +542,20 @@ export const useScenarioDrawer = (
       },
     });
 
+  const setFormError = (key: string) => {
+    _setFormErrors({ ...formErrors, [key]: true });
+  };
+
+  const removeFormError = (key: string) => {
+    delete formErrors[key];
+    _setFormErrors({ ...formErrors });
+  };
+
+  const formFieldHasErrors = (key: string) =>
+    Object.keys(formErrors).includes(key);
+
+  const hasFormErrors = () => Object.keys(formErrors).length > 0;
+
   return {
     scenarioDrawerState,
 
@@ -572,6 +592,11 @@ export const useScenarioDrawer = (
     setRemainingConsequence,
     setProbabilityAndRemainingProbability,
     setConsequenceAndRemainingConsequence,
+
+    setFormError,
+    hasFormErrors,
+    removeFormError,
+    formFieldHasErrors,
   };
 };
 

--- a/plugins/ros/src/components/utils/translations.ts
+++ b/plugins/ros/src/components/utils/translations.ts
@@ -138,6 +138,11 @@ export const pluginRiScTranslationRef = createTranslationRef({
       },
     },
     scenarioDrawer: {
+      action: {
+        requiredError: 'Field is required',
+        descriptionError: 'Description cannot be empty',
+        urlError: 'Invalid url',
+      },
       title: 'Risk scenario',
       titleError: 'Scenario title is required',
       subtitle:
@@ -300,6 +305,11 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
           'dictionary.url': 'URL',
           'dictionary.emptyUrl': 'Ingen URL spesifisert',
           'dictionary.vulnerabilities': 'Sårbarheter',
+
+          'scenarioDrawer.action.descriptionError':
+            'Beskrivelse kan ikke være tom',
+          'scenarioDrawer.action.urlError': 'Ugyldig URL',
+          'scenarioDrawer.action.requiredError': 'Feltet er påkrevd',
 
           'rosStatus.statusBadge.missing':
             'Venter på godkjenning av risikoeier',


### PR DESCRIPTION
Legger til veldig basic form validation etter man har skrevet input. 
Utvider `useScenarioDrawer` til å ha en map over tilstanden til de forskjellige input-feltene ved redigering av en ROS. 