### PR TITLE
fix: action description overflow

### DIFF
--- a/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
@@ -48,7 +48,14 @@ export const ActionBox = ({ action, index }: ActionBoxProps) => {
         <Typography sx={{ ...label, marginTop: 1 }}>
           {t('dictionary.description')}
         </Typography>
-        <Typography sx={body2}>{action.description}</Typography>
+        <Typography
+          sx={{
+            ...body2,
+            wordBreak: 'break-all',
+          }}
+        >
+          {action.description}
+        </Typography>
 
         <Box
           sx={{
@@ -62,7 +69,10 @@ export const ActionBox = ({ action, index }: ActionBoxProps) => {
             <Typography sx={label}>{t('dictionary.url')}</Typography>
             {action.url ? (
               <Link
-                sx={body2}
+                sx={{
+                  ...body2,
+                  wordBreak: 'break-all',
+                }}
                 target="_blank"
                 rel="noreferrer"
                 href={


### PR DESCRIPTION
Url's or other extremly long "words" are now broken to prevent overflow. 

Now:
<img width="857" alt="image" src="https://github.com/user-attachments/assets/223bafc6-1e3a-4349-ade1-a2116c3225c0">
