### PR TITLE
Upgrade node SAML to fix critical vulnerabilties in xml-crypto

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
     "swagger-ui-react": "5.10.5",
     "jsonpath-plus": "^10.2.0",
     "koa": "2.15.4",
-    "@module-federation/dts-plugin": "0.9.1"
+    "@module-federation/dts-plugin": "0.9.1",
+    "@node-saml/node-saml": "5.0.1",
+    "xml-crypto": "6.0.1"
   },
   "prettier": "@backstage/cli/config/prettier",
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9177,9 +9177,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@node-saml/node-saml@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@node-saml/node-saml@npm:5.0.0"
+"@node-saml/node-saml@npm:5.0.1":
+  version: 5.0.1
+  resolution: "@node-saml/node-saml@npm:5.0.1"
   dependencies:
     "@types/debug": "npm:^4.1.12"
     "@types/qs": "npm:^6.9.11"
@@ -9188,12 +9188,12 @@ __metadata:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     debug: "npm:^4.3.4"
-    xml-crypto: "npm:^6.0.0"
+    xml-crypto: "npm:^6.0.1"
     xml-encryption: "npm:^3.0.2"
     xml2js: "npm:^0.6.2"
     xmlbuilder: "npm:^15.1.1"
     xpath: "npm:^0.0.34"
-  checksum: 10c0/50a7aab94d410c0b1169eb5b0cf13ac964281a88d6fc155345e82afb2d6ccc159db90ebffa89c3d348fc233c0558af8d2b7b11f0ce8e65f90cd8297c0d274c1a
+  checksum: 10c0/07e66f763a94d44c9fc5ab2f8839cf0a98bcc8929c1641925e165ba5966cbee5886f4c4bfe1c2b6c040e2dbd178529c67b9169343dc6a4bb333dff7debcb17da
   languageName: node
   linkType: hard
 
@@ -37969,14 +37969,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+"xml-crypto@npm:6.0.1":
+  version: 6.0.1
+  resolution: "xml-crypto@npm:6.0.1"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10c0/1a9d8be4cc7a4c618fa413b8ef30f11cda9ae81f20bc03e84c51f6c61383168a9915f8c3a26061e2053e58807b76d3a13726338f7bc0d8c45285fbb1da296293
+  checksum: 10c0/608121007ddc50e7e0e23c1305af1dba5e449ff79ab3d0ecfb034a8072896f47bc082d377d7ef13c4ee82137f64cd1b5dde1d2f8eecea59fda55a04c1b080d0a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
NY! 🤠 Har fått to kritiske sårbarheter for xml-crypto, som er en tredjepartsavhengighet gjennom node SAML, og som er patchet i versjon 5.0.1.