### PR TITLE
Bugfix: scenario order changes does not work properly

### DIFF
--- a/plugins/ros/src/components/scenarioTable/ScenarioTable.tsx
+++ b/plugins/ros/src/components/scenarioTable/ScenarioTable.tsx
@@ -52,17 +52,23 @@ export const ScenarioTable = ({ riSc }: ScenarioTableProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [riSc.scenarios, updateStatus.isSuccess]);
 
-  const moveRow = (dragIndex: number, hoverIndex: number) => {
+  const moveRowLocal = (dragIndex: number, hoverIndex: number) => {
     const updatedScenarios = [...tempScenarios];
     const [removed] = updatedScenarios.splice(dragIndex, 1);
     updatedScenarios.splice(hoverIndex, 0, removed);
+    setTempScenarios(updatedScenarios);
+  };
+
+  const moveRowFinal = (dragIndex: number, dropIndex: number) => {
+    const updatedScenarios = [...tempScenarios];
+    const [removed] = updatedScenarios.splice(dragIndex, 1);
+    updatedScenarios.splice(dropIndex, 0, removed);
     setTempScenarios(updatedScenarios);
 
     const updatedRiSc = {
       ...riSc,
       scenarios: updatedScenarios,
     };
-
     updateRiSc(updatedRiSc, () => {});
   };
 
@@ -179,7 +185,8 @@ export const ScenarioTable = ({ riSc }: ScenarioTableProps) => {
                       index={idx}
                       scenario={scenario}
                       viewRow={openScenarioDrawer}
-                      moveRow={moveRow}
+                      moveRowFinal={moveRowFinal}
+                      moveRowLocal={moveRowLocal}
                       isLastRow={idx === riSc.scenarios.length - 1}
                       isEditing={isEditing}
                     />

--- a/plugins/ros/src/components/scenarioTable/ScenarioTableRow.tsx
+++ b/plugins/ros/src/components/scenarioTable/ScenarioTableRow.tsx
@@ -21,7 +21,8 @@ interface ScenarioTableRowProps {
   scenario: Scenario;
   viewRow: (id: string) => void;
   index: number;
-  moveRow: (dragIndex: number, hoverIndex: number) => void;
+  moveRowFinal: (dragIndex: number, dropIndex: number) => void;
+  moveRowLocal: (dragIndex: number, hoverIndex: number) => void;
   isLastRow?: boolean;
   isEditing: boolean;
 }
@@ -30,7 +31,8 @@ export const ScenarioTableRow = ({
   scenario,
   viewRow,
   index,
-  moveRow,
+  moveRowFinal,
+  moveRowLocal,
   isLastRow,
   isEditing,
 }: ScenarioTableRowProps) => {
@@ -68,18 +70,29 @@ export const ScenarioTableRow = ({
       const isMovingUp = dragIndex > hoverIndex && hoverClientY > hoverMiddleY;
       if (isMovingDown || isMovingUp) return;
 
-      moveRow(dragIndex, hoverIndex);
+      moveRowLocal(dragIndex, hoverIndex);
+
       item.index = hoverIndex;
     },
   });
 
-  const [{ isDragging }, drag, preview] = useDrag({
+  const [{ isDragging }, drag, preview] = useDrag(() => ({
     type: 'row',
-    item: { index },
+    item: { index, originalIndex: index },
+
+    end: (item, monitor) => {
+      if (monitor.didDrop()) {
+        const finalIndex = item.index;
+        const { originalIndex } = item;
+
+        moveRowFinal(originalIndex, finalIndex);
+      }
+    },
+
     collect: monitor => ({
       isDragging: monitor.isDragging(),
     }),
-  });
+  }));
 
   preview(drop(ref));
 


### PR DESCRIPTION
Explanation: Currently, the risc is updated every time a row change is done in the scenario table. This introduces a bug when moving a scenario mulitple rows up/down. We only want it to update when you drop the row. This PR hopefully fixes this 🤠 