### PR TITLE
Display correct order for very low and low probability columns

### DIFF
--- a/plugins/ros/src/components/scenarioWizard/components/ProbabilityTable.tsx
+++ b/plugins/ros/src/components/scenarioWizard/components/ProbabilityTable.tsx
@@ -21,8 +21,8 @@ export const ProbabilityTableInfo = () => {
 
   return (
     <Box sx={riskRow}>
-      {getContentCell(1)}
       {getContentCell(0)}
+      {getContentCell(1)}
       {getContentCell(2)}
       {getContentCell(3)}
       {getContentCell(4)}


### PR DESCRIPTION
Fixes [this](https://github.com/orgs/kartverket/projects/20/views/4?pane=issue&itemId=83325407&issue=kartverket%7Cbackstage-plugin-risk-scorecard-frontend%7C347) issue