### PR TITLE
Improve edit list functionality

### DIFF
--- a/plugins/ros/src/components/scenarioTable/ScenarioTable.tsx
+++ b/plugins/ros/src/components/scenarioTable/ScenarioTable.tsx
@@ -16,7 +16,6 @@ import { useScenario } from '../../contexts/ScenarioContext';
 import { RiSc, RiScWithMetadata } from '../../utils/types';
 import { useFontStyles } from '../../utils/style';
 import { useRiScs } from '../../contexts/RiScContext';
-import { arrayNotEquals } from '../../utils/utilityfunctions';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { CheckCircle, Edit } from '@mui/icons-material';
@@ -33,7 +32,6 @@ export const ScenarioTable = ({ riSc }: ScenarioTableProps) => {
   const { openNewScenarioWizard, openScenarioDrawer } = useScenario();
   const [tempScenarios, setTempScenarios] = useState(riSc.scenarios);
   const { updateRiSc, updateStatus } = useRiScs();
-  const [isOrderChanged, setIsOrderChanged] = useState(false);
 
   useEffect(() => {
     if (!updateStatus.isSuccess) {
@@ -59,24 +57,13 @@ export const ScenarioTable = ({ riSc }: ScenarioTableProps) => {
     const [removed] = updatedScenarios.splice(dragIndex, 1);
     updatedScenarios.splice(hoverIndex, 0, removed);
     setTempScenarios(updatedScenarios);
-    const updatedOrder = updatedScenarios.map(scenario => scenario.ID);
-    setIsOrderChanged(
-      arrayNotEquals(
-        riSc.scenarios.map(scenario => scenario.ID),
-        updatedOrder,
-      ),
-    );
-  };
 
-  const saveOrder = () => {
     const updatedRiSc = {
       ...riSc,
-      scenarios: tempScenarios,
+      scenarios: updatedScenarios,
     };
 
-    updateRiSc(updatedRiSc, () => {
-      setIsOrderChanged(false);
-    });
+    updateRiSc(updatedRiSc, () => {});
   };
 
   const [isEditing, setIsEditing] = useState<boolean>(false);
@@ -110,16 +97,9 @@ export const ScenarioTable = ({ riSc }: ScenarioTableProps) => {
                 startIcon={isEditing ? <CheckCircle /> : <Edit />}
                 variant="text"
                 color="primary"
-                onClick={() => {
-                  if (isEditing && isOrderChanged) {
-                    saveOrder();
-                    setIsEditing(false);
-                  } else if (isEditing && !isOrderChanged) {
-                    setIsEditing(false);
-                  } else {
-                    setIsEditing(true);
-                  }
-                }}
+                onClick={() =>
+                  isEditing ? setIsEditing(false) : setIsEditing(true)
+                }
               >
                 {isEditing
                   ? t('scenarioTable.doneEditing')

--- a/plugins/ros/src/components/scenarioTable/ScenarioTableRow.tsx
+++ b/plugins/ros/src/components/scenarioTable/ScenarioTableRow.tsx
@@ -51,15 +51,11 @@ export const ScenarioTableRow = ({
   const [, drop] = useDrop({
     accept: 'row',
     hover(item: { index: number }, monitor) {
-      if (!ref.current) {
-        return;
-      }
+      if (!ref.current) return;
+
       const dragIndex = item.index;
       const hoverIndex = index;
-
-      if (dragIndex === hoverIndex) {
-        return;
-      }
+      if (dragIndex === hoverIndex) return;
 
       const hoverBoundingRect = ref.current?.getBoundingClientRect();
       const hoverMiddleY =
@@ -67,13 +63,10 @@ export const ScenarioTableRow = ({
       const clientOffset = monitor.getClientOffset();
       const hoverClientY = clientOffset!.y - hoverBoundingRect.top;
 
-      if (dragIndex < hoverIndex && hoverClientY < hoverMiddleY) {
-        return;
-      }
-
-      if (dragIndex > hoverIndex && hoverClientY > hoverMiddleY) {
-        return;
-      }
+      const isMovingDown =
+        dragIndex < hoverIndex && hoverClientY < hoverMiddleY;
+      const isMovingUp = dragIndex > hoverIndex && hoverClientY > hoverMiddleY;
+      if (isMovingDown || isMovingUp) return;
 
       moveRow(dragIndex, hoverIndex);
       item.index = hoverIndex;

--- a/plugins/ros/src/utils/translations.ts
+++ b/plugins/ros/src/utils/translations.ts
@@ -130,8 +130,8 @@ export const pluginRiScTranslationRef = createTranslationRef({
         probabilityChar: 'P',
         completed: 'complete',
       },
-      editButton: 'Edit scenario list',
-      doneEditing: 'Save editing',
+      editButton: 'Edit list',
+      doneEditing: 'Finish editing',
     },
     riskMatrix: {
       title: 'Risk matrix', // Risk matrix or Risk overview
@@ -557,7 +557,7 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
           'scenarioTable.columns.probabilityChar': 'S',
           'scenarioTable.columns.completed': 'fullført',
           'scenarioTable.editButton': 'Rediger liste',
-          'scenarioTable.doneEditing': 'Lagre endringer',
+          'scenarioTable.doneEditing': 'Avslutt redigering',
 
           'riskMatrix.title': 'Risikomatrise',
           'riskMatrix.estimatedRisk.title': 'Estimert risiko',


### PR DESCRIPTION
Instead of saving scenario list order onclick the save button, the risc is not updated directly when changing the order. This aligns better with the delete functionality. Now the "edit list" button only shows the order and delete funtionality and "finish editing" hides it.