### PR TITLE
Ekspanderer tiltak ved trykk på tiltakstekst

### DIFF
--- a/plugins/ros/README.md
+++ b/plugins/ros/README.md
@@ -1,6 +1,6 @@
 # Risk Scorecard (RiSc)
 
-This is a plugin for Backstage that helps you and your team when working continuously with risk analysis (:))
+This is a plugin for Backstage that helps you and your team when working continuously with risk analysis (:)
 The plugin is dependent on a backend service in order to decrypt and communicate with GitHub, and some configuration is
 necessary for them to communicate.
 
@@ -11,7 +11,8 @@ proxy:
   endpoints:
     '/risc-proxy':
       target: http://localhost:8080
-      allowedHeaders: ['Authorization', 'GCP-Access-Token', 'GitHub-Access-Token']
+      allowedHeaders:
+        ['Authorization', 'GCP-Access-Token', 'GitHub-Access-Token']
 ```
 
 The backend uses Backstage-issued tokens to validate the user, and GCP access tokens to federate access to the GCP KMS.

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
@@ -101,27 +101,33 @@ export const ActionBox = ({
 
   return (
     <Box>
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'row',
-          alignItems: 'center',
-        }}
-      >
-        <IconButton onClick={() => toggleActionExpanded(action.ID)}>
-          {isExpanded ? <ExpandLess /> : <ExpandMore />}
-        </IconButton>
-        <Typography
+      <Box sx={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
+        <Box
           sx={{
-            fontSize: '16px',
-            fontWeight: 500,
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+            cursor: 'pointer',
+            width: '100%',
           }}
+          onClick={() => toggleActionExpanded(action.ID)}
         >
-          {isActionTitlePresent
-            ? action.title
-            : `${t('dictionary.measure')} ${index + 1}`}
-        </Typography>
+          <IconButton>
+            {isExpanded ? <ExpandLess /> : <ExpandMore />}
+          </IconButton>
+          <Typography
+            sx={{
+              fontSize: '16px',
+              fontWeight: 500,
+            }}
+          >
+            {isActionTitlePresent
+              ? action.title
+              : `${t('dictionary.measure')} ${index + 1}`}
+          </Typography>
+        </Box>
         <IconButton
+          disabled={isExpanded ? false : true}
           sx={{
             marginLeft: 'auto',
             opacity: isExpanded ? 1 : 0,


### PR DESCRIPTION
Problem:
Ønsker å kunne ekspandere tiltak ved å trykke på teksten (ikke bare “hatten”)

Fiks:
Gjør (nesten) hele tiltaket klikkbart slik at tiltak ekspanderer når man trykker på det.