### PR TITLE
UX-forbedringer i ScenarioDrawer og refaktorering av useFetchRiScs

### DIFF
--- a/plugins/ros/src/PluginRoot.tsx
+++ b/plugins/ros/src/PluginRoot.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { useRoutes } from 'react-router-dom';
 import { CacheProvider } from '@emotion/react';
 import createCache from '@emotion/cache';
 import { RiScPlugin } from './components/riScPlugin/RiScPlugin';
@@ -17,16 +17,17 @@ const cache = createCache({
 });
 
 export const PluginRoot = () => {
+  const pluginRoutes = useRoutes(
+    ['/home', riScRouteRef.path, scenarioRouteRef.path].map(path => ({
+      path,
+      element: <RiScPlugin />,
+    })),
+  );
+
   return (
     <CacheProvider value={cache}>
       <RiScProvider>
-        <ScenarioProvider>
-          <Routes>
-            <Route path="/" element={<RiScPlugin />} />
-            <Route path={riScRouteRef.path} element={<RiScPlugin />} />
-            <Route path={scenarioRouteRef.path} element={<RiScPlugin />} />
-          </Routes>
-        </ScenarioProvider>
+        <ScenarioProvider>{pluginRoutes}</ScenarioProvider>
       </RiScProvider>
     </CacheProvider>
   );

--- a/plugins/ros/src/PluginRoot.tsx
+++ b/plugins/ros/src/PluginRoot.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Route, Routes } from 'react-router-dom';
+import { CacheProvider } from '@emotion/react';
+import createCache from '@emotion/cache';
+import { RiScPlugin } from './components/riScPlugin/RiScPlugin';
+import { ScenarioProvider } from './contexts/ScenarioContext';
+import { riScRouteRef, scenarioRouteRef } from './routes';
+import { RiScProvider } from './contexts/RiScContext';
+
+const emotionInsertionPoint = document.createElement('meta');
+emotionInsertionPoint.setAttribute('name', 'emotion-insertion-point');
+document.querySelector('head')?.appendChild(emotionInsertionPoint);
+
+const cache = createCache({
+  key: 'css',
+  insertionPoint: emotionInsertionPoint,
+});
+
+export const PluginRoot = () => {
+  return (
+    <CacheProvider value={cache}>
+      <RiScProvider>
+        <ScenarioProvider>
+          <Routes>
+            <Route path="/" element={<RiScPlugin />} />
+            <Route path={riScRouteRef.path} element={<RiScPlugin />} />
+            <Route path={scenarioRouteRef.path} element={<RiScPlugin />} />
+          </Routes>
+        </ScenarioProvider>
+      </RiScProvider>
+    </CacheProvider>
+  );
+};

--- a/plugins/ros/src/PluginRoot.tsx
+++ b/plugins/ros/src/PluginRoot.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useRoutes } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import { CacheProvider } from '@emotion/react';
 import createCache from '@emotion/cache';
 import { RiScPlugin } from './components/riScPlugin/RiScPlugin';
@@ -16,19 +16,20 @@ const cache = createCache({
   insertionPoint: emotionInsertionPoint,
 });
 
-export const PluginRoot = () => {
-  const pluginRoutes = useRoutes(
-    ['/home', riScRouteRef.path, scenarioRouteRef.path].map(path => ({
-      path,
-      element: <RiScPlugin />,
-    })),
-  );
+const ProvidedPlugin = () => (
+  <CacheProvider value={cache}>
+    <RiScProvider>
+      <ScenarioProvider>
+        <RiScPlugin />
+      </ScenarioProvider>
+    </RiScProvider>
+  </CacheProvider>
+);
 
-  return (
-    <CacheProvider value={cache}>
-      <RiScProvider>
-        <ScenarioProvider>{pluginRoutes}</ScenarioProvider>
-      </RiScProvider>
-    </CacheProvider>
-  );
-};
+export const PluginRoot = () => (
+  <Routes>
+    <Route path="/" element={<ProvidedPlugin />} />
+    <Route path={riScRouteRef.path} element={<ProvidedPlugin />} />
+    <Route path={scenarioRouteRef.path} element={<ProvidedPlugin />} />
+  </Routes>
+);

--- a/plugins/ros/src/components/common/Textfield.tsx
+++ b/plugins/ros/src/components/common/Textfield.tsx
@@ -5,7 +5,7 @@ import {
   TextField as MUITextField,
 } from '@material-ui/core';
 import React, { ChangeEvent, useState } from 'react';
