### PR TITLE
Proper error handling for when the user does not have access to any GCP crypto keys

### DIFF
--- a/plugins/ros/src/components/riScDialog/ConfigEncryptionDialog.tsx
+++ b/plugins/ros/src/components/riScDialog/ConfigEncryptionDialog.tsx
@@ -124,7 +124,7 @@ const ConfigEncryptionDialog = ({
       <GcpCryptoKeyMenu
         chosenGcpCryptoKey={chosenGcpCryptoKey}
         onChange={handleChangeGcpCryptoKey}
-        gcpCryptoKeys={gcpCryptoKeys}
+        gcpCryptoKeys={gcpCryptoKeys.includes(chosenGcpCryptoKey) ? gcpCryptoKeys : [...gcpCryptoKeys, chosenGcpCryptoKey]}
       />
       <Box>
         <Accordion elevation={1} defaultExpanded={publicAgeKeys.length > 0}>

--- a/plugins/ros/src/components/riScDialog/ConfigEncryptionDialog.tsx
+++ b/plugins/ros/src/components/riScDialog/ConfigEncryptionDialog.tsx
@@ -118,7 +118,9 @@ const ConfigEncryptionDialog = ({
           ? t('sopsConfigDialog.description.new')
           : t('sopsConfigDialog.description.edit')}
       </DialogContentText>
-      {t('sopsConfigDialog.selectKeysTitle')}
+      <Typography variant="subtitle2">
+        {t('sopsConfigDialog.selectKeysTitle')}
+      </Typography>
       {t('sopsConfigDialog.gcpCryptoKeyDescription')}
 
       <GcpCryptoKeyMenu

--- a/plugins/ros/src/components/riScDialog/ConfigEncryptionDialog.tsx
+++ b/plugins/ros/src/components/riScDialog/ConfigEncryptionDialog.tsx
@@ -83,12 +83,14 @@ const ConfigEncryptionDialog = ({
   useEffect(() => {
     setValue('sopsConfig', {
       shamir_threshold: 2,
-      gcp_kms: chosenGcpCryptoKey ? [
-        {
-          resource_id: chosenGcpCryptoKey.resourceId,
-          created_at: chosenGcpCryptoKey.createdAt,
-        },
-      ] : [],
+      gcp_kms: chosenGcpCryptoKey
+        ? [
+            {
+              resource_id: chosenGcpCryptoKey.resourceId,
+              created_at: chosenGcpCryptoKey.createdAt,
+            },
+          ]
+        : [],
       age: publicAgeKeys.map(key => ({ recipient: key })),
     });
   }, [chosenGcpCryptoKey, publicAgeKeys, setValue]);

--- a/plugins/ros/src/components/riScDialog/RiScDialog.tsx
+++ b/plugins/ros/src/components/riScDialog/RiScDialog.tsx
@@ -102,11 +102,19 @@ export const RiScDialog = ({ onClose, dialogState }: RiScDialogProps) => {
     }
   };
 
-  const handleNext = handleSubmit(() => {
-    if (activeStep === 0) {
-      setActiveStep(1);
-    }
-  });
+  const handleNext = handleSubmit(
+    () => {
+      if (activeStep === 0) {
+        setActiveStep(1);
+      }
+    },
+    // Continue to step 1 even if there are errors, as long as there are no errors in step 0 (the content)
+    validationErrors => {
+      if (activeStep === 0 && validationErrors.content === undefined) {
+        setActiveStep(1);
+      }
+    },
+  );
 
   const handleBack = () => {
     if (activeStep === 1) {
@@ -146,6 +154,7 @@ export const RiScDialog = ({ onClose, dialogState }: RiScDialogProps) => {
                 setValue={setValue}
                 state={dialogState}
                 register={register}
+                errors={errors}
               />
             )}
           </DialogContent>
@@ -219,6 +228,7 @@ export const RiScDialog = ({ onClose, dialogState }: RiScDialogProps) => {
             setValue={setValue}
             state={dialogState}
             register={register}
+            errors={errors}
           />
         </DialogContent>
         <DialogActions sx={dialogActions}>

--- a/plugins/ros/src/components/riScDialog/RiScDialog.tsx
+++ b/plugins/ros/src/components/riScDialog/RiScDialog.tsx
@@ -81,15 +81,6 @@ export const RiScDialog = ({ onClose, dialogState }: RiScDialogProps) => {
   });
 
   const [activeStep, setActiveStep] = useState(0);
-  const titleTranslation = (() => {
-    if (dialogState === RiScDialogStates.Create) {
-      return t('rosDialog.titleNew', {});
-    }
-    if (dialogState === RiScDialogStates.EditRiscInfo) {
-      return t('rosDialog.titleEdit', {});
-    }
-    return t('rosDialog.editEncryption', {});
-  })();
 
   const [createRiScFrom, setCreateRiScFrom] = useState<CreateRiScFrom>(
     CreateRiScFrom.Scratch,
@@ -133,8 +124,8 @@ export const RiScDialog = ({ onClose, dialogState }: RiScDialogProps) => {
 
   if (dialogState === RiScDialogStates.Create) {
     return (
-      <Dialog open={dialogState === RiScDialogStates.Create} onClose={onClose}>
-        <DialogTitle>{titleTranslation}</DialogTitle>
+      <Dialog open={true} onClose={onClose}>
+        <DialogTitle>{t('rosDialog.titleNew')}</DialogTitle>
         <RiScStepper activeStep={activeStep}>
           <DialogContent
             sx={{ display: 'flex', flexDirection: 'column', gap: '16px' }}
@@ -168,7 +159,7 @@ export const RiScDialog = ({ onClose, dialogState }: RiScDialogProps) => {
           <Button variant="outlined" onClick={onClose}>
             {t('dictionary.cancel')}
           </Button>
-          {activeStep === 0 ? (
+          {activeStep < 1 ? (
             <Button variant="contained" onClick={handleNext}>
               {t('dictionary.next')}
             </Button>
@@ -184,11 +175,8 @@ export const RiScDialog = ({ onClose, dialogState }: RiScDialogProps) => {
 
   if (dialogState === RiScDialogStates.EditRiscInfo) {
     return (
-      <Dialog
-        open={dialogState === RiScDialogStates.EditRiscInfo}
-        onClose={onClose}
-      >
-        <DialogTitle>{titleTranslation}</DialogTitle>
+      <Dialog open={true} onClose={onClose}>
+        <DialogTitle>{t('rosDialog.titleEdit')}</DialogTitle>
         <DialogContent
           sx={{ display: 'flex', flexDirection: 'column', gap: '16px' }}
         >
@@ -214,11 +202,8 @@ export const RiScDialog = ({ onClose, dialogState }: RiScDialogProps) => {
 
   if (dialogState === RiScDialogStates.EditEncryption) {
     return (
-      <Dialog
-        open={dialogState === RiScDialogStates.EditEncryption}
-        onClose={onClose}
-      >
-        <DialogTitle>{titleTranslation}</DialogTitle>
+      <Dialog open={true} onClose={onClose}>
+        <DialogTitle>{t('rosDialog.editEncryption')}</DialogTitle>
         <DialogContent
           sx={{ display: 'flex', flexDirection: 'column', gap: '16px' }}
         >

--- a/plugins/ros/src/utils/translations.ts
+++ b/plugins/ros/src/utils/translations.ts
@@ -205,6 +205,10 @@ export const pluginRiScTranslationRef = createTranslationRef({
       chooseGcpCryptoKey: 'Choose GCP key',
       gcpCryptoKeyDescription:
         'From the list below, select the GCP crypto key you want to use for encrypting and decrypting Risk scorecards.',
+      gcpCryptoKeyNoSelectableKey:
+        'You do not have access to any suitable GCP crypto keys.',
+      gcpCryptoKeyNonSelectedErrorMessage:
+        'A GCP crypto key must be selected.',
       publicAgeKeysAlreadyPresent:
         'The following age keys are already present:',
       publicAgeKeyQuestion:
@@ -629,6 +633,10 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
           'sopsConfigDialog.chooseGcpCryptoKey': 'Velg GCP-nøkkel',
           'sopsConfigDialog.gcpCryptoKeyDescription':
             "Fra listen under kan du velge hvilken GCP-nøkkel vil du bruke for å kryptere og dekryptere RoS'ene dine med.",
+          'sopsConfigDialog.gcpCryptoKeyNoSelectableKey':
+            'Du har ikke tilgang til noe egnede GCP-nøkler.',
+          'sopsConfigDialog.gcpCryptoKeyNonSelectedErrorMessage':
+            'En GCP-nøkkel må være valgt.',
           'sopsConfigDialog.publicAgeKeysAlreadyPresent':
             'Følgende age-nøkler er allerede til stede:',
           'sopsConfigDialog.publicAgeKeyQuestion':

--- a/plugins/ros/src/utils/translations.ts
+++ b/plugins/ros/src/utils/translations.ts
@@ -207,8 +207,7 @@ export const pluginRiScTranslationRef = createTranslationRef({
         'From the list below, select the GCP crypto key you want to use for encrypting and decrypting Risk scorecards.',
       gcpCryptoKeyNoSelectableKey:
         'You do not have access to any suitable GCP crypto keys.',
-      gcpCryptoKeyNonSelectedErrorMessage:
-        'A GCP crypto key must be selected.',
+      gcpCryptoKeyNonSelectedErrorMessage: 'A GCP crypto key must be selected.',
       publicAgeKeysAlreadyPresent:
         'The following age keys are already present:',
       publicAgeKeyQuestion:


### PR DESCRIPTION
Currently, the web application will simply crash when the reaching the encryption dialog in the creation dialog, if the user does not have access to any GCP crypto key. This fixes the problem by providing the user with a custom message, instead of the key selection field when there are no selectable GCP crypto keys. Also adds validation on the crypto key field, to make sure that a GCP crypto key is selected.

In the *edit encryption dialog*, the current configured key for the project is not included in the list of choosable GCP crypto keys if it not passed from the backend (for example, already configured, but not included with the new filter from kartverket/backstage-plugin-risk-scorecard-backend#314). To not confuse users, this PR adds the currently configured key to the list of choosable GCP crypto keys if it is not already there.