### PR TITLE
fix/pr-url

### DIFF
--- a/plugins/ros/src/contexts/RiScContext.tsx
+++ b/plugins/ros/src/contexts/RiScContext.tsx
@@ -302,12 +302,13 @@ const RiScProvider = ({ children }: { children: ReactNode }) => {
 
   const approveRiSc = () => {
     if (selectedRiSc && riScs) {
-      const updatedRiSc = {
-        ...selectedRiSc,
-        status: RiScStatus.SentForApproval,
-      };
-
-      publishRiScs(selectedRiSc.id, () => {
+      publishRiScs(selectedRiSc.id, res => {
+        const prUrl = res.pendingApproval?.pullRequestUrl;
+        const updatedRiSc = {
+          ...selectedRiSc,
+          status: RiScStatus.SentForApproval,
+          pullRequestUrl: prUrl,
+        };
         setSelectedRiSc(updatedRiSc);
         setRiScs(riScs.map(r => (r.id === selectedRiSc.id ? updatedRiSc : r)));
       });


### PR DESCRIPTION
call to approveRiSc uses the response to correctly set the href prop in the status component.