### PR TITLE
Don't update the RISC if no changes have been made

### DIFF
--- a/plugins/ros/src/components/riScDialog/RiScDialog.tsx
+++ b/plugins/ros/src/components/riScDialog/RiScDialog.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { RiScWithMetadata } from '../../utils/types';
-import { emptyRiSc } from '../../utils/utilityfunctions';
+import { emptyRiSc, isDeeplyEqual } from '../../utils/utilityfunctions';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { pluginRiScTranslationRef } from '../../utils/translations';
 import { useRiScs } from '../../contexts/RiScContext';
@@ -117,7 +117,10 @@ export const RiScDialog = ({ onClose, dialogState }: RiScDialogProps) => {
     if (dialogState === RiScDialogStates.Create) {
       createNewRiSc(data, createRiScFrom === CreateRiScFrom.Default);
     } else {
-      updateRiSc(data);
+      // Only update the risc if it has changed
+      if (!isDeeplyEqual(data, selectedRiSc)) {
+        updateRiSc(data);
+      }
     }
     onClose();
   });

--- a/plugins/ros/src/utils/utilityfunctions.test.ts
+++ b/plugins/ros/src/utils/utilityfunctions.test.ts
@@ -1,0 +1,46 @@
+import { isDeeplyEqual } from './utilityfunctions';
+
+describe('isDeeplyEqual', () => {
+  const testCases: [unknown, unknown, boolean][] = [
+    [0, 0, true],
+    [0, 1, false],
+    ['', '', true],
+    ['', 'a', false],
+    ['b', 'a', false],
+    [null, null, true],
+    [undefined, undefined, true],
+    [[], [], true],
+    [[], [1], false],
+    [{}, {}, true],
+    [{}, { 0: 1 }, false],
+    [0, '', false],
+    [0, 'a', false],
+    [0, null, false],
+    [0, undefined, false],
+    [0, [], false],
+    [0, {}, false],
+    ['', null, false],
+    ['', undefined, false],
+    ['', [], false],
+    ['', {}, false],
+    [[0], { '0': 0 }, false],
+    [[0], { 0: 0 }, false],
+    [[0, 3, 4], [0, 3, 4], true],
+    [{ 0: 1 }, { 0: 1 }, true],
+    [{ 0: [0, 1], 1: [2, 3] }, { 0: [0, 1], 1: [2, 3] }, true],
+    [{ 0: [0, 1], 1: [2, 3] }, { 0: [0, 1] }, false],
+    [{ 0: { a: 'b' } }, { 0: [0, 1] }, false],
+    [{ 0: { a: 'b' } }, { 0: { a: 'b' } }, true],
+    [{ 0: { a: { b: 1 } } }, { 0: { a: 'b' } }, false],
+    [{ 0: { a: { b: 1 } } }, { 0: { a: { b: 1 } } }, true],
+    [{ 0: { a: { b: 1 } } }, { 0: { a: { b: 1, c: 1 } } }, false],
+    [{ 0: { a: { b: 1, c: 1 }, b: 1 } }, { 0: { a: { b: 1, c: 1 } } }, false],
+    [{ 0: 1 }, { '0': 1 }, true],
+  ];
+
+  testCases.forEach(([a, b, result]) =>
+    test(`isDeeplyEqual(${JSON.stringify(a)}, ${JSON.stringify(b)})`, () => {
+      expect(isDeeplyEqual(a, b)).toBe(result);
+    }),
+  );
+});

--- a/plugins/ros/src/utils/utilityfunctions.test.ts
+++ b/plugins/ros/src/utils/utilityfunctions.test.ts
@@ -46,16 +46,18 @@ describe('isDeeplyEqual', () => {
 
   const testCasesIgnored: [unknown, unknown, string[], boolean][] = [
     [0, 0, [], true],
-    [0, 0, ["test"], true],
-    [{}, {test: 0}, ["test"], true],
-    [{test: 1}, {test: 0}, ["test"], true],
-    [{test: 1}, {test: 0}, ["test2"], false],
-    [{test: {a: 1}}, {test: 0}, ["test"], true],
-    [{test: 0}, "a", ["test"], false],
-  ]
+    [0, 0, ['test'], true],
+    [{}, { test: 0 }, ['test'], true],
+    [{ test: 1 }, { test: 0 }, ['test'], true],
+    [{ test: 1 }, { test: 0 }, ['test2'], false],
+    [{ test: { a: 1 } }, { test: 0 }, ['test'], true],
+    [{ test: 0 }, 'a', ['test'], false],
+  ];
 
   testCasesIgnored.forEach(([a, b, ignored, result]) =>
-    test(`isDeeplyEqual(${JSON.stringify(a)}, ${JSON.stringify(b)}, ${JSON.stringify(ignored)})`, () => {
+    test(`isDeeplyEqual(${JSON.stringify(a)}, ${JSON.stringify(
+      b,
+    )}, ${JSON.stringify(ignored)})`, () => {
       expect(isDeeplyEqual(a, b, ignored)).toBe(result);
     }),
   );

--- a/plugins/ros/src/utils/utilityfunctions.test.ts
+++ b/plugins/ros/src/utils/utilityfunctions.test.ts
@@ -43,4 +43,20 @@ describe('isDeeplyEqual', () => {
       expect(isDeeplyEqual(a, b)).toBe(result);
     }),
   );
+
+  const testCasesIgnored: [unknown, unknown, string[], boolean][] = [
+    [0, 0, [], true],
+    [0, 0, ["test"], true],
+    [{}, {test: 0}, ["test"], true],
+    [{test: 1}, {test: 0}, ["test"], true],
+    [{test: 1}, {test: 0}, ["test2"], false],
+    [{test: {a: 1}}, {test: 0}, ["test"], true],
+    [{test: 0}, "a", ["test"], false],
+  ]
+
+  testCasesIgnored.forEach(([a, b, ignored, result]) =>
+    test(`isDeeplyEqual(${JSON.stringify(a)}, ${JSON.stringify(b)}, ${JSON.stringify(ignored)})`, () => {
+      expect(isDeeplyEqual(a, b, ignored)).toBe(result);
+    }),
+  );
 });

--- a/plugins/ros/src/utils/utilityfunctions.ts
+++ b/plugins/ros/src/utils/utilityfunctions.ts
@@ -321,9 +321,14 @@ export const deleteAction = (
 };
 
 /**
- * A recursive method for determining if a and b are deeply equal
+ * A recursive method for determining if a and b are deeply equal. Keys in the ignoredKeys argument are ignored in the
+ * comparison, i.e., they are considered non-existing in both a and b.
  */
-export function isDeeplyEqual<T>(a: T, b: T): boolean {
+export function isDeeplyEqual<T>(
+  a: T,
+  b: T,
+  ignoredKeys: string[] = [],
+): boolean {
   // If objects are equal, there is no need compare them any further.
   if (a === b) return true;
 
@@ -334,14 +339,19 @@ export function isDeeplyEqual<T>(a: T, b: T): boolean {
     if (Array.isArray(a) !== Array.isArray(b)) return false;
 
     // Check if a and b have the same number of entries
-    if (Object.keys(a).length !== Object.keys(b).length) return false;
+    if (
+      Object.keys(a).filter(key => !ignoredKeys.includes(key)).length !==
+      Object.keys(b).filter(key => !ignoredKeys.includes(key)).length
+    )
+      return false;
 
     // Check if every key of a is a key of b and that the entry associated with the key is deeply the same in a and b.
     // Since a and b has the same number of entries, it is sufficient to check only the keys of a.
     return Object.entries(a).every(
       ([key, value]) =>
-        Object.hasOwn(b, key as keyof T) &&
-        isDeeplyEqual(value, b[key as keyof T]),
+        ignoredKeys.includes(key) ||
+        (Object.hasOwn(b, key as keyof T) &&
+          isDeeplyEqual(value, b[key as keyof T])),
     );
   }
 

--- a/plugins/ros/src/utils/utilityfunctions.ts
+++ b/plugins/ros/src/utils/utilityfunctions.ts
@@ -319,3 +319,32 @@ export const deleteAction = (
   remove(index);
   onSubmit();
 };
+
+/**
+ * A recursive method for determining if a and b are deeply equal
+ */
+export function isDeeplyEqual<T>(a: T, b: T): boolean {
+  // If objects are equal, there is no need compare them any further.
+  if (a === b) return true;
+
+  // Only do comparison on objects, ignoring null (which maps to object).
+  if (a && b && typeof a === 'object' && typeof b === 'object') {
+    // Check if a and b are both arrays or not. If only one is, then a and b are not equal. It is necessary to perform
+    // this check, as otherwise the method below will say that [] and {} are equal (or [0] and {0: 0}).
+    if (Array.isArray(a) !== Array.isArray(b)) return false;
+
+    // Check if a and b have the same number of entries
+    if (Object.keys(a).length !== Object.keys(b).length) return false;
+
+    // Check if every key of a is a key of b and that the entry associated with the key is deeply the same in a and b.
+    // Since a and b has the same number of entries, it is sufficient to check only the keys of a.
+    return Object.entries(a).every(
+      ([key, value]) =>
+        Object.hasOwn(b, key as keyof T) &&
+        isDeeplyEqual(value, b[key as keyof T]),
+    );
+  }
+
+  // If a or b is null or a primitive type, then they are not equal as a === b should have returned true already.
+  return false;
+}


### PR DESCRIPTION
Currently, clicking "save" in the form for updating the title and description or the encryption configuration, will send an update request to the backend, even if no changes have been made. This PR stops the frontend from sending an update to the backend when the data has not been changed in the form.