### PR TITLE
rafactor/error-info-messages

### DIFF
--- a/plugins/ros/src/components/riScPlugin/RiScPlugin.tsx
+++ b/plugins/ros/src/components/riScPlugin/RiScPlugin.tsx
@@ -40,6 +40,7 @@ export const RiScPlugin = () => {
     riScs,
     selectRiSc,
     isFetching,
+    resetResponse,
     resetRiScStatus,
     response,
     riScUpdateStatus,
@@ -51,14 +52,17 @@ export const RiScPlugin = () => {
   ) as ScenarioWizardSteps | null;
 
   useEffect(() => {
-    if (scenarioWizardStep !== null) resetRiScStatus();
-  }, [resetRiScStatus, scenarioWizardStep]);
+    if (scenarioWizardStep !== null) {
+      resetRiScStatus();
+      resetResponse();
+    }
+  }, [resetRiScStatus, resetResponse, scenarioWizardStep]);
 
   return (
     <>
-      {response && (
+      {response && !riScUpdateStatus.isLoading && (
         <Alert
-          severity={getAlertSeverity(response.status)}
+          severity={getAlertSeverity(riScUpdateStatus)}
           sx={{ marginBottom: 2 }}
         >
           <Typography>{response.statusMessage}</Typography>

--- a/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
@@ -162,7 +162,7 @@ export const ScenarioDrawer = () => {
 
       {response &&
         response.status !== ProcessingStatus.ErrorWhenFetchingRiScs && (
-          <Alert severity={getAlertSeverity(response.status)}>
+          <Alert severity={getAlertSeverity(riScUpdateStatus)}>
             <Typography>{response.statusMessage}</Typography>
           </Alert>
         )}

--- a/plugins/ros/src/components/scenarioWizard/ScenarioWizard.tsx
+++ b/plugins/ros/src/components/scenarioWizard/ScenarioWizard.tsx
@@ -27,6 +27,7 @@ import { heading1, label } from '../common/typography';
 import { useForm } from 'react-hook-form';
 import { FormScenario, Scenario } from '../../utils/types';
 import { useSearchParams } from 'react-router-dom';
+import { getAlertSeverity } from '../../utils/utilityfunctions';
 
 export const ScenarioWizard = ({ step }: { step: ScenarioWizardSteps }) => {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
@@ -154,9 +155,8 @@ export const ScenarioWizard = ({ step }: { step: ScenarioWizardSteps }) => {
         <>
           {stepComponents[step]}
 
-          {response && riScUpdateStatus.isError && (
-            <Alert severity="error">
-              <Typography>{t('dictionary.saveError')}</Typography>
+          {response && (
+            <Alert severity={getAlertSeverity(riScUpdateStatus)}>
               <Typography>{response.statusMessage}</Typography>
             </Alert>
           )}

--- a/plugins/ros/src/contexts/ScenarioContext.tsx
+++ b/plugins/ros/src/contexts/ScenarioContext.tsx
@@ -6,6 +6,8 @@ import { useNavigate, useParams } from 'react-router';
 import { useSearchParams } from 'react-router-dom';
 import { generateRandomId } from '../utils/utilityfunctions';
 import { useRiScs } from './RiScContext';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { pluginRiScTranslationRef } from '../utils/translations';
 
 export const emptyAction = (): Action => ({
   ID: generateRandomId(),
@@ -83,6 +85,8 @@ const ScenarioProvider = ({ children }: { children: ReactNode }) => {
 
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
+  const { t } = useTranslationRef(pluginRiScTranslationRef);
+
   const emptyFormScenario = (initialScenario: Scenario): FormScenario => ({
     ...initialScenario,
     risk: {
@@ -125,7 +129,7 @@ const ScenarioProvider = ({ children }: { children: ReactNode }) => {
       // If there is an invalid scenario ID in the URL, navigate to the RiSc with error state
       if (!selectedScenario) {
         navigate(getRiScPath({ riScId: riSc.id }), {
-          state: 'Risikoscenarioet du prøver å åpne eksisterer ikke',
+          state: t('errorMessages.ScenarioDoesNotExist'),
         });
         return;
       }
@@ -133,7 +137,7 @@ const ScenarioProvider = ({ children }: { children: ReactNode }) => {
       setScenario(selectedScenario);
       setIsDrawerOpen(true);
     }
-  }, [riSc, scenarioIdFromParams, getRiScPath, navigate, searchParams]);
+  }, [riSc, scenarioIdFromParams, getRiScPath, navigate, searchParams, t]);
 
   // SCENARIO DRAWER FUNCTIONS
   const openScenarioDrawer = (id: string) => {

--- a/plugins/ros/src/utils/hooks.ts
+++ b/plugins/ros/src/utils/hooks.ts
@@ -1,5 +1,5 @@
 import { useEntity } from '@backstage/plugin-catalog-react';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import {
   configApiRef,
   fetchApiRef,
@@ -22,6 +22,8 @@ import {
   riScToDTOString,
 } from './DTOs';
 import { latestSupportedVersion } from './constants';
+import { pluginRiScTranslationRef } from './translations';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 
 const useGithubRepositoryInformation = (): GithubRepoInfo => {
   const [, org, repo] =
@@ -35,23 +37,6 @@ const useGithubRepositoryInformation = (): GithubRepoInfo => {
   };
 };
 
-const useResponse = (): [
-  SubmitResponseObject | null,
-  (submitStatus: SubmitResponseObject) => void,
-] => {
-  const [submitResponse, setSubmitResponse] =
-    useState<SubmitResponseObject | null>(null);
-
-  const displaySubmitResponse = (submitStatus: SubmitResponseObject) => {
-    setSubmitResponse(submitStatus);
-    setTimeout(() => {
-      setSubmitResponse(null);
-    }, 10000);
-  };
-
-  return [submitResponse, displaySubmitResponse];
-};
-
 export const useAuthenticatedFetch = () => {
   const repoInformation = useGithubRepositoryInformation();
   const googleApi = useApi(googleAuthApiRef);
@@ -62,13 +47,36 @@ export const useAuthenticatedFetch = () => {
   const uriToFetchAllRiScs = `${riScUri}/${latestSupportedVersion}/all`;
   const uriToFetchRiSc = (id: string) => `${riScUri}/${id}`;
   const uriToPublishRiSc = (id: string) => `${riScUri}/publish/${id}`;
+
+  const { t } = useTranslationRef(pluginRiScTranslationRef);
+
+  const useResponse = (): [
+    SubmitResponseObject | null,
+    (submitStatus: SubmitResponseObject | null) => void,
+  ] => {
+    const [submitResponse, setSubmitResponse] =
+      useState<SubmitResponseObject | null>(null);
+
+    const displaySubmitResponse = useCallback(
+      (submitStatus: SubmitResponseObject | null) => {
+        setSubmitResponse(submitStatus);
+        setTimeout(() => {
+          setSubmitResponse(null);
+        }, 10000);
+      },
+      [],
+    );
+
+    return [submitResponse, displaySubmitResponse];
+  };
+
   const [response, setResponse] = useResponse();
 
-  const authenticatedFetch = <T>(
+  const authenticatedFetch = <T, K>(
     uri: string,
     method: 'GET' | 'POST' | 'PUT',
     onSuccess: (response: T) => void,
-    onError: (error: T) => void,
+    onError: (error: K) => void,
     body?: string,
   ) => {
     Promise.all([
@@ -83,16 +91,19 @@ export const useAuthenticatedFetch = () => {
           'Content-Type': 'application/json',
         },
         body: body,
-      })
-        .then(res => {
-          if (!res.ok) {
-            throw new Error(`HTTP error! Status: ${res.status}`);
-          }
-          return res.json();
-        })
-        .then(json => json as T)
-        .then(res => onSuccess(res))
-        .catch(error => onError(error));
+      }).then(res => {
+        if (!res.ok) {
+          return res
+            .json()
+            .then(json => json as K)
+            .then(typedJson => onError(typedJson))
+            .catch(error => onError(error));
+        }
+        return res
+          .json()
+          .then(json => json as T)
+          .then(typedJson => onSuccess(typedJson));
+      });
     });
   };
 
@@ -100,14 +111,14 @@ export const useAuthenticatedFetch = () => {
     onSuccess: (response: RiScContentResultDTO[]) => void,
     onError?: () => void,
   ) =>
-    authenticatedFetch<RiScContentResultDTO[]>(
+    authenticatedFetch<RiScContentResultDTO[], RiScContentResultDTO[]>(
       uriToFetchAllRiScs,
       'GET',
       onSuccess,
       () => {
         if (onError) onError();
         setResponse({
-          statusMessage: 'Failed to fetch risc scorecards',
+          statusMessage: t('errorMessages.FailedToFetchRiScs'),
           status: ProcessingStatus.ErrorWhenFetchingRiScs,
         });
       },
@@ -116,10 +127,10 @@ export const useAuthenticatedFetch = () => {
   const publishRiScs = (
     riScId: string,
     onSuccess?: (response: PublishRiScResultDTO) => void,
-    onError?: (error: PublishRiScResultDTO) => void,
+    onError?: (error: ProcessRiScResultDTO) => void,
   ) =>
     identityApi.getProfileInfo().then(profile =>
-      authenticatedFetch<PublishRiScResultDTO>(
+      authenticatedFetch<PublishRiScResultDTO, ProcessRiScResultDTO>(
         uriToPublishRiSc(riScId),
         'POST',
         res => {
@@ -140,7 +151,7 @@ export const useAuthenticatedFetch = () => {
     onError?: (error: ProcessRiScResultDTO) => void,
   ) =>
     identityApi.getProfileInfo().then(profile =>
-      authenticatedFetch<ProcessRiScResultDTO>(
+      authenticatedFetch<ProcessRiScResultDTO, ProcessRiScResultDTO>(
         riScUri,
         'POST',
         res => {
@@ -161,7 +172,7 @@ export const useAuthenticatedFetch = () => {
     onError?: (error: ProcessRiScResultDTO) => void,
   ) => {
     identityApi.getProfileInfo().then(profile =>
-      authenticatedFetch<ProcessRiScResultDTO>(
+      authenticatedFetch<ProcessRiScResultDTO, ProcessRiScResultDTO>(
         uriToFetchRiSc(riSc.id),
         'PUT',
         res => {
@@ -169,6 +180,7 @@ export const useAuthenticatedFetch = () => {
           if (onSuccess) onSuccess(res);
         },
         error => {
+          setResponse(error);
           if (onError) onError(error);
         },
         riScToDTOString(riSc.content, riSc.isRequiresNewApproval!!, profile),

--- a/plugins/ros/src/utils/translations.ts
+++ b/plugins/ros/src/utils/translations.ts
@@ -34,7 +34,6 @@ export const pluginRiScTranslationRef = createTranslationRef({
       risk: 'Risk',
       save: 'Save',
       saveAndClose: 'Save and close',
-      saveError: 'Could not save scenario. Please try again.',
       scenario: 'Scenario',
       scope: 'Scope',
       status: 'Status',
@@ -286,6 +285,25 @@ export const pluginRiScTranslationRef = createTranslationRef({
       Completed: 'Completed',
       Aborted: 'Aborted',
     },
+    errorMessages: {
+      DefaultErrorMessage: 'An error occured',
+      ErrorWhenUpdatingRiSc: 'Failed to update risk scorecard',
+      ErrorWhenCreatingPullRequest: 'Failed to save approval of risk scorecard',
+      ErrorWhenCreatingRiSc: 'Failed to create risk scorecard',
+      ErrorWhenFetchingRiScs: 'Failed to fetch risk scorecards with ids: ',
+      FailedToFetchRiScs: 'Failed to fetch risk scorecards',
+      RiScDoesNotExist:
+        'The risk scorecard you are trying to open does not exist',
+      ScenarioDoesNotExist:
+        'The scenario you are trying to open does not exist',
+    },
+    infoMessages: {
+      CreatedPullRequest: 'Successfully saved approval of risk scorecard ',
+      UpdatedRiSc: 'Risk scorecard updated',
+      UpdatedRiScRequiresNewApproval:
+        'Risk scorecard update and requires new approval',
+      CreatedRiSc: 'Created new risk scorecard successfully',
+    },
   },
 });
 
@@ -321,8 +339,6 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
           'dictionary.risk': 'Risiko',
           'dictionary.save': 'Lagre',
           'dictionary.saveAndClose': 'Lagre og lukk',
-          'dictionary.saveError':
-            'Noe gikk galt ved lagring. Venligst prøv igjen.',
           'dictionary.scenario': 'Scenario',
           'dictionary.scope': 'Omfang',
           'dictionary.status': 'Status',
@@ -542,6 +558,31 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
           'actionStatus.On hold': 'På vent',
           'actionStatus.Completed': 'Fullført',
           'actionStatus.Aborted': 'Avbrutt',
+
+          'errorMessages.DefaultErrorMessage': 'Det oppstod en feil',
+          'errorMessages.ErrorWhenUpdatingRiSc':
+            'Kunne ikke lagre risiko- og sårbarhetsanalyse',
+          'errorMessages.ErrorWhenCreatingRiSc':
+            'Kunne ikke opprette risiko- og sårbarhetsanalyse',
+          'errorMessages.RiScDoesNotExist':
+            'Risiko- og sårbarhetsanalysen du prøver å åpne eksisterer ikke',
+          'errorMessages.ScenarioDoesNotExist':
+            'Scenariet du prøver å åpne eksisterer ikke',
+          'errorMessages.ErrorWhenCreatingPullRequest':
+            'Kunne ikke lagre godkjenning av risiko- og sårbarhetsanalysen',
+          'errorMessages.ErrorWhenFetchingRiScs':
+            'Kunne ikke hente risiko- og sårbarhetsanalyser med id-er: ',
+          'errorMessages.FailedToFetchRiScs':
+            'Kunne ikke hente risiko- og sårbarhetsanalyser',
+
+          'infoMessages.CreatedPullRequest':
+            'Godkjenning av risiko- og sårbarhetsanalysen ble lagret',
+          'infoMessages.UpdatedRiSc':
+            'Risiko- og sårbarhetsanalysen ble oppdatert',
+          'infoMessages.UpdatedRiScRequiresNewApproval':
+            'Risiko- og sårbarhetsanalysen ble oppdatert og trenger ny godkjenning',
+          'infoMessages.CreatedRiSc':
+            'Risiko- og sårbarhetsanalyse ble opprettet',
         },
       }),
   },

--- a/plugins/ros/src/utils/types.ts
+++ b/plugins/ros/src/utils/types.ts
@@ -89,6 +89,7 @@ export enum ProcessingStatus {
   EncryptionFailed = 'EncryptionFailed',
   CouldNotCreateBranch = 'CouldNotCreateBranch',
   UpdatedRiSc = 'UpdatedRiSc',
+  UpdatedRiScRequiresNewApproval = 'UpdatedRiScRequiresNewApproval',
   CreatedRiSc = 'CreatedRiSc',
   CreatedPullRequest = 'CreatedPullRequest',
   ErrorWhenCreatingRiSc = 'ErrorWhenCreatingRiSc',

--- a/plugins/ros/src/utils/utilityfunctions.ts
+++ b/plugins/ros/src/utils/utilityfunctions.ts
@@ -1,10 +1,11 @@
-import { ProcessingStatus, RiSc, Risk, Scenario } from './types';
+import { RiSc, Risk, Scenario } from './types';
 import {
   consequenceOptions,
   latestSupportedVersion,
   probabilityOptions,
   riskMatrix,
 } from './constants';
+import { RiScUpdateStatus } from '../contexts/RiScContext';
 
 export function generateRandomId(): string {
   return [...Array(5)]
@@ -24,16 +25,14 @@ export function formatNOK(amount: number): string {
 }
 
 export function getAlertSeverity(
-  status: ProcessingStatus,
-): 'error' | 'warning' | 'info' {
-  switch (status) {
-    case ProcessingStatus.UpdatedRiSc:
-    case ProcessingStatus.CreatedRiSc:
-    case ProcessingStatus.CreatedPullRequest:
-      return 'info';
-    default:
-      return 'warning';
+  updateStatus: RiScUpdateStatus,
+): 'error' | 'info' | 'warning' {
+  if (updateStatus.isSuccess) {
+    return 'info';
+  } else if (updateStatus.isError) {
+    return 'error';
   }
+  return 'warning';
 }
 
 export function getRiskMatrixColor(risiko: Risk) {
@@ -159,4 +158,15 @@ export function formatNumber(
     return getTranslationWithCorrectUnit(cost, 1e12, 'billion');
   }
   return getTranslationWithCorrectUnit(cost, 1e15, 'trillion');
+}
+
+export function getTranslationKey(
+  type: string,
+  key: string,
+  t: (s: any) => string,
+): string {
+  if (type === 'error') {
+    return t([`errorMessages.${key}`, 'errorMessages.DefaultErrorMessage']);
+  }
+  return t(`infoMessages.${key}`);
 }


### PR DESCRIPTION
This is a rather big one with many changes. I therefore included descriptions and some examples to address the changes.

- Expanded the useEffect in the RiScPlugin to also call on resetResponse. This is done so that the response, which controls if and what error message should be shown, is reset to null when navigating to the Wizard, to prevent the alert to linger. 

- Refactor the getAlertSeverity() so that is easier to maintain the code. Swapped out ProcessingStatus with RiScUpdateStatus to set the severity level to make it more generic. Previously 'warning' was used for alerts that should've been errors. 

- Added translations for getting the strings that is shown in the alerts. Sometimes the alerts showed messages that would not make sense for a user, but rather a developer. 

- Added a utility function for returning the correct the translation key with string interpolation. 

- The authenticated fetch uses a onError() callback function. Earlier it was not possible to use the response from the backend, e.g. status and statusMessage. Now this is made availble by setting the with the return value from backend. This will then look like this in a hook: 

`       error => {
          setResponse(error);
          if (onError) onError(error);`
          
Which then make this possible to update the response to get the correct error handling in e.g. in RiScContext:

` error => {
          setRiScUpdateStatus({
            isLoading: false,
            isError: true,
            isSuccess: false,
          });
          setResponse({
            ...error,
            statusMessage: getTranslationKey('error', error.status, t),
          }); `
          
- Fixed a infinite loop bug that was caused by using setResponse in a useEffect. This was fixed by using the useCallback hook in the useResponse hook, so that the reference for the function does not change, causing the useEffect to be triggered infinitely. 