-import { useScenario } from '../../ScenarioContext';
+import { useScenario } from '../../contexts/ScenarioContext';
 import { useFontStyles, useInputFieldStyles } from '../../utils/style';
 
 type ErrorProps = {

--- a/plugins/ros/src/components/common/typography.ts
+++ b/plugins/ros/src/components/common/typography.ts
@@ -57,6 +57,10 @@ export const label2: SxProps<Theme> = theme => ({
   color: theme.palette.mode === 'dark' ? '#F8F8F8' : 'rgba(0, 0, 0, 0.87)',
 });
 
+export const emptyState: SxProps<Theme> = {
+  fontStyle: 'italic',
+};
+
 export const subtitle1: SxProps<Theme> = theme => ({
   fontSize: theme.spacing(2),
   fontWeight: 700,

--- a/plugins/ros/src/components/common/typography.ts
+++ b/plugins/ros/src/components/common/typography.ts
@@ -1,92 +1,89 @@
 import { SxProps, Theme } from '@mui/material/styles';
 
-export const formLabel: SxProps<Theme> = theme => ({
-  fontSize: theme.spacing(1.75),
+export const formLabel: SxProps<Theme> = {
+  fontSize: '0.875rem',
   fontWeight: 700,
   textTransform: 'uppercase',
-  marginBottom: theme.spacing(1),
-  color: theme.palette.mode === 'dark' ? '#F8F8F8' : 'rgba(0, 0, 0, 0.87)',
-});
+  marginBottom: '8px',
+};
 
-export const heading1: SxProps<Theme> = theme => ({
-  fontSize: theme.spacing(4),
+export const heading1: SxProps<Theme> = {
+  fontSize: '2rem',
   fontWeight: 700,
-});
+};
 
-export const heading2: SxProps<Theme> = theme => ({
-  fontSize: theme.spacing(3.5),
+export const heading2: SxProps<Theme> = {
+  fontSize: '1.75rem',
   fontWeight: 500,
-});
+};
 
-export const heading3: SxProps<Theme> = theme => ({
-  fontSize: theme.spacing(2.5),
+export const heading3: SxProps<Theme> = {
+  fontSize: '1.25rem',
   fontWeight: 500,
-});
+};
 
-export const body1: SxProps<Theme> = theme => ({
-  fontSize: theme.spacing(2),
+export const body1: SxProps<Theme> = {
+  fontSize: '1rem',
   fontWeight: 500,
-});
+};
 
-export const body2: SxProps<Theme> = theme => ({
-  fontSize: theme.spacing(2),
+export const body2: SxProps<Theme> = {
+  fontSize: '1rem',
   fontWeight: 400,
   whiteSpace: 'pre-line',
-});
+};
 
-export const label: SxProps<Theme> = theme => ({
-  fontSize: theme.spacing(1.75),
+export const label: SxProps<Theme> = {
+  fontSize: '0.875rem',
   fontWeight: 700,
   textTransform: 'uppercase',
-  color: theme.palette.mode === 'dark' ? '#F8F8F8' : 'rgba(0, 0, 0, 0.87)',
   paddingBottom: '0.4rem',
-});
+};
 
-export const labelSubtitle: SxProps<Theme> = theme => ({
-  fontSize: theme.spacing(1.75),
+export const labelSubtitle: SxProps<Theme> = {
+  fontSize: '0.875rem',
   fontWeight: 400,
-  color: theme.palette.mode === 'dark' ? '#F8F8F8' : 'rgba(0, 0, 0, 0.87)',
   paddingBottom: '0.4rem',
   marginTop: '-0.2rem',
-});
+};
 
-export const label2: SxProps<Theme> = theme => ({
-  fontSize: theme.spacing(1.75),
+export const label2: SxProps<Theme> = {
+  fontSize: '0.875rem',
   fontWeight: 700,
   textTransform: 'uppercase',
-  color: theme.palette.mode === 'dark' ? '#F8F8F8' : 'rgba(0, 0, 0, 0.87)',
-});
+};
 
 export const emptyState: SxProps<Theme> = {
+  fontSize: '1rem',
   fontStyle: 'italic',
 };
 
-export const subtitle1: SxProps<Theme> = theme => ({
-  fontSize: theme.spacing(2),
+export const subtitle1: SxProps<Theme> = {
+  fontSize: '1rem',
   fontWeight: 700,
-});
+};
 
-export const subtitle2: SxProps<Theme> = theme => ({
-  fontSize: theme.spacing(2),
+export const subtitle2: SxProps<Theme> = {
+  fontSize: '1rem',
   fontWeight: 400,
-});
+};
 
-export const headerSubtitle: SxProps<Theme> = theme => ({
-  fontSize: theme.spacing(2),
+export const headerSubtitle: SxProps<Theme> = {
+  fontSize: '1rem',
   fontWeight: 500,
   paddingBottom: '1rem',
   marginTop: '-0.2rem',
-});
+};
 
-export const risikoLevel: SxProps<Theme> = theme => ({
-  fontSize: theme.spacing(2.25),
+export const risikoLevel: SxProps<Theme> = {
+  fontSize: '1.125rem',
   fontWeight: 700,
   paddingTop: 0,
-});
+};
 
-export const actionSubtitle: SxProps<Theme> = theme => ({
-  fontSize: theme.spacing(2.25),
+export const actionSubtitle: SxProps<Theme> = {
+  fontSize: '1.125rem',
   fontWeight: 700,
-  marginBottom: theme.spacing(2),
-  marginTop: theme.spacing(2),
-});
+  marginBottom: '16px',
+  marginTop: '16px',
+};

--- a/plugins/ros/src/components/riScDialog/RiScDialog.tsx
+++ b/plugins/ros/src/components/riScDialog/RiScDialog.tsx
@@ -7,12 +7,13 @@ import {
   Typography,
 } from '@material-ui/core';
 import { TextField } from '../common/Textfield';
-import { RiSc, RiScWithMetadata } from '../../utils/types';
+import { RiSc } from '../../utils/types';
 import { emptyRiSc } from '../../utils/utilityfunctions';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { pluginRiScTranslationRef } from '../../utils/translations';
 import { useRiScDialogStyles } from './riScDialogStyle';
 import { useFontStyles } from '../../utils/style';
+import { useRiScs } from '../../contexts/RiScContext';
 
 export enum RiScDialogStates {
   Closed,
@@ -23,9 +24,6 @@ export enum RiScDialogStates {
 interface RiScDialogProps {
   onClose: () => void;
   dialogState: RiScDialogStates;
-  createNewRiSc: (newRiSc: RiSc) => void;
-  updateRiSc: (newRiSc: RiSc) => void;
-  riSc: RiScWithMetadata | null;
 }
 
 interface RiskError {
@@ -33,20 +31,16 @@ interface RiskError {
   scope: string | null;
 }
 
-export const RiScDialog = ({
-  onClose,
-  dialogState,
-  createNewRiSc,
-  updateRiSc,
-  riSc,
-  ...props
-}: RiScDialogProps) => {
+export const RiScDialog = ({ onClose, dialogState }: RiScDialogProps) => {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
   const { paper, content, buttons } = useRiScDialogStyles();
   const { h1 } = useFontStyles();
+  const { selectedRiSc, createNewRiSc, updateRiSc } = useRiScs();
 
   const [newRiSc, setNewRiSc] = useState<RiSc>(
-    dialogState === RiScDialogStates.Edit ? riSc!!.content : emptyRiSc(),
+    dialogState === RiScDialogStates.Edit
+      ? selectedRiSc!!.content
+      : emptyRiSc(),
   );
 
   const [newRiScError, setNewRiScError] = useState<RiskError>({
@@ -110,7 +104,6 @@ export const RiScDialog = ({
       classes={{ paper: paper }}
       open={dialogState !== RiScDialogStates.Closed}
       onClose={handleCancel}
-      {...props}
     >
       <DialogContent>
         <Typography className={h1}>{header}</Typography>

--- a/plugins/ros/src/components/riScInfo/RiScInfo.tsx
+++ b/plugins/ros/src/components/riScInfo/RiScInfo.tsx
@@ -7,16 +7,18 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { pluginRiScTranslationRef } from '../../utils/translations';
 import { useFontStyles } from '../../utils/style';
 import EditButton from '../common/EditButton';
+import { useRiScs } from '../../contexts/RiScContext';
 
 interface RiScInfoProps {
   riSc: RiScWithMetadata;
-  approveRiSc: () => void;
   edit: () => void;
 }
 
-export const RiScInfo = ({ riSc, approveRiSc, edit }: RiScInfoProps) => {
+export const RiScInfo = ({ riSc, edit }: RiScInfoProps) => {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
   const { label, body2 } = useFontStyles();
+
+  const { approveRiSc } = useRiScs();
 
   return (
     <Grid container>

--- a/plugins/ros/src/components/riScInfo/riScStatus/RiScStatusComponent.tsx
+++ b/plugins/ros/src/components/riScInfo/riScStatus/RiScStatusComponent.tsx
@@ -13,11 +13,12 @@ import React, { ReactComponentElement, useState } from 'react';
 import { RiScStatus, RiScWithMetadata } from '../../../utils/types';
 import Alert from '@mui/material/Alert';
 import { useRiScDialogStyles } from '../../riScDialog/riScDialogStyle';
-import Checkbox from '@material-ui/core/Checkbox';
+import Checkbox from '@mui/material/Checkbox';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { pluginRiScTranslationRef } from '../../../utils/translations';
 import { useButtonStyles } from './riScStatusComponentStyle';
 import CheckIcon from '@mui/icons-material/Check';
+import FormControlLabel from '@mui/material/FormControlLabel';
 
 interface RiScPublishDialogProps {
   openDialog: boolean;
@@ -44,18 +45,16 @@ const RiScPublishDialog = ({
       <DialogTitle>{t('publishDialog.title')}</DialogTitle>
       <DialogContent>
         <Alert severity="info" icon={false}>
-          <Grid container>
-            <Grid item xs={1}>
+          <FormControlLabel
+            control={
               <Checkbox
                 color="primary"
                 checked={riskOwnerApproves}
                 onChange={handleCheckboxInput}
               />
-            </Grid>
-            <Grid item xs={8}>
-              {t('publishDialog.checkboxLabel')}
-            </Grid>
-          </Grid>
+            }
+            label={t('publishDialog.checkboxLabel')}
+          />
         </Alert>
       </DialogContent>
       <div

--- a/plugins/ros/src/components/riScPlugin/RiScPlugin.tsx
+++ b/plugins/ros/src/components/riScPlugin/RiScPlugin.tsx
@@ -55,7 +55,10 @@ export const RiScPlugin = () => {
   return (
     <>
       {response && (
-        <Alert severity={getAlertSeverity(response.status)}>
+        <Alert
+          severity={getAlertSeverity(response.status)}
+          sx={{ marginBottom: 2 }}
+        >
           <Typography>{response.statusMessage}</Typography>
         </Alert>
       )}
@@ -87,7 +90,7 @@ export const RiScPlugin = () => {
                 <Dropdown<string>
                   options={riScs.map(riSc => riSc.content.title) ?? []}
                   selectedValues={selectedRiSc?.content.title ?? ''}
-                  handleChange={selectRiSc}
+                  handleChange={title => selectRiSc(title)}
                   variant="standard"
                 />
               </Grid>

--- a/plugins/ros/src/components/riScPlugin/RiScPlugin.tsx
+++ b/plugins/ros/src/components/riScPlugin/RiScPlugin.tsx
@@ -25,7 +25,7 @@ export const RiScPlugin = () => {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
   const { linearProgress } = useLinearProgressStyle();
 
-  const [RiScDialogState, setRiScDialogState] = useState<RiScDialogStates>(
+  const [riScDialogState, setRiScDialogState] = useState<RiScDialogStates>(
     RiScDialogStates.Closed,
   );
 
@@ -39,13 +39,9 @@ export const RiScPlugin = () => {
     riScs,
     selectRiSc,
     isFetching,
-    createNewRiSc,
-    updateRiSc,
-    updateRiScStatus,
     resetRiScStatus,
-    approveRiSc,
     response,
-    isRequesting,
+    riScUpdateStatus,
   } = useRiScs();
 
   const [searchParams] = useSearchParams();
@@ -63,14 +59,12 @@ export const RiScPlugin = () => {
           <Typography>{response.statusMessage}</Typography>
         </Alert>
       )}
-      {isRequesting && <LinearProgress className={linearProgress} />}
+      {riScUpdateStatus.isLoading && (
+        <LinearProgress className={linearProgress} />
+      )}
 
       {scenarioWizardStep !== null ? (
-        <ScenarioWizard
-          step={scenarioWizardStep}
-          isFetching={isFetching}
-          updateStatus={updateRiScStatus}
-        />
+        <ScenarioWizard step={scenarioWizardStep} />
       ) : (
         <>
           <ContentHeader title={t('contentHeader.title')}>
@@ -93,7 +87,7 @@ export const RiScPlugin = () => {
                 <Dropdown<string>
                   options={riScs.map(riSc => riSc.content.title) ?? []}
                   selectedValues={selectedRiSc?.content.title ?? ''}
-                  handleChange={title => selectRiSc(title)}
+                  handleChange={selectRiSc}
                   variant="standard"
                 />
               </Grid>
@@ -118,11 +112,7 @@ export const RiScPlugin = () => {
             {selectedRiSc && (
               <>
                 <Grid item xs={12}>
-                  <RiScInfo
-                    riSc={selectedRiSc}
-                    approveRiSc={approveRiSc}
-                    edit={openEditRiScDialog}
-                  />
+                  <RiScInfo riSc={selectedRiSc} edit={openEditRiScDialog} />
                 </Grid>
                 <Grid item xs md={7} lg={8}>
                   <ScenarioTable riSc={selectedRiSc.content} />
@@ -136,14 +126,8 @@ export const RiScPlugin = () => {
         </>
       )}
 
-      {RiScDialogState !== RiScDialogStates.Closed && (
-        <RiScDialog
-          onClose={closeRiScDialog}
-          createNewRiSc={createNewRiSc}
-          updateRiSc={updateRiSc}
-          riSc={selectedRiSc}
-          dialogState={RiScDialogState}
-        />
+      {riScDialogState !== RiScDialogStates.Closed && (
+        <RiScDialog onClose={closeRiScDialog} dialogState={riScDialogState} />
       )}
 
       {!scenarioWizardStep && <ScenarioDrawer />}

--- a/plugins/ros/src/components/riskMatrix/RiskMatrixScenarioCount.tsx
+++ b/plugins/ros/src/components/riskMatrix/RiskMatrixScenarioCount.tsx
@@ -15,7 +15,7 @@ import { RiSc } from '../../utils/types';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { pluginRiScTranslationRef } from '../../utils/translations';
 import { useRiskMatrixStyles } from './riskMatrixStyle';
-import { useScenario } from '../../ScenarioContext';
+import { useScenario } from '../../contexts/ScenarioContext';
 
 interface ScenarioCountProps {
   riSc: RiSc;

--- a/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
@@ -9,12 +9,17 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { pluginRiScTranslationRef } from '../../utils/translations';
 import { ScopeSection } from './components/ScopeSection';
 import { useForm } from 'react-hook-form';
-import { Scenario } from '../../utils/types';
+import { ProcessingStatus, Scenario } from '../../utils/types';
 import RiskFormSection from './components/RiskFormSection';
 import ActionFormSection from './components/ActionFormSection';
 import ScopeFormSection from './components/ScopeFormSection';
 import Drawer from '@mui/material/Drawer';
 import Button from '@mui/material/Button';
+import { useRiScs } from '../../contexts/RiScContext';
+import CircularProgress from '@mui/material/CircularProgress';
+import Alert from '@mui/material/Alert';
+import { getAlertSeverity } from '../../utils/utilityfunctions';
+import Typography from '@mui/material/Typography';
 
 export const ScenarioDrawer = () => {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
@@ -27,7 +32,12 @@ export const ScenarioDrawer = () => {
     submitEditedScenarioToRiSc,
   } = useScenario();
 
-  const formMethods = useForm<Scenario>({ defaultValues: scenario });
+  const { riScUpdateStatus, response } = useRiScs();
+
+  const formMethods = useForm<Scenario>({
+    defaultValues: scenario,
+    mode: 'onBlur',
+  });
 
   const onCancel = () => {
     formMethods.reset(scenario);
@@ -41,8 +51,13 @@ export const ScenarioDrawer = () => {
 
   const onSubmit = formMethods.handleSubmit((data: Scenario) => {
     submitEditedScenarioToRiSc(data);
-    setIsEditing(false);
   });
+
+  useEffect(() => {
+    if (riScUpdateStatus.isSuccess) {
+      setIsEditing(false);
+    }
+  }, [riScUpdateStatus.isSuccess]);
 
   useEffect(() => {
     formMethods.reset(scenario);
@@ -117,9 +132,17 @@ export const ScenarioDrawer = () => {
             color="primary"
             variant="contained"
             onClick={onSubmit}
-            disabled={!formMethods.formState.isDirty}
+            disabled={
+              !formMethods.formState.isDirty || riScUpdateStatus.isLoading
+            }
           >
             {t('dictionary.save')}
+            {riScUpdateStatus.isLoading && (
+              <CircularProgress
+                size={16}
+                sx={{ marginLeft: 1, color: 'inherit' }}
+              />
+            )}
           </Button>
         )}
         <Button
@@ -132,6 +155,13 @@ export const ScenarioDrawer = () => {
           {t('scenarioDrawer.deleteScenarioButton')}
         </Button>
       </Box>
+
+      {response &&
+        response.status !== ProcessingStatus.ErrorWhenFetchingRiScs && (
+          <Alert severity={getAlertSeverity(response.status)}>
+            <Typography>{response.statusMessage}</Typography>
+          </Alert>
+        )}
 
       <DeleteConfirmation />
     </Drawer>

--- a/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
@@ -75,14 +75,15 @@ export const ScenarioDrawer = () => {
           marginLeft: 'auto',
         }}
       >
-        <Button
-          color="primary"
-          variant="contained"
-          onClick={isEditing ? onSubmit : () => setIsEditing(true)}
-          disabled={isEditing && !formMethods.formState.isDirty}
-        >
-          {t(isEditing ? 'dictionary.save' : 'dictionary.edit')}
-        </Button>
+        {!isEditing && (
+          <Button
+            color="primary"
+            variant="contained"
+            onClick={() => setIsEditing(true)}
+          >
+            {t('dictionary.edit')}
+          </Button>
+        )}
         <Button
           variant="outlined"
           color="primary"
@@ -105,16 +106,32 @@ export const ScenarioDrawer = () => {
           <ActionsSection />
         </>
       )}
-
-      <Button
-        startIcon={<DeleteIcon />}
-        variant="text"
-        color="primary"
-        onClick={openDeleteConfirmation}
-        sx={{ marginRight: 'auto' }}
+      <Box
+        sx={{
+          display: 'flex',
+          gap: '16px',
+        }}
       >
-        {t('scenarioDrawer.deleteScenarioButton')}
-      </Button>
+        {isEditing && (
+          <Button
+            color="primary"
+            variant="contained"
+            onClick={onSubmit}
+            disabled={!formMethods.formState.isDirty}
+          >
+            {t('dictionary.save')}
+          </Button>
+        )}
+        <Button
+          startIcon={<DeleteIcon />}
+          variant="text"
+          color="primary"
+          onClick={openDeleteConfirmation}
+          sx={{ marginLeft: 'auto' }}
+        >
+          {t('scenarioDrawer.deleteScenarioButton')}
+        </Button>
+      </Box>
 
       <DeleteConfirmation />
     </Drawer>

--- a/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
@@ -50,14 +50,8 @@ export const ScenarioDrawer = () => {
   };
 
   const onSubmit = formMethods.handleSubmit((data: Scenario) => {
-    submitEditedScenarioToRiSc(data);
+    submitEditedScenarioToRiSc(data, () => setIsEditing(false));
   });
-
-  useEffect(() => {
-    if (riScUpdateStatus.isSuccess) {
-      setIsEditing(false);
-    }
-  }, [riScUpdateStatus.isSuccess]);
 
   useEffect(() => {
     formMethods.reset(scenario);

--- a/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
@@ -12,7 +12,7 @@ import { useForm } from 'react-hook-form';
 import { Scenario } from '../../utils/types';
 import RiskFormSection from './components/RiskFormSection';
 import ActionFormSection from './components/ActionFormSection';
-import ScenarioFormSection from './components/ScenarioFormSection';
+import ScopeFormSection from './components/ScopeFormSection';
 import Drawer from '@mui/material/Drawer';
 import Button from '@mui/material/Button';
 
@@ -95,7 +95,7 @@ export const ScenarioDrawer = () => {
 
       {isEditing ? (
         <>
-          <ScenarioFormSection formMethods={formMethods} />
+          <ScopeFormSection formMethods={formMethods} />
           <RiskFormSection formMethods={formMethods} />
           <ActionFormSection formMethods={formMethods} />
         </>

--- a/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import Box from '@mui/material/Box';
-import { useScenario } from '../../ScenarioContext';
+import { useScenario } from '../../contexts/ScenarioContext';
 import { RiskSection } from './components/RiskSection';
 import { ActionsSection } from './components/ActionsSection';
 import DeleteIcon from '@mui/icons-material/Delete';

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
@@ -6,7 +6,7 @@ import Chip from '@mui/material/Chip';
 import Box from '@mui/material/Box';
 import Link from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
-import { body2, label } from '../../common/typography';
+import { body2, emptyState, label } from '../../common/typography';
 import Button from '@mui/material/Button';
 import Collapse from '@mui/material/Collapse';
 import { ExpandLess, ExpandMore } from '@mui/icons-material';
@@ -38,6 +38,8 @@ export const ActionBox = ({ action, index, saveScenario }: ActionBoxProps) => {
           width: '100%',
           justifyContent: 'start',
           textAlign: 'left',
+          textTransform: 'initial',
+          fontSize: '16px',
         }}
         startIcon={isExpanded ? <ExpandLess /> : <ExpandMore />}
         onClick={() => setIsExpanded(!isExpanded)}
@@ -47,7 +49,11 @@ export const ActionBox = ({ action, index, saveScenario }: ActionBoxProps) => {
           ? action.title
           : `${t('dictionary.measure')} ${index}`}
       </Button>
-      <Collapse in={isExpanded}>
+      <Collapse
+        in={isExpanded}
+        sx={{ '.MuiCollapse-wrapperInner': { paddingTop: '8px' } }}
+      >
+        <Typography sx={label}>{t('dictionary.description')}</Typography>
         <Typography sx={body2}>{action.description}</Typography>
 
         <Box
@@ -72,7 +78,11 @@ export const ActionBox = ({ action, index, saveScenario }: ActionBoxProps) => {
                 {action.url}
               </Link>
             ) : (
-              <Typography sx={body2}>{t('dictionary.emptyUrl')}</Typography>
+              <Typography sx={emptyState}>
+                {t('dictionary.emptyField', {
+                  field: t('dictionary.url').toLowerCase(),
+                })}
+              </Typography>
             )}
           </Box>
 

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
@@ -30,16 +30,19 @@ export const ActionBox = ({ action, index, saveScenario }: ActionBoxProps) => {
   }, [action, saveScenario, previousAction]);
   const isActionTitlePresent = action.title !== null && action.title !== '';
 
+  /* @ts-ignore Because ts can't typecheck strings against our keys */
+  const translatedActionStatus = t(`actionStatus.${action.status}`);
+
   return (
     <Box>
       <Button
         sx={{
-          color: 'inherit',
           width: '100%',
-          justifyContent: 'start',
-          textAlign: 'left',
-          textTransform: 'initial',
           fontSize: '16px',
+          color: 'inherit',
+          textAlign: 'left',
+          justifyContent: 'start',
+          textTransform: 'initial',
         }}
         startIcon={isExpanded ? <ExpandLess /> : <ExpandMore />}
         onClick={() => setIsExpanded(!isExpanded)}
@@ -49,11 +52,10 @@ export const ActionBox = ({ action, index, saveScenario }: ActionBoxProps) => {
           ? action.title
           : `${t('dictionary.measure')} ${index}`}
       </Button>
-      <Collapse
-        in={isExpanded}
-        sx={{ '.MuiCollapse-wrapperInner': { paddingTop: '8px' } }}
-      >
-        <Typography sx={label}>{t('dictionary.description')}</Typography>
+      <Collapse in={isExpanded}>
+        <Typography sx={{ ...label, marginTop: 1 }}>
+          {t('dictionary.description')}
+        </Typography>
         <Typography sx={body2}>{action.description}</Typography>
 
         <Box
@@ -87,7 +89,7 @@ export const ActionBox = ({ action, index, saveScenario }: ActionBoxProps) => {
           </Box>
 
           <Chip
-            label={action.status}
+            label={translatedActionStatus}
             sx={{
               margin: 0,
               backgroundColor:

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionFormSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionFormSection.tsx
@@ -30,6 +30,12 @@ const ActionFormSection = ({
     name: 'actions',
   });
 
+  const translatedActionStatuses = actionStatusOptions.map(actionStatus => ({
+    value: actionStatus,
+    /* @ts-ignore Because ts can't typecheck strings against our keys */
+    renderedValue: t(`actionStatus.${actionStatus}`),
+  }));
+
   return (
     <Paper sx={section}>
       <Typography sx={heading3}>{t('dictionary.measure')}</Typography>
@@ -95,10 +101,7 @@ const ActionFormSection = ({
                 control={control}
                 name={`actions.${index}.status`}
                 label={t('dictionary.status')}
-                options={actionStatusOptions.map(value => ({
-                  value,
-                  renderedValue: value,
-                }))}
+                options={translatedActionStatuses}
               />
             </Box>
           </Box>

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionFormSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionFormSection.tsx
@@ -28,6 +28,9 @@ const ActionFormSection = ({
   const { fields, append, remove } = useFieldArray({
     control,
     name: 'actions',
+    rules: {
+      required: true,
+    },
   });
 
   const translatedActionStatuses = actionStatusOptions.map(actionStatus => ({
@@ -75,6 +78,9 @@ const ActionFormSection = ({
             <Input
               required
               {...register(`actions.${index}.description`, { required: true })}
+              error={
+                formState.errors?.actions?.[index]?.description !== undefined
+              }
               label={t('dictionary.description')}
             />
             <Box

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionFormSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionFormSection.tsx
@@ -56,7 +56,7 @@ const ActionFormSection = ({
               }}
             >
               <Typography sx={heading3}>
-                {t('scenarioDrawer.measureTab.title')} {index + 1}
+                {t('dictionary.measure')} {index + 1}
               </Typography>
               <IconButton onClick={() => remove(index)} color="primary">
                 <DeleteIcon aria-label="Edit" />

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionFormSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionFormSection.tsx
@@ -12,7 +12,7 @@ import { heading3 } from '../../common/typography';
 import { AddCircle } from '@mui/icons-material';
 import Divider from '@mui/material/Divider';
 import Button from '@mui/material/Button';
-import { emptyAction } from '../../../ScenarioContext';
+import { emptyAction } from '../../../contexts/ScenarioContext';
 import IconButton from '@mui/material/IconButton';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { section } from '../scenarioDrawerComponents';

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionsSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionsSection.tsx
@@ -4,7 +4,7 @@ import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { pluginRiScTranslationRef } from '../../../utils/translations';
-import { useScenario } from '../../../ScenarioContext';
+import { useScenario } from '../../../contexts/ScenarioContext';
 import { section } from '../scenarioDrawerComponents';
 import Box from '@mui/material/Box';
 import { body2, emptyState, heading3, label } from '../../common/typography';

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionsSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionsSection.tsx
@@ -7,7 +7,7 @@ import { pluginRiScTranslationRef } from '../../../utils/translations';
 import { useScenario } from '../../../ScenarioContext';
 import { section } from '../scenarioDrawerComponents';
 import Box from '@mui/material/Box';
-import { body2, heading3, label } from '../../common/typography';
+import { body2, emptyState, heading3, label } from '../../common/typography';
 import Divider from '@mui/material/Divider';
 
 export const ActionsSection = () => {
@@ -16,9 +16,7 @@ export const ActionsSection = () => {
 
   return (
     <Paper sx={section}>
-      <Typography sx={heading3}>
-        {t('scenarioDrawer.measureTab.title')}
-      </Typography>
+      <Typography sx={heading3}>{t('dictionary.measures')}</Typography>
       {scenario.existingActions && (
         <Box>
           <Typography sx={label}>
@@ -28,16 +26,24 @@ export const ActionsSection = () => {
         </Box>
       )}
 
-      {scenario.actions.map((action, index) => (
-        <Fragment key={action.ID}>
-          <Divider />
-          <ActionBox
-            action={action}
-            index={index + 1}
-            saveScenario={saveScenario}
-          />
-        </Fragment>
-      ))}
+      {scenario.actions.length > 0 ? (
+        scenario.actions.map((action, index) => (
+          <Fragment key={action.ID}>
+            <Divider />
+            <ActionBox
+              action={action}
+              index={index + 1}
+              saveScenario={saveScenario}
+            />
+          </Fragment>
+        ))
+      ) : (
+        <Typography sx={emptyState}>
+          {t('dictionary.emptyField', {
+            field: t('dictionary.measures').toLowerCase(),
+          })}
+        </Typography>
+      )}
     </Paper>
   );
 };

--- a/plugins/ros/src/components/scenarioDrawer/components/DeleteConfirmation.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/DeleteConfirmation.tsx
@@ -2,7 +2,7 @@ import Button from '@mui/material/Button';
 import React from 'react';
 import { pluginRiScTranslationRef } from '../../../utils/translations';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
-import { useScenario } from '../../../ScenarioContext';
+import { useScenario } from '../../../contexts/ScenarioContext';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogActions from '@mui/material/DialogActions';

--- a/plugins/ros/src/components/scenarioDrawer/components/RiskSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/RiskSection.tsx
@@ -11,7 +11,7 @@ import {
 import KeyboardDoubleArrowRightIcon from '@mui/icons-material/KeyboardDoubleArrowRight';
 import { pluginRiScTranslationRef } from '../../../utils/translations';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
-import { useScenario } from '../../../ScenarioContext';
+import { useScenario } from '../../../contexts/ScenarioContext';
 import { Risk } from '../../../utils/types';
 import { section } from '../scenarioDrawerComponents';
 import { body1, heading3, label, label2 } from '../../common/typography';

--- a/plugins/ros/src/components/scenarioDrawer/components/ScopeFormSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ScopeFormSection.tsx
@@ -14,7 +14,7 @@ import { heading3 } from '../../common/typography';
 import Paper from '@mui/material/Paper';
 import { section } from '../scenarioDrawerComponents';
 
-const ScenarioFormSection = ({
+const ScopeFormSection = ({
   formMethods,
 }: {
   formMethods: UseFormReturn<Scenario>;
@@ -74,4 +74,4 @@ const ScenarioFormSection = ({
   );
 };
 
-export default ScenarioFormSection;
+export default ScopeFormSection;

--- a/plugins/ros/src/components/scenarioDrawer/components/ScopeSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ScopeSection.tsx
@@ -7,7 +7,13 @@ import Typography from '@mui/material/Typography';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { useScenario } from '../../../ScenarioContext';
 import { section } from '../scenarioDrawerComponents';
-import { body2, heading1, heading3, label } from '../../common/typography';
+import {
+  body2,
+  emptyState,
+  heading1,
+  heading3,
+  label,
+} from '../../common/typography';
 
 export const ScopeSection = () => {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
@@ -21,7 +27,15 @@ export const ScopeSection = () => {
 
       <Box>
         <Typography sx={label}>{t('dictionary.description')}</Typography>
-        <Typography sx={body2}>{scenario.description}</Typography>
+        {scenario.description ? (
+          <Typography sx={body2}>{scenario.description}</Typography>
+        ) : (
+          <Typography sx={emptyState}>
+            {t('dictionary.emptyField', {
+              field: t('dictionary.description').toLowerCase(),
+            })}
+          </Typography>
+        )}
       </Box>
 
       <Divider />
@@ -29,20 +43,36 @@ export const ScopeSection = () => {
       <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2 }}>
         <Box>
           <Typography sx={label}>{t('dictionary.threatActors')}</Typography>
-          {scenario.threatActors.map(threatActor => (
-            <Typography key={threatActor} sx={body2}>
-              {threatActor}
+          {scenario.threatActors.length > 0 ? (
+            scenario.threatActors.map(threatActor => (
+              <Typography key={threatActor} sx={body2}>
+                {threatActor}
+              </Typography>
+            ))
+          ) : (
+            <Typography sx={emptyState}>
+              {t('dictionary.emptyField', {
+                field: t('dictionary.threatActors').toLowerCase(),
+              })}
             </Typography>
-          ))}
+          )}
         </Box>
 
         <Box>
           <Typography sx={label}>{t('dictionary.vulnerabilities')}</Typography>
-          {scenario.vulnerabilities.map(vulnerability => (
-            <Typography key={vulnerability} sx={body2}>
-              {vulnerability}
+          {scenario.vulnerabilities.length > 0 ? (
+            scenario.vulnerabilities.map(vulnerability => (
+              <Typography key={vulnerability} sx={body2}>
+                {vulnerability}
+              </Typography>
+            ))
+          ) : (
+            <Typography sx={emptyState}>
+              {t('dictionary.emptyField', {
+                field: t('dictionary.vulnerabilities').toLowerCase(),
+              })}
             </Typography>
-          ))}
+          )}
         </Box>
       </Box>
     </Paper>

--- a/plugins/ros/src/components/scenarioDrawer/components/ScopeSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ScopeSection.tsx
@@ -44,11 +44,15 @@ export const ScopeSection = () => {
         <Box>
           <Typography sx={label}>{t('dictionary.threatActors')}</Typography>
           {scenario.threatActors.length > 0 ? (
-            scenario.threatActors.map(threatActor => (
-              <Typography key={threatActor} sx={body2}>
-                {threatActor}
-              </Typography>
-            ))
+            scenario.threatActors.map(threatActor => {
+              /* @ts-ignore Because ts can't typecheck strings against our keys */
+              const translatedThreatActor = t(`threatActors.${threatActor}`);
+              return (
+                <Typography key={threatActor} sx={body2}>
+                  {translatedThreatActor}
+                </Typography>
+              );
+            })
           ) : (
             <Typography sx={emptyState}>
               {t('dictionary.emptyField', {
@@ -61,11 +65,17 @@ export const ScopeSection = () => {
         <Box>
           <Typography sx={label}>{t('dictionary.vulnerabilities')}</Typography>
           {scenario.vulnerabilities.length > 0 ? (
-            scenario.vulnerabilities.map(vulnerability => (
-              <Typography key={vulnerability} sx={body2}>
-                {vulnerability}
-              </Typography>
-            ))
+            scenario.vulnerabilities.map(vulnerability => {
+              /* @ts-ignore Because ts can't typecheck strings against our keys */
+              const translatedVulnerability = t(
+                `vulnerabilities.${vulnerability}`,
+              );
+              return (
+                <Typography key={vulnerability} sx={body2}>
+                  {translatedVulnerability}
+                </Typography>
+              );
+            })
           ) : (
             <Typography sx={emptyState}>
               {t('dictionary.emptyField', {

--- a/plugins/ros/src/components/scenarioDrawer/components/ScopeSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ScopeSection.tsx
@@ -5,7 +5,7 @@ import Paper from '@mui/material/Paper';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
-import { useScenario } from '../../../ScenarioContext';
+import { useScenario } from '../../../contexts/ScenarioContext';
 import { section } from '../scenarioDrawerComponents';
 import {
   body2,

--- a/plugins/ros/src/components/scenarioTable/ScenarioTable.tsx
+++ b/plugins/ros/src/components/scenarioTable/ScenarioTable.tsx
@@ -94,7 +94,7 @@ export const ScenarioTable = ({ riSc }: ScenarioTableProps) => {
 
                   <TableCell className={tableCell}>
                     <Typography className={label} style={{ paddingBottom: 0 }}>
-                      {t('scenarioTable.columns.measuresCount')}
+                      {t('dictionary.measures')}
                     </Typography>
                   </TableCell>
                   <TableCell className={tableCell}>

--- a/plugins/ros/src/components/scenarioTable/ScenarioTable.tsx
+++ b/plugins/ros/src/components/scenarioTable/ScenarioTable.tsx
@@ -14,7 +14,7 @@ import { useTableStyles } from './ScenarioTableStyles';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { pluginRiScTranslationRef } from '../../utils/translations';
 import { useFontStyles } from '../../utils/style';
-import { useScenario } from '../../ScenarioContext';
+import { useScenario } from '../../contexts/ScenarioContext';
 
 interface ScenarioTableProps {
   riSc: RiSc;

--- a/plugins/ros/src/components/scenarioWizard/ScenarioWizard.tsx
+++ b/plugins/ros/src/components/scenarioWizard/ScenarioWizard.tsx
@@ -16,6 +16,7 @@ import { CloseConfirmation } from './components/CloseConfirmation';
 import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
 import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
 import { useScenario } from '../../contexts/ScenarioContext';
+import { useRiScs } from '../../contexts/RiScContext';
 
 const scenarioWizardSteps = [
   'scenario',
@@ -28,18 +29,13 @@ export type ScenarioWizardSteps = (typeof scenarioWizardSteps)[number];
 
 interface ScenarioStepperProps {
   step: ScenarioWizardSteps;
-  isFetching: boolean;
-  updateStatus: { isLoading: boolean; isSuccess: boolean; isError: boolean };
 }
 
-export const ScenarioWizard = ({
-  step,
-  isFetching,
-  updateStatus,
-}: ScenarioStepperProps) => {
+export const ScenarioWizard = ({ step }: ScenarioStepperProps) => {
   const wizardRef = useRef<HTMLDivElement>(null);
   const { t } = useTranslationRef(pluginRiScTranslationRef);
   const { h1, label } = useFontStyles();
+  const { isFetching, riScUpdateStatus } = useRiScs();
 
   const {
     root,
@@ -79,13 +75,13 @@ export const ScenarioWizard = ({
   }, [closeScenario]);
 
   useEffect(() => {
-    if (updateStatus.isSuccess && canCloseIfSuccessfull) {
+    if (riScUpdateStatus.isSuccess && canCloseIfSuccessfull) {
       close();
-    } else if (updateStatus.isError && wizardRef.current) {
+    } else if (riScUpdateStatus.isError && wizardRef.current) {
       setShowCloseConfirmation(false);
       wizardRef.current.scrollIntoView({ behavior: 'smooth', block: 'end' });
     }
-  }, [canCloseIfSuccessfull, close, updateStatus]);
+  }, [canCloseIfSuccessfull, close, riScUpdateStatus]);
 
   const saveAndClose = () => {
     if (hasFormErrors()) {
@@ -183,7 +179,7 @@ export const ScenarioWizard = ({
                   }[step]
                 }
               </Box>
-              {updateStatus.isError && (
+              {riScUpdateStatus.isError && (
                 <Alert style={{ marginBottom: '1rem' }} severity="error">
                   <Typography>{t('dictionary.saveError')}</Typography>
                 </Alert>
@@ -206,7 +202,7 @@ export const ScenarioWizard = ({
                     className={button}
                     variant={isLastStep() ? 'contained' : 'outlined'}
                     onClick={saveAndClose}
-                    disabled={updateStatus.isLoading}
+                    disabled={riScUpdateStatus.isLoading}
                   >
                     {t('dictionary.saveAndClose')}
                   </Button>

--- a/plugins/ros/src/components/scenarioWizard/ScenarioWizard.tsx
+++ b/plugins/ros/src/components/scenarioWizard/ScenarioWizard.tsx
@@ -15,7 +15,7 @@ import { Spinner } from '../common/Spinner';
 import { CloseConfirmation } from './components/CloseConfirmation';
 import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
 import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
-import { useScenario } from '../../ScenarioContext';
+import { useScenario } from '../../contexts/ScenarioContext';
 
 const scenarioWizardSteps = [
   'scenario',

--- a/plugins/ros/src/components/scenarioWizard/steps/ActionsStep.tsx
+++ b/plugins/ros/src/components/scenarioWizard/steps/ActionsStep.tsx
@@ -8,7 +8,7 @@ import { TextField } from '../../common/Textfield';
 import AddCircle from '@material-ui/icons/AddCircle';
 import { useFontStyles } from '../../../utils/style';
 import { ActionEdit } from '../components/ActionEdit';
-import { useScenario } from '../../../ScenarioContext';
+import { useScenario } from '../../../contexts/ScenarioContext';
 
 export const ActionsStep = () => {
   const { t } = useTranslationRef(pluginRiScTranslationRef);

--- a/plugins/ros/src/components/scenarioWizard/steps/RiskStep.tsx
+++ b/plugins/ros/src/components/scenarioWizard/steps/RiskStep.tsx
@@ -11,7 +11,7 @@ import { ProbabilityTable } from '../components/ProbabilityTable';
 import { ConsequenceTable } from '../components/ConsequenceTable';
 import { useFontStyles } from '../../../utils/style';
 import { useRiskStepStyles } from './riskStepStyles';
-import { useScenario } from '../../../ScenarioContext';
+import { useScenario } from '../../../contexts/ScenarioContext';
 
 interface RiskStepProps {
   riskType: 'initial' | 'rest';

--- a/plugins/ros/src/components/scenarioWizard/steps/ScenarioStep.tsx
+++ b/plugins/ros/src/components/scenarioWizard/steps/ScenarioStep.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { pluginRiScTranslationRef } from '../../../utils/translations';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { useFontStyles } from '../../../utils/style';
-import { useScenario } from '../../../ScenarioContext';
+import { useScenario } from '../../../contexts/ScenarioContext';
 
 export const ScenarioStep = () => {
   const { t } = useTranslationRef(pluginRiScTranslationRef);

--- a/plugins/ros/src/contexts/RiScContext.tsx
+++ b/plugins/ros/src/contexts/RiScContext.tsx
@@ -27,7 +27,11 @@ type RiScDrawerProps = {
   selectRiSc: (title: string) => void;
   selectedRiSc: RiScWithMetadata | null;
   createNewRiSc: (riSc: RiSc) => void;
-  updateRiSc: (riSc: RiSc) => void;
+  updateRiSc: (
+    riSc: RiSc,
+    onSuccess?: () => void,
+    onError?: () => void,
+  ) => void;
   approveRiSc: () => void;
   riScUpdateStatus: RiScUpdateStatus;
   resetRiScStatus: () => void;
@@ -242,7 +246,11 @@ const RiScProvider = ({ children }: { children: ReactNode }) => {
     );
   };
 
-  const updateRiSc = (riSc: RiSc) => {
+  const updateRiSc = (
+    riSc: RiSc,
+    onSuccess?: () => void,
+    onError?: () => void,
+  ) => {
     if (selectedRiSc && riScs) {
       const isRequiresNewApproval = requiresNewApproval(
         selectedRiSc.content,
@@ -277,6 +285,7 @@ const RiScProvider = ({ children }: { children: ReactNode }) => {
             riScs.map(r => (r.id === selectedRiSc.id ? updatedRiSc : r)),
           );
           setIsRequesting(false);
+          if (onSuccess) onSuccess();
         },
         () => {
           setRiScUpdateStatus({
@@ -285,6 +294,7 @@ const RiScProvider = ({ children }: { children: ReactNode }) => {
             isSuccess: false,
           });
           setIsRequesting(false);
+          if (onError) onError();
         },
       );
     }

--- a/plugins/ros/src/contexts/RiScContext.tsx
+++ b/plugins/ros/src/contexts/RiScContext.tsx
@@ -16,22 +16,23 @@ import { dtoToRiSc, RiScDTO } from '../utils/DTOs';
 import { useEffectOnce } from 'react-use';
 import { useFetch } from '../utils/hooks';
 
+type RiScUpdateStatus = {
+  isLoading: boolean;
+  isError: boolean;
+  isSuccess: boolean;
+};
+
 type RiScDrawerProps = {
-  selectedRiSc: RiScWithMetadata | null;
   riScs: RiScWithMetadata[] | null;
   selectRiSc: (title: string) => void;
-  isFetching: boolean;
+  selectedRiSc: RiScWithMetadata | null;
   createNewRiSc: (riSc: RiSc) => void;
   updateRiSc: (riSc: RiSc) => void;
-  updateRiScStatus: {
-    isLoading: boolean;
-    isError: boolean;
-    isSuccess: boolean;
-  };
-  resetRiScStatus: () => void;
   approveRiSc: () => void;
+  riScUpdateStatus: RiScUpdateStatus;
+  resetRiScStatus: () => void;
+  isFetching: boolean;
   response: SubmitResponseObject | null;
-  isRequesting: boolean;
 };
 
 const RiScContext = React.createContext<RiScDrawerProps | undefined>(undefined);
@@ -60,7 +61,7 @@ const RiScProvider = ({ children }: { children: ReactNode }) => {
     null,
   );
   const [isFetching, setIsFetching] = useState(true);
-  const [updateRiScStatus, setUpdateRiScStatus] = useState({
+  const [riScUpdateStatus, setRiScUpdateStatus] = useState({
     isLoading: false,
     isError: false,
     isSuccess: false,
@@ -147,7 +148,7 @@ const RiScProvider = ({ children }: { children: ReactNode }) => {
   }, [riScs, riScIdFromParams]);
 
   const resetRiScStatus = useCallback(() => {
-    setUpdateRiScStatus({
+    setRiScUpdateStatus({
       isLoading: false,
       isSuccess: false,
       isError: false,
@@ -258,16 +259,15 @@ const RiScProvider = ({ children }: { children: ReactNode }) => {
         schemaVersion: riSc.schemaVersion,
       };
 
-      setUpdateRiScStatus({
+      setRiScUpdateStatus({
         isLoading: true,
         isError: false,
         isSuccess: false,
       });
-      setIsRequesting(true);
       putRiScs(
         updatedRiSc,
         () => {
-          setUpdateRiScStatus({
+          setRiScUpdateStatus({
             isLoading: false,
             isError: false,
             isSuccess: true,
@@ -279,7 +279,7 @@ const RiScProvider = ({ children }: { children: ReactNode }) => {
           setIsRequesting(false);
         },
         () => {
-          setUpdateRiScStatus({
+          setRiScUpdateStatus({
             isLoading: false,
             isError: true,
             isSuccess: false,
@@ -305,17 +305,17 @@ const RiScProvider = ({ children }: { children: ReactNode }) => {
   };
 
   const value = {
-    selectedRiSc: selectedRiSc,
-    riScs: riScs,
-    selectRiSc: selectRiSc,
+    riScs,
+    selectRiSc,
+    selectedRiSc,
+    createNewRiSc,
+    updateRiSc,
+    approveRiSc,
+    riScUpdateStatus,
+    resetRiScStatus,
+    isRequesting,
     isFetching,
-    updateRiScStatus: updateRiScStatus,
-    resetRiScStatus: resetRiScStatus,
-    createNewRiSc: createNewRiSc,
-    updateRiSc: updateRiSc,
-    approveRiSc: approveRiSc,
     response,
-    isRequesting: isRequesting,
   };
 
   return <RiScContext.Provider value={value}>{children}</RiScContext.Provider>;

--- a/plugins/ros/src/contexts/RiScContext.tsx
+++ b/plugins/ros/src/contexts/RiScContext.tsx
@@ -1,0 +1,332 @@
+import React, { ReactNode } from 'react';
+import {
+  ContentStatus,
+  ProcessingStatus,
+  RiSc,
+  RiScStatus,
+  RiScWithMetadata,
+  SubmitResponseObject,
+} from '../utils/types';
+import { useCallback, useEffect, useState } from 'react';
+import { useRouteRef } from '@backstage/core-plugin-api';
+import { requiresNewApproval } from '../utils/utilityfunctions';
+import { riScRouteRef } from '../routes';
+import { useLocation, useNavigate, useParams } from 'react-router';
+import { dtoToRiSc, RiScDTO } from '../utils/DTOs';
+import { useEffectOnce } from 'react-use';
+import { useFetch } from '../utils/hooks';
+
+type RiScDrawerProps = {
+  selectedRiSc: RiScWithMetadata | null;
+  riScs: RiScWithMetadata[] | null;
+  selectRiSc: (title: string) => void;
+  isFetching: boolean;
+  createNewRiSc: (riSc: RiSc) => void;
+  updateRiSc: (riSc: RiSc) => void;
+  updateRiScStatus: {
+    isLoading: boolean;
+    isError: boolean;
+    isSuccess: boolean;
+  };
+  resetRiScStatus: () => void;
+  approveRiSc: () => void;
+  response: SubmitResponseObject | null;
+  isRequesting: boolean;
+};
+
+const RiScContext = React.createContext<RiScDrawerProps | undefined>(undefined);
+
+const RiScProvider = ({ children }: { children: ReactNode }) => {
+  const params = useParams();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const getRiScPath = useRouteRef(riScRouteRef);
+  const [isRequesting, setIsRequesting] = useState<boolean>(false);
+
+  const riScIdFromParams = params.riScId;
+
+  const {
+    fetchRiScs,
+    postRiScs,
+    putRiScs,
+    publishRiScs,
+    response,
+    setResponse,
+    fetchLatestJSONSchema,
+  } = useFetch();
+
+  const [riScs, setRiScs] = useState<RiScWithMetadata[] | null>(null);
+  const [selectedRiSc, setSelectedRiSc] = useState<RiScWithMetadata | null>(
+    null,
+  );
+  const [isFetching, setIsFetching] = useState(true);
+  const [updateRiScStatus, setUpdateRiScStatus] = useState({
+    isLoading: false,
+    isError: false,
+    isSuccess: false,
+  });
+
+  useEffect(() => {
+    if (location.state) {
+      setResponse({
+        statusMessage: location.state,
+        status: ProcessingStatus.ErrorWhenFetchingRiScs,
+      });
+    }
+  }, [location, setResponse]);
+
+  // Initial fetch of RiScs
+  useEffectOnce(() => {
+    fetchRiScs(
+      res => {
+        const fetchedRiScs: RiScWithMetadata[] = res
+          .filter(risk => risk.status === ContentStatus.Success)
+          .map(riScDTO => {
+            // This action can throw a runtime error if content is not parsable by JSON library.
+            // If that happens, it is catched by the fetch onError catch.
+            const json = JSON.parse(riScDTO.riScContent) as RiScDTO;
+
+            const content = dtoToRiSc(json);
+            return {
+              id: riScDTO.riScId,
+              content: content,
+              status: riScDTO.riScStatus,
+              pullRequestUrl: riScDTO.pullRequestUrl,
+            };
+          });
+        setRiScs(fetchedRiScs);
+        setIsFetching(false);
+
+        const errorRiScs: string[] = res
+          .filter(risk => risk.status !== ContentStatus.Success)
+          .map(risk => risk.riScId);
+
+        if (errorRiScs.length > 0) {
+          const errorMessage = `Failed to fetch risc scorecards with ids: ${errorRiScs.join(
+            ', ',
+          )}`;
+          setResponse({
+            statusMessage: errorMessage,
+            status: ProcessingStatus.ErrorWhenFetchingRiScs,
+          });
+        }
+
+        // If there are no RiScs, don't set a selected RiSc
+        if (fetchedRiScs.length === 0) {
+          return;
+        }
+
+        // If there is no RiSc ID in the URL, navigate to the first RiSc
+        if (!riScIdFromParams) {
+          navigate(getRiScPath({ riScId: fetchedRiScs[0].id }));
+          return;
+        }
+
+        const riSc = fetchedRiScs.find(r => r.id === riScIdFromParams);
+
+        // If there is an invalid RiSc ID in the URL, navigate to the first RiSc with error state
+        if (!riSc) {
+          navigate(getRiScPath({ riScId: fetchedRiScs[0].id }), {
+            state: 'The risk scorecard you are trying to open does not exist',
+          });
+          return;
+        }
+      },
+      () => setIsFetching(false),
+    );
+  });
+
+  // Set selected RiSc based on URL
+  useEffect(() => {
+    if (riScIdFromParams) {
+      const riSc = riScs?.find(r => r.id === riScIdFromParams);
+      if (riSc) {
+        setSelectedRiSc(riSc);
+      }
+    }
+  }, [riScs, riScIdFromParams]);
+
+  const resetRiScStatus = useCallback(() => {
+    setUpdateRiScStatus({
+      isLoading: false,
+      isSuccess: false,
+      isError: false,
+    });
+  }, []);
+
+  const selectRiSc = (title: string) => {
+    const riScId = riScs?.find(riSc => riSc.content.title === title)?.id;
+    if (riScId) {
+      navigate(getRiScPath({ riScId: riScId }));
+    }
+  };
+
+  const createNewRiSc = (riSc: RiSc) => {
+    setIsFetching(true);
+    setSelectedRiSc(null);
+    fetchLatestJSONSchema(
+      res => {
+        const resString = JSON.stringify(res);
+        const schema = JSON.parse(resString);
+        const schemaVersion = schema.properties.schemaVersion.default.replace(
+          /'/g,
+          '',
+        );
+
+        const newRiSc: RiSc = {
+          ...riSc,
+          schemaVersion: schemaVersion ? schemaVersion : '3.3',
+        };
+
+        postRiScs(
+          newRiSc,
+          res2 => {
+            if (!res2.riScId) throw new Error('No RiSc ID returned');
+
+            const RiScWithLatestSchemaVersion: RiScWithMetadata = {
+              id: res2.riScId,
+              status: RiScStatus.Draft,
+              content: riSc,
+              schemaVersion: riSc.schemaVersion,
+            };
+
+            setRiScs(
+              riScs
+                ? [...riScs, RiScWithLatestSchemaVersion]
+                : [RiScWithLatestSchemaVersion],
+            );
+            setSelectedRiSc(RiScWithLatestSchemaVersion);
+            setIsFetching(false);
+            navigate(getRiScPath({ riScId: res2.riScId }));
+          },
+          () => {
+            setSelectedRiSc(selectedRiSc);
+            setIsFetching(false);
+          },
+        );
+      },
+      () => {
+        const fallBackSchemaVersion = '3.3';
+        const newRiSc: RiSc = {
+          ...riSc,
+          schemaVersion: fallBackSchemaVersion,
+        };
+        postRiScs(
+          newRiSc,
+          res2 => {
+            if (!res2.riScId) throw new Error('No RiSc ID returned');
+
+            const RiScWithLatestSchemaVersion: RiScWithMetadata = {
+              id: res2.riScId,
+              status: RiScStatus.Draft,
+              content: riSc,
+              schemaVersion: riSc.schemaVersion,
+            };
+
+            setRiScs(
+              riScs
+                ? [...riScs, RiScWithLatestSchemaVersion]
+                : [RiScWithLatestSchemaVersion],
+            );
+            setSelectedRiSc(RiScWithLatestSchemaVersion);
+            setIsFetching(false);
+            navigate(getRiScPath({ riScId: res2.riScId }));
+          },
+          () => {
+            setSelectedRiSc(selectedRiSc);
+            setIsFetching(false);
+          },
+        );
+      },
+    );
+  };
+
+  const updateRiSc = (riSc: RiSc) => {
+    if (selectedRiSc && riScs) {
+      const isRequiresNewApproval = requiresNewApproval(
+        selectedRiSc.content,
+        riSc,
+      );
+      const updatedRiSc = {
+        ...selectedRiSc,
+        content: riSc,
+        status:
+          selectedRiSc.status !== RiScStatus.Draft && isRequiresNewApproval
+            ? RiScStatus.Draft
+            : selectedRiSc.status,
+        isRequiresNewApproval: isRequiresNewApproval,
+        schemaVersion: riSc.schemaVersion,
+      };
+
+      setUpdateRiScStatus({
+        isLoading: true,
+        isError: false,
+        isSuccess: false,
+      });
+      setIsRequesting(true);
+      putRiScs(
+        updatedRiSc,
+        () => {
+          setUpdateRiScStatus({
+            isLoading: false,
+            isError: false,
+            isSuccess: true,
+          });
+          setSelectedRiSc(updatedRiSc);
+          setRiScs(
+            riScs.map(r => (r.id === selectedRiSc.id ? updatedRiSc : r)),
+          );
+          setIsRequesting(false);
+        },
+        () => {
+          setUpdateRiScStatus({
+            isLoading: false,
+            isError: true,
+            isSuccess: false,
+          });
+          setIsRequesting(false);
+        },
+      );
+    }
+  };
+
+  const approveRiSc = () => {
+    if (selectedRiSc && riScs) {
+      const updatedRiSc = {
+        ...selectedRiSc,
+        status: RiScStatus.SentForApproval,
+      };
+
+      publishRiScs(selectedRiSc.id, () => {
+        setSelectedRiSc(updatedRiSc);
+        setRiScs(riScs.map(r => (r.id === selectedRiSc.id ? updatedRiSc : r)));
+      });
+    }
+  };
+
+  const value = {
+    selectedRiSc: selectedRiSc,
+    riScs: riScs,
+    selectRiSc: selectRiSc,
+    isFetching,
+    updateRiScStatus: updateRiScStatus,
+    resetRiScStatus: resetRiScStatus,
+    createNewRiSc: createNewRiSc,
+    updateRiSc: updateRiSc,
+    approveRiSc: approveRiSc,
+    response,
+    isRequesting: isRequesting,
+  };
+
+  return <RiScContext.Provider value={value}>{children}</RiScContext.Provider>;
+};
+
+const useRiScs = () => {
+  const context = React.useContext(RiScContext);
+  if (context === undefined) {
+    throw new Error('useRiScs must be used within a RiScProvider');
+  }
+  return context;
+};
+
+export { RiScProvider, useRiScs };

--- a/plugins/ros/src/contexts/ScenarioContext.tsx
+++ b/plugins/ros/src/contexts/ScenarioContext.tsx
@@ -1,12 +1,13 @@
 import React, { ReactNode, useState, useEffect } from 'react';
 import { useRouteRef } from '@backstage/core-plugin-api';
-import { Action, RiSc, RiScWithMetadata, Scenario } from './utils/types';
-import { consequenceOptions, probabilityOptions } from './utils/constants';
-import { riScRouteRef, scenarioRouteRef } from './routes';
-import { useNavigate } from 'react-router';
+import { Action, Scenario } from '../utils/types';
+import { consequenceOptions, probabilityOptions } from '../utils/constants';
+import { riScRouteRef, scenarioRouteRef } from '../routes';
+import { useNavigate, useParams } from 'react-router';
 import { useSearchParams } from 'react-router-dom';
-import { ScenarioWizardSteps } from './components/scenarioWizard/ScenarioWizard';
-import { generateRandomId } from './utils/utilityfunctions';
+import { ScenarioWizardSteps } from '../components/scenarioWizard/ScenarioWizard';
+import { generateRandomId } from '../utils/utilityfunctions';
+import { useRiScs } from './RiScContext';
 
 export const emptyAction = (): Action => ({
   ID: generateRandomId(),
@@ -84,17 +85,13 @@ const ScenarioContext = React.createContext<ScenarioDrawerProps | undefined>(
   undefined,
 );
 
-const ScenarioProvider = ({
-  riSc,
-  updateRiSc,
-  scenarioIdFromParams,
-  children,
-}: {
-  children: ReactNode;
-  riSc: RiScWithMetadata | null;
-  updateRiSc: (riSc: RiSc) => void;
-  scenarioIdFromParams?: string;
-}) => {
+const ScenarioProvider = ({ children }: { children: ReactNode }) => {
+  const params = useParams();
+  const scenarioIdFromParams = params.scenarioId;
+  const { selectedRiSc, updateRiSc } = useRiScs();
+
+  const riSc = selectedRiSc ?? null;
+
   // STATES
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 

--- a/plugins/ros/src/contexts/ScenarioContext.tsx
+++ b/plugins/ros/src/contexts/ScenarioContext.tsx
@@ -48,7 +48,11 @@ type ScenarioDrawerProps = {
   saveScenario: () => boolean;
   editScenario: (step: ScenarioWizardSteps) => void;
   isNewScenario: boolean;
-  submitEditedScenarioToRiSc: (editedScenario: Scenario) => void;
+  submitEditedScenarioToRiSc: (
+    editedScenario: Scenario,
+    onSuccess?: () => void,
+    onError?: () => void,
+  ) => void;
 
   openScenario: (id: string) => void;
   closeScenario: () => void;
@@ -195,14 +199,22 @@ const ScenarioProvider = ({ children }: { children: ReactNode }) => {
     return false;
   };
 
-  const submitEditedScenarioToRiSc = (editedScenario: Scenario) => {
+  const submitEditedScenarioToRiSc = (
+    editedScenario: Scenario,
+    onSuccess?: () => void,
+    onError?: () => void,
+  ) => {
     if (riSc) {
-      updateRiSc({
-        ...riSc.content,
-        scenarios: riSc.content.scenarios.map(s =>
-          s.ID === editedScenario.ID ? editedScenario : s,
-        ),
-      });
+      updateRiSc(
+        {
+          ...riSc.content,
+          scenarios: riSc.content.scenarios.map(s =>
+            s.ID === editedScenario.ID ? editedScenario : s,
+          ),
+        },
+        onSuccess,
+        onError,
+      );
     }
   };
 

--- a/plugins/ros/src/plugin.ts
+++ b/plugins/ros/src/plugin.ts
@@ -17,7 +17,7 @@ export const riScPlugin = createPlugin({
 export const RiScPage = riScPlugin.provide(
   createRoutableExtension({
     name: 'RiScPage',
-    component: () => import('./components/riScPlugin').then(m => m.RiScPlugin),
+    component: () => import('./PluginRoot').then(m => m.PluginRoot),
     mountPoint: rootRouteRef,
   }),
 );

--- a/plugins/ros/src/utils/hooks.ts
+++ b/plugins/ros/src/utils/hooks.ts
@@ -1,35 +1,26 @@
 import { useEntity } from '@backstage/plugin-catalog-react';
-import { useCallback, useEffect, useState } from 'react';
+import { useState } from 'react';
 import {
   configApiRef,
   fetchApiRef,
   googleAuthApiRef,
   identityApiRef,
   useApi,
-  useRouteRef,
 } from '@backstage/core-plugin-api';
 import {
-  ContentStatus,
   GithubRepoInfo,
   ProcessingStatus,
   RiSc,
-  RiScStatus,
   RiScWithMetadata,
   SubmitResponseObject,
 } from './types';
-import { requiresNewApproval } from './utilityfunctions';
-import { riScRouteRef } from '../routes';
-import { useLocation, useNavigate } from 'react-router';
 import {
-  dtoToRiSc,
   ProcessRiScResultDTO,
   profileInfoToDTOString,
   PublishRiScResultDTO,
   RiScContentResultDTO,
-  RiScDTO,
   riScToDTOString,
 } from './DTOs';
-import { useEffectOnce } from 'react-use';
 
 const useGithubRepositoryInformation = (): GithubRepoInfo => {
   const [, org, repo] =
@@ -60,7 +51,7 @@ const useResponse = (): [
   return [submitResponse, displaySubmitResponse];
 };
 
-const useFetch = () => {
+export const useFetch = () => {
   const repoInformation = useGithubRepositoryInformation();
   const googleApi = useApi(googleAuthApiRef);
   const identityApi = useApi(identityApiRef);
@@ -211,303 +202,5 @@ const useFetch = () => {
     response,
     setResponse,
     fetchLatestJSONSchema,
-  };
-};
-
-export const useFetchRiScs = (
-  riScIdFromParams?: string,
-): {
-  selectedRiSc: RiScWithMetadata | null;
-  riScs: RiScWithMetadata[] | null;
-  selectRiSc: (title: string) => void;
-  isFetching: boolean;
-  createNewRiSc: (riSc: RiSc) => void;
-  updateRiSc: (riSc: RiSc) => void;
-  updateRiScStatus: {
-    isLoading: boolean;
-    isError: boolean;
-    isSuccess: boolean;
-  };
-  resetRiScStatus: () => void;
-  approveRiSc: () => void;
-  response: SubmitResponseObject | null;
-  isRequesting: boolean;
-} => {
-  const location = useLocation();
-  const navigate = useNavigate();
-  const getRiScPath = useRouteRef(riScRouteRef);
-  const [isRequesting, setIsRequesting] = useState<boolean>(false);
-
-  const {
-    fetchRiScs,
-    postRiScs,
-    putRiScs,
-    publishRiScs,
-    response,
-    setResponse,
-    fetchLatestJSONSchema,
-  } = useFetch();
-
-  const [riScs, setRiScs] = useState<RiScWithMetadata[] | null>(null);
-  const [selectedRiSc, setSelectedRiSc] = useState<RiScWithMetadata | null>(
-    null,
-  );
-  const [isFetching, setIsFetching] = useState(true);
-  const [updateRiScStatus, setUpdateRiScStatus] = useState({
-    isLoading: false,
-    isError: false,
-    isSuccess: false,
-  });
-
-  useEffect(() => {
-    if (location.state) {
-      setResponse({
-        statusMessage: location.state,
-        status: ProcessingStatus.ErrorWhenFetchingRiScs,
-      });
-    }
-  }, [location, setResponse]);
-
-  // Initial fetch of RiScs
-  useEffectOnce(() => {
-    fetchRiScs(
-      res => {
-        const fetchedRiScs: RiScWithMetadata[] = res
-          .filter(risk => risk.status === ContentStatus.Success)
-          .map(riScDTO => {
-            // This action can throw a runtime error if content is not parsable by JSON library.
-            // If that happens, it is catched by the fetch onError catch.
-            const json = JSON.parse(riScDTO.riScContent) as RiScDTO;
-
-            const content = dtoToRiSc(json);
-            return {
-              id: riScDTO.riScId,
-              content: content,
-              status: riScDTO.riScStatus,
-              pullRequestUrl: riScDTO.pullRequestUrl,
-            };
-          });
-        setRiScs(fetchedRiScs);
-        setIsFetching(false);
-
-        const errorRiScs: string[] = res
-          .filter(risk => risk.status !== ContentStatus.Success)
-          .map(risk => risk.riScId);
-
-        if (errorRiScs.length > 0) {
-          const errorMessage = `Failed to fetch risc scorecards with ids: ${errorRiScs.join(
-            ', ',
-          )}`;
-          setResponse({
-            statusMessage: errorMessage,
-            status: ProcessingStatus.ErrorWhenFetchingRiScs,
-          });
-        }
-
-        // If there are no RiScs, don't set a selected RiSc
-        if (fetchedRiScs.length === 0) {
-          return;
-        }
-
-        // If there is no RiSc ID in the URL, navigate to the first RiSc
-        if (!riScIdFromParams) {
-          navigate(getRiScPath({ riScId: fetchedRiScs[0].id }));
-          return;
-        }
-
-        const riSc = fetchedRiScs.find(r => r.id === riScIdFromParams);
-
-        // If there is an invalid RiSc ID in the URL, navigate to the first RiSc with error state
-        if (!riSc) {
-          navigate(getRiScPath({ riScId: fetchedRiScs[0].id }), {
-            state: 'The risk scorecard you are trying to open does not exist',
-          });
-          return;
-        }
-      },
-      () => setIsFetching(false),
-    );
-  });
-
-  // Set selected RiSc based on URL
-  useEffect(() => {
-    if (riScIdFromParams) {
-      const riSc = riScs?.find(r => r.id === riScIdFromParams);
-      if (riSc) {
-        setSelectedRiSc(riSc);
-      }
-    }
-  }, [riScs, riScIdFromParams]);
-
-  const resetRiScStatus = useCallback(() => {
-    setUpdateRiScStatus({
-      isLoading: false,
-      isSuccess: false,
-      isError: false,
-    });
-  }, []);
-
-  const selectRiSc = (title: string) => {
-    const riScId = riScs?.find(riSc => riSc.content.title === title)?.id;
-    if (riScId) {
-      navigate(getRiScPath({ riScId: riScId }));
-    }
-  };
-
-  const createNewRiSc = (riSc: RiSc) => {
-    setIsFetching(true);
-    setSelectedRiSc(null);
-    fetchLatestJSONSchema(
-      res => {
-        const resString = JSON.stringify(res);
-        const schema = JSON.parse(resString);
-        const schemaVersion = schema.properties.schemaVersion.default.replace(
-          /'/g,
-          '',
-        );
-
-        const newRiSc: RiSc = {
-          ...riSc,
-          schemaVersion: schemaVersion ? schemaVersion : '3.3',
-        };
-
-        postRiScs(
-          newRiSc,
-          res2 => {
-            if (!res2.riScId) throw new Error('No RiSc ID returned');
-
-            const RiScWithLatestSchemaVersion: RiScWithMetadata = {
-              id: res2.riScId,
-              status: RiScStatus.Draft,
-              content: riSc,
-              schemaVersion: riSc.schemaVersion,
-            };
-
-            setRiScs(
-              riScs
-                ? [...riScs, RiScWithLatestSchemaVersion]
-                : [RiScWithLatestSchemaVersion],
-            );
-            setSelectedRiSc(RiScWithLatestSchemaVersion);
-            setIsFetching(false);
-            navigate(getRiScPath({ riScId: res2.riScId }));
-          },
-          () => {
-            setSelectedRiSc(selectedRiSc);
-            setIsFetching(false);
-          },
-        );
-      },
-      () => {
-        const fallBackSchemaVersion = '3.3';
-        const newRiSc: RiSc = {
-          ...riSc,
-          schemaVersion: fallBackSchemaVersion,
-        };
-        postRiScs(
-          newRiSc,
-          res2 => {
-            if (!res2.riScId) throw new Error('No RiSc ID returned');
-
-            const RiScWithLatestSchemaVersion: RiScWithMetadata = {
-              id: res2.riScId,
-              status: RiScStatus.Draft,
-              content: riSc,
-              schemaVersion: riSc.schemaVersion,
-            };
-
-            setRiScs(
-              riScs
-                ? [...riScs, RiScWithLatestSchemaVersion]
-                : [RiScWithLatestSchemaVersion],
-            );
-            setSelectedRiSc(RiScWithLatestSchemaVersion);
-            setIsFetching(false);
-            navigate(getRiScPath({ riScId: res2.riScId }));
-          },
-          () => {
-            setSelectedRiSc(selectedRiSc);
-            setIsFetching(false);
-          },
-        );
-      },
-    );
-  };
-
-  const updateRiSc = (riSc: RiSc) => {
-    if (selectedRiSc && riScs) {
-      const isRequiresNewApproval = requiresNewApproval(
-        selectedRiSc.content,
-        riSc,
-      );
-      const updatedRiSc = {
-        ...selectedRiSc,
-        content: riSc,
-        status:
-          selectedRiSc.status !== RiScStatus.Draft && isRequiresNewApproval
-            ? RiScStatus.Draft
-            : selectedRiSc.status,
-        isRequiresNewApproval: isRequiresNewApproval,
-        schemaVersion: riSc.schemaVersion,
-      };
-
-      setUpdateRiScStatus({
-        isLoading: true,
-        isError: false,
-        isSuccess: false,
-      });
-      setIsRequesting(true);
-      putRiScs(
-        updatedRiSc,
-        () => {
-          setUpdateRiScStatus({
-            isLoading: false,
-            isError: false,
-            isSuccess: true,
-          });
-          setSelectedRiSc(updatedRiSc);
-          setRiScs(
-            riScs.map(r => (r.id === selectedRiSc.id ? updatedRiSc : r)),
-          );
-          setIsRequesting(false);
-        },
-        () => {
-          setUpdateRiScStatus({
-            isLoading: false,
-            isError: true,
-            isSuccess: false,
-          });
-          setIsRequesting(false);
-        },
-      );
-    }
-  };
-
-  const approveRiSc = () => {
-    if (selectedRiSc && riScs) {
-      const updatedRiSc = {
-        ...selectedRiSc,
-        status: RiScStatus.SentForApproval,
-      };
-
-      publishRiScs(selectedRiSc.id, () => {
-        setSelectedRiSc(updatedRiSc);
-        setRiScs(riScs.map(r => (r.id === selectedRiSc.id ? updatedRiSc : r)));
-      });
-    }
-  };
-
-  return {
-    selectedRiSc: selectedRiSc,
-    riScs: riScs,
-    selectRiSc: selectRiSc,
-    isFetching,
-    updateRiScStatus: updateRiScStatus,
-    resetRiScStatus: resetRiScStatus,
-    createNewRiSc: createNewRiSc,
-    updateRiSc: updateRiSc,
-    approveRiSc: approveRiSc,
-    response,
-    isRequesting: isRequesting,
   };
 };

--- a/plugins/ros/src/utils/hooks.ts
+++ b/plugins/ros/src/utils/hooks.ts
@@ -131,7 +131,7 @@ export const useFetch = () => {
       });
     });
 
-  const publishRiSc = (
+  const publishRiScs = (
     riScId: string,
     onSuccess?: (response: PublishRiScResultDTO) => void,
     onError?: (error: PublishRiScResultDTO) => void,
@@ -152,7 +152,7 @@ export const useFetch = () => {
       ),
     );
 
-  const postRiSc = (
+  const postRiScs = (
     riSc: RiSc,
     onSuccess?: (response: ProcessRiScResultDTO) => void,
     onError?: (error: ProcessRiScResultDTO) => void,
@@ -173,7 +173,7 @@ export const useFetch = () => {
       ),
     );
 
-  const putRiSc = (
+  const putRiScs = (
     riSc: RiScWithMetadata,
     onSuccess?: (response: ProcessRiScResultDTO) => void,
     onError?: (error: ProcessRiScResultDTO) => void,
@@ -195,10 +195,10 @@ export const useFetch = () => {
   };
 
   return {
-    fetchRiScs: fetchRiScs,
-    postRiScs: postRiSc,
-    putRiScs: putRiSc,
-    publishRiScs: publishRiSc,
+    fetchRiScs,
+    postRiScs,
+    putRiScs,
+    publishRiScs,
     response,
     setResponse,
     fetchLatestJSONSchema,

--- a/plugins/ros/src/utils/translations.ts
+++ b/plugins/ros/src/utils/translations.ts
@@ -261,6 +261,13 @@ export const pluginRiScTranslationRef = createTranslationRef({
       'Denial of service': 'Denial of service',
       'Escalation of rights': 'Escalation of rights',
     },
+    actionStatus: {
+      'Not started': 'Not started',
+      'In progress': 'In progress',
+      'On hold': 'On hold',
+      Completed: 'Completed',
+      Aborted: 'Aborted',
+    },
   },
 });
 
@@ -492,6 +499,11 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
           'vulnerabilities.Information leak': 'Informasjonslekkasje',
           'vulnerabilities.Denial of service': 'Tjenestenekt',
           'vulnerabilities.Escalation of rights': 'Rettighetseskalering',
+          'actionStatus.Not started': 'Ikke startet',
+          'actionStatus.In progress': 'Startet',
+          'actionStatus.On hold': 'På vent',
+          'actionStatus.Completed': 'Fullført',
+          'actionStatus.Aborted': 'Avbrutt',
         },
       }),
   },

--- a/plugins/ros/src/utils/translations.ts
+++ b/plugins/ros/src/utils/translations.ts
@@ -24,6 +24,7 @@ export const pluginRiScTranslationRef = createTranslationRef({
       estimatedRisk: 'Estimated risk',
       initialRisk: 'Initial risk', // Starting or Initial risk
       measure: 'Action', // Measure, Action or Initiative
+      measures: 'Actions', // Measure, Action or Initiative
       measureOwner: 'Responsible', // Responsible? Measure owner? Initiative owner?
       next: 'Next',
       planned: 'Planned',
@@ -40,7 +41,7 @@ export const pluginRiScTranslationRef = createTranslationRef({
       threatActors: 'Threat actors',
       title: 'Title',
       url: 'URL',
-      emptyUrl: 'No URL specified',
+      emptyField: 'No {{field}} specified',
       vulnerabilities: 'Vulnerabilities',
     },
     rosStatus: {
@@ -61,7 +62,6 @@ export const pluginRiScTranslationRef = createTranslationRef({
       title: 'Risk scenarios',
       addScenarioButton: 'Add scenario',
       columns: {
-        measuresCount: 'Actions',
         consequenceChar: 'C',
         probabilityChar: 'P',
         completed: 'complete',
@@ -142,6 +142,7 @@ export const pluginRiScTranslationRef = createTranslationRef({
         requiredError: 'Field is required',
         descriptionError: 'Description cannot be empty',
         urlError: 'Invalid url',
+        emptyState: 'This scenario has no defined actions',
       },
       title: 'Risk scenario',
       titleError: 'Scenario title is required',
@@ -164,7 +165,6 @@ export const pluginRiScTranslationRef = createTranslationRef({
         measureOwnerDescription:
           'Decide who will be responsible for completion of this action',
         addMeasureButton: 'Add planned action',
-        title: 'Actions',
         plannedMeasures: 'Planned actions',
         existingMeasure: 'Existing measures',
         existingMeasureSubtitle:
@@ -304,13 +304,15 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
           'dictionary.threatActors': 'Trusselaktører',
           'dictionary.title': 'Tittel',
           'dictionary.url': 'URL',
-          'dictionary.emptyUrl': 'Ingen URL spesifisert',
+          'dictionary.emptyField': 'Ingen {{field}} spesifisert',
           'dictionary.vulnerabilities': 'Sårbarheter',
 
           'scenarioDrawer.action.descriptionError':
             'Beskrivelse kan ikke være tom',
           'scenarioDrawer.action.urlError': 'Ugyldig URL',
           'scenarioDrawer.action.requiredError': 'Feltet er påkrevd',
+          'scenarioDrawer.action.emptyState':
+            'Scenariet har ingen definerte tiltak',
 
           'rosStatus.statusBadge.missing':
             'Venter på godkjenning av risikoeier',
@@ -325,7 +327,6 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
 
           'scenarioTable.title': 'Risikoscenarioer',
           'scenarioTable.addScenarioButton': 'Legg til scenario',
-          'scenarioTable.columns.measuresCount': 'Tiltak',
           'scenarioTable.columns.consequenceChar': 'K',
           'scenarioTable.columns.probabilityChar': 'S',
           'scenarioTable.columns.completed': 'fullført',
@@ -398,7 +399,6 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
             'Hvor stor sannsynlighet er det for at dette scenarioet vil forekomme. Dersom du er mellom to sannsynlighetsverdier velg den høyeste.',
           'scenarioDrawer.measureTab.subtitle':
             'Hvilke tiltak bør gjøres for å unngå scenarioet?',
-          'scenarioDrawer.measureTab.title': 'Tiltak',
           'scenarioDrawer.measureTab.measureOwnerDescription':
             'De eller den som er ansvarlig for at tiltaket blir gjennomført',
           'scenarioDrawer.measureTab.addMeasureButton': 'Legg til tiltak',


### PR DESCRIPTION
- Fikser scrollbar og fargekontrast på risikoakseptansecheckboksen
- Flytter lagreknappen i ScenarioDrawer til bunnen
- Empty state (ingen blablabla spesifisert) text
- Passer på at vi bruker norsk oversettelse når man har satt språket til norsk
- Loading og response direkte i ScenarioDrawer basert på svar fra serveren
  - ⚠️ som følge av dette var det passende med refaktorering av useFetchRiScs til å heller være en global kontekst