### PR TITLE
fix/google-access-token-paramater

### DIFF
--- a/plugins/ros/src/utils/hooks.ts
+++ b/plugins/ros/src/utils/hooks.ts
@@ -75,10 +75,7 @@ export const useAuthenticatedFetch = () => {
   ) => {
     Promise.all([
       identityApi.getCredentials(),
-      googleApi.getAccessToken([
-        'https://www.googleapis.com/auth/cloud-platform',
-        'https://www.googleapis.com/auth/cloudkms',
-      ]),
+      googleApi.getAccessToken(['https://www.googleapis.com/auth/cloudkms']),
     ]).then(([idToken, googleAccessToken]) => {
       fetch(uri, {
         method: method,


### PR DESCRIPTION
removed redundant parameter in call to google api. 
this caused the Oauth consent screen to ask for permissions that was not intended. 