### PR TITLE
Feature/migration requires new approval

### DIFF
--- a/plugins/ros/src/components/riScInfo/riScStatus/RiScStatusComponent.tsx
+++ b/plugins/ros/src/components/riScInfo/riScStatus/RiScStatusComponent.tsx
@@ -197,10 +197,10 @@ export const RiScStatusComponent = ({
 
       <RosAcceptance
         status={selectedRiSc.status}
-        migration={selectedRiSc.migrationChanges}
+        migration={selectedRiSc.migrationStatus?.migrationChanges}
       />
       {selectedRiSc.status === RiScStatus.SentForApproval &&
-        !selectedRiSc.migrationChanges && (
+        !selectedRiSc.migrationStatus?.migrationChanges && (
           <Typography sx={{ fontWeight: 700 }} paragraph variant="subtitle1">
             <PullRequestSvg />
             {t('rosStatus.prStatus')}
@@ -210,7 +210,7 @@ export const RiScStatusComponent = ({
           </Typography>
         )}
       {selectedRiSc.status === RiScStatus.Draft &&
-        !selectedRiSc.migrationChanges && (
+        !selectedRiSc.migrationStatus?.migrationChanges && (
           <Button
             color="primary"
             variant="contained"
@@ -221,7 +221,7 @@ export const RiScStatusComponent = ({
             {t('rosStatus.approveButton')}
           </Button>
         )}
-      {selectedRiSc.migrationChanges && (
+      {selectedRiSc.migrationStatus?.migrationChanges && (
         <Button
           color="primary"
           variant="contained"

--- a/plugins/ros/src/contexts/RiScContext.tsx
+++ b/plugins/ros/src/contexts/RiScContext.tsx
@@ -199,7 +199,6 @@ const RiScProvider = ({ children }: { children: ReactNode }) => {
     );
   };
 
-  // TODO: ta inn risc with metadata, bruk den
   const updateRiSc = (
     riSc: RiSc,
     onSuccess?: () => void,

--- a/plugins/ros/src/contexts/RiScContext.tsx
+++ b/plugins/ros/src/contexts/RiScContext.tsx
@@ -95,7 +95,7 @@ const RiScProvider = ({ children }: { children: ReactNode }) => {
               content: content,
               status: riScDTO.riScStatus,
               pullRequestUrl: riScDTO.pullRequestUrl,
-              migrationChanges: riScDTO.migrationChanges ? true : false,
+              migrationStatus: riScDTO.migrationStatus,
             };
           });
         setRiScs(fetchedRiScs);
@@ -199,16 +199,16 @@ const RiScProvider = ({ children }: { children: ReactNode }) => {
     );
   };
 
+  // TODO: ta inn risc with metadata, bruk den
   const updateRiSc = (
     riSc: RiSc,
     onSuccess?: () => void,
     onError?: () => void,
   ) => {
     if (selectedRiSc && riScs) {
-      const isRequiresNewApproval = requiresNewApproval(
-        selectedRiSc.content,
-        riSc,
-      );
+      const isRequiresNewApproval =
+        selectedRiSc.migrationStatus?.migrationRequiresNewApproval ??
+        requiresNewApproval(selectedRiSc.content, riSc);
       const updatedRiSc = {
         ...selectedRiSc,
         content: riSc,
@@ -218,7 +218,10 @@ const RiScProvider = ({ children }: { children: ReactNode }) => {
             : selectedRiSc.status,
         isRequiresNewApproval: isRequiresNewApproval,
         schemaVersion: riSc.schemaVersion,
-        migrationChanges: false,
+        migrationStatus: {
+          migrationChanges: false,
+          migrationRequiresNewApproval: isRequiresNewApproval,
+        },
       };
 
       setRiScUpdateStatus({

--- a/plugins/ros/src/utils/DTOs.ts
+++ b/plugins/ros/src/utils/DTOs.ts
@@ -1,6 +1,7 @@
 import {
   Action,
   ContentStatus,
+  MigrationStatus,
   Modify,
   ProcessingStatus,
   RiSc,
@@ -34,7 +35,7 @@ export type PublishRiScResultDTO = {
 export type RiScContentResultDTO = {
   riScStatus: RiScStatus;
   riScContent: string;
-  migrationChanges?: boolean;
+  migrationStatus: MigrationStatus;
 } & ContentRiScResultDTO;
 
 export type RiScDTO = {

--- a/plugins/ros/src/utils/types.ts
+++ b/plugins/ros/src/utils/types.ts
@@ -17,8 +17,8 @@ export type RiScWithMetadata = {
 };
 
 export type MigrationStatus = {
-  migrationChanges?: boolean;
-  migrationRequiresNewApproval?: boolean;
+  migrationChanges: boolean;
+  migrationRequiresNewApproval: boolean;
 };
 
 export type RiSc = {

--- a/plugins/ros/src/utils/types.ts
+++ b/plugins/ros/src/utils/types.ts
@@ -13,7 +13,12 @@ export type RiScWithMetadata = {
   isRequiresNewApproval?: boolean;
   pullRequestUrl?: string;
   schemaVersion?: string;
+  migrationStatus?: MigrationStatus;
+};
+
+export type MigrationStatus = {
   migrationChanges?: boolean;
+  migrationRequiresNewApproval?: boolean;
 };
 
 export type RiSc = {


### PR DESCRIPTION
Use expanded migrationStatus in order to determine if migration changes from backend should trigger a need for a new approval.