### PR TITLE
[Sikkerhet] Oppdaterer med catalog-info.yaml til versjon 3.0

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 3.0
 organization: IT
 product: Kartverket.dev
 repo_types: [InternalClient]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,38 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "backstage-plugin-risk-scorecard-frontend"
+  tags:
+  - "internal"
+spec:
+  type: "website"
+  lifecycle: "production"
+  owner: "skvis"
+  system: "utviklerportal"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_backstage-plugin-risk-scorecard-frontend"
+  title: "Security Champion backstage-plugin-risk-scorecard-frontend"
+spec:
+  type: "security_champion"
+  parent: "eiendom_security_champions"
+  members:
+  - "jorn-ola-birkeland"
+  children:
+  - "resource:backstage-plugin-risk-scorecard-frontend"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "backstage-plugin-risk-scorecard-frontend"
+  links:
+  - url: "https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend"
+    title: "backstage-plugin-risk-scorecard-frontend på GitHub"
+spec:
+  type: "repo"
+  owner: "security_champion_backstage-plugin-risk-scorecard-frontend"
+  dependencyOf:
+  - "component:backstage-plugin-risk-scorecard-frontend"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage, samtidig som `beskrivelse.yaml` nå går til `version: 3.0`.
Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.