### PR TITLE
feature: expand migration information

### DIFF
--- a/plugins/ros/src/components/riScInfo/riScStatus/RiScStatusComponent.tsx
+++ b/plugins/ros/src/components/riScInfo/riScStatus/RiScStatusComponent.tsx
@@ -1,5 +1,9 @@
 import React, { ReactComponentElement, useState } from 'react';
-import { RiScStatus, RiScWithMetadata } from '../../../utils/types';
+import {
+  MigrationVersions,
+  RiScStatus,
+  RiScWithMetadata,
+} from '../../../utils/types';
 import Alert from '@mui/material/Alert';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -18,6 +22,8 @@ import { InfoCard } from '@backstage/core-components';
 import { PullRequestSvg } from '../../common/Icons';
 import { useRiScs } from '../../../contexts/RiScContext';
 import { subtitle1 } from '../../common/typography';
+import { Box } from '@material-ui/core';
+import { WarningAmberOutlined } from '@mui/icons-material';
 
 interface RiScPublishDialogProps {
   openDialog: boolean;
@@ -76,12 +82,14 @@ interface RiScMigrationDialogProps {
   openDialog: boolean;
   handleCancel: () => void;
   handleUpdate: () => void;
+  migrationVersions?: MigrationVersions;
 }
 
 const RiScMigrationDialog = ({
   openDialog,
   handleCancel,
   handleUpdate,
+  migrationVersions,
 }: RiScMigrationDialogProps): ReactComponentElement<any> => {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
 
@@ -95,6 +103,22 @@ const RiScMigrationDialog = ({
     <Dialog open={openDialog}>
       <DialogTitle>{t('migrationDialog.title')}</DialogTitle>
       <DialogContent>
+        <Box sx={{ marginBottom: '16px' }}>
+          <Typography>
+            {t('migrationDialog.description')}
+            {migrationVersions?.toVersion} {t('migrationDialog.description2')}{' '}
+            {migrationVersions?.fromVersion}
+            {t('migrationDialog.description3')}
+            <Link
+              underline="always"
+              target="_blank"
+              href="https://github.com/kartverket/backstage-plugin-risk-scorecard-backend/blob/main/docs/schemaChangelog.md"
+            >
+              {t('migrationDialog.changelog')}
+            </Link>{' '}
+            {t('migrationDialog.description4')}
+          </Typography>
+        </Box>
         <Alert severity="info" icon={false}>
           <FormControlLabel
             control={
@@ -133,9 +157,18 @@ const RosAcceptance = ({
   const { t } = useTranslationRef(pluginRiScTranslationRef);
   if (migration) {
     return (
-      <Typography paragraph sx={subtitle1}>
-        {t('rosStatus.statusBadge.migration')}
-      </Typography>
+      <>
+        <Typography paragraph sx={subtitle1}>
+          <WarningAmberOutlined
+            fontSize="medium"
+            sx={{ transform: 'translateY(5px)', marginTop: '5px' }}
+          />{' '}
+          {t('rosStatus.statusBadge.migration.title')}
+        </Typography>
+        <Typography>
+          {t('rosStatus.statusBadge.migration.description')}
+        </Typography>
+      </>
     );
   }
   switch (status) {
@@ -222,24 +255,29 @@ export const RiScStatusComponent = ({
           </Button>
         )}
       {selectedRiSc.migrationStatus?.migrationChanges && (
-        <Button
-          color="primary"
-          variant="contained"
-          onClick={() => setMigrationDialogIsOpen(!migrationDialogIsOpen)}
-          sx={{ display: 'block', marginLeft: 'auto' }}
-        >
-          <Typography variant="button">{t('rosStatus.saveButton')}</Typography>
-        </Button>
+        <>
+          <Button
+            color="primary"
+            variant="contained"
+            onClick={() => setMigrationDialogIsOpen(!migrationDialogIsOpen)}
+            sx={{ display: 'block', marginLeft: 'auto' }}
+          >
+            <Typography variant="button">
+              {t('rosStatus.moreInformationButton')}
+            </Typography>
+          </Button>
+          <RiScMigrationDialog
+            openDialog={migrationDialogIsOpen}
+            handleUpdate={handleUpdate}
+            handleCancel={() => setMigrationDialogIsOpen(false)}
+            migrationVersions={selectedRiSc.migrationStatus?.migrationVersions}
+          />
+        </>
       )}
       <RiScPublishDialog
         openDialog={publishRiScDialogIsOpen}
         handlePublish={handleApproveAndPublish}
         handleCancel={() => setPublishRiScDialogIsOpen(false)}
-      />
-      <RiScMigrationDialog
-        openDialog={migrationDialogIsOpen}
-        handleUpdate={handleUpdate}
-        handleCancel={() => setMigrationDialogIsOpen(false)}
       />
     </InfoCard>
   );

--- a/plugins/ros/src/utils/translations.ts
+++ b/plugins/ros/src/utils/translations.ts
@@ -49,12 +49,15 @@ export const pluginRiScTranslationRef = createTranslationRef({
         missing: 'Awaiting acceptance from risk owner', // Mangler godkjenning av risikoeier
         approved: 'Accepted by risk owner', // Godkjent av risikoeier
         error: 'Failed to retrieve status', // Kunne ikke hente status
-        migration:
-          'There has been done changes to the risk scorecard, as a result of a migration to the newest version. The changes can be both deletion and modification of information. If you want to keep the changes and update to the newest version, click "Save changes". Note that if you make other changes and save, this will also save the changes from the migration.', // Automatisk migrering av ROS
+        migration: {
+          title: 'You are required to review and save changes',
+          description:
+            'There has been done changes to the risk scorecard, as a result of a migration to the newest version. The changes may include deletion and modification of information. It will not be possible to save edits of the scorecard without including and accepting the changes.', // Automatisk migrering av ROS
+        },
       },
       prStatus: ' Pending pull request in ', // Avventer godkjenning av PR i Github
       approveButton: 'Accept risks', // Godkjenn ROS
-      saveButton: 'Save changes', // Lagre ROS migrering
+      moreInformationButton: 'More information', // Lagre ROS migrering
     },
     publishDialog: {
       title: 'Accept risks', // Godkjenn ROS
@@ -62,6 +65,12 @@ export const pluginRiScTranslationRef = createTranslationRef({
         'I confirm that I am the risk owner and accept the risks detailed in this risk scorecard.',
     },
     migrationDialog: {
+      description:
+        'The changes have been done to adhere to the latest schema version. In this case, the RiSc was update to ',
+      description2: 'from',
+      description3: '. Review the ',
+      description4: 'for more information.',
+      changelog: 'schema changelog',
       title: 'Save changes', // Lagre ROS migrering
       checkboxLabel:
         'I confirm that I have reviewed and wish to save the changes made during the migration.',
@@ -329,17 +338,26 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
             'Venter på godkjenning av risikoeier',
           'rosStatus.statusBadge.approved': 'Godkjent av risikoeier',
           'rosStatus.statusBadge.error': 'Kunne ikke hente status',
-          'rosStatus.statusBadge.migration':
-            'Det har blitt gjort endringer i risiko- og sårbarhetsanalysen, som følge av en migrering til nyeste versjon. Endringene kan være både sletting og endring av informsasjon. Hvis du vil beholde endringene og oppdatere til nyeste versjon, klikk "Lagre endringer". Merk at dersom du gjør andre endringer og lagrer, vil dette føre til at endringene gjort i forbindelse med migreringen blir lagret.',
+          'rosStatus.statusBadge.migration.title':
+            'Gjennomgang og lagring av endringer kreves',
+          'rosStatus.statusBadge.migration.description':
+            'Det har blitt gjort endringer i risiko- og sårbarhetsanalysen, som følge av en migrering til nyeste versjon. Endringene kan være både sletting og endring av informsasjon. Det vil ikke være mulig å lagre endringer av analysen uten å inkludere og godta endringene.',
           'rosStatus.prStatus': ' Avventer godkjenning av pull request i ',
           'rosStatus.approveButton': 'Godkjenn ROS',
-          'rosStatus.saveButton': 'Lagre endringer',
+          'rosStatus.moreInformationButton': 'Mer informasjon',
 
           'publishDialog.title': 'Godkjenn ROS-analyse',
           'publishDialog.checkboxLabel':
             'Jeg bekrefter at jeg er risikoeier og godtar risikoen beskrevet i denne risiko- og sårbarhetsanalysen.',
 
           'migrationDialog.title': 'Lagre endringer',
+          'migrationDialog.description':
+            'Endringene er gjort for å følge den nyeste skjema versjonen. I dette tilfellet ble ROS-analysen oppdatert til ',
+          'migrationDialog.description2': 'fra',
+          'migrationDialog.description3': '. Se ',
+          'migrationDialog.description4': 'for mer informasjon.',
+          'migrationDialog.changelog': 'endringslogg for skjema',
+
           'migrationDialog.checkboxLabel':
             'Jeg bekrefter at jeg har gjennomgått og ønsker å lagre endringene som er gjort under migreringen.',
 

--- a/plugins/ros/src/utils/types.ts
+++ b/plugins/ros/src/utils/types.ts
@@ -19,6 +19,12 @@ export type RiScWithMetadata = {
 export type MigrationStatus = {
   migrationChanges: boolean;
   migrationRequiresNewApproval: boolean;
+  migrationVersions?: MigrationVersions;
+};
+
+export type MigrationVersions = {
+  fromVersion: string;
+  toVersion: string;
 };
 
 export type RiSc = {


### PR DESCRIPTION
Include from- and to migration versions and schema changelog in the migration dialog. 
Change some wording and styling. 

Merge after https://github.com/kartverket/backstage-plugin-risk-scorecard-backend/pull/206