### PR TITLE
🐛fix: Add github-markdown-css for prettier markdown formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@backstage/cli": "backstage:^",
     "@backstage/e2e-test-utils": "backstage:^",
     "@playwright/test": "^1.51.1",
+    "github-markdown-css": "^5.8.1",
     "lerna": "^8.2.2",
     "node-gyp": "^11.2.0",
     "prettier": "^3.5.3",

--- a/plugins/ros/package.json
+++ b/plugins/ros/package.json
@@ -52,6 +52,7 @@
     "@uiw/react-markdown-preview": "^5.1.3",
     "@uiw/react-md-editor": "^4.0.5",
     "date-fns": "^4.1.0",
+    "github-markdown-css": "^5.8.1",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
     "react-hook-form": "^7.55.0",

--- a/plugins/ros/src/components/common/Markdown.tsx
+++ b/plugins/ros/src/components/common/Markdown.tsx
@@ -1,12 +1,12 @@
-import Typography from "@mui/material/Typography";
-import ReactMarkdown from "react-markdown";
+import Typography from '@mui/material/Typography';
+import ReactMarkdown from 'react-markdown';
 import 'github-markdown-css/github-markdown.css';
 
 type Props = {
-  description: string
+  description: string;
 };
 
-export function Markdown({ description }:Props) {
+export function Markdown({ description }: Props) {
   return (
     <Typography className="markdown-body">
       <ReactMarkdown>{description}</ReactMarkdown>

--- a/plugins/ros/src/components/common/Markdown.tsx
+++ b/plugins/ros/src/components/common/Markdown.tsx
@@ -1,0 +1,15 @@
+import Typography from "@mui/material/Typography";
+import ReactMarkdown from "react-markdown";
+import 'github-markdown-css/github-markdown.css';
+
+type Props = {
+  description: string
+};
+
+export function Markdown({ description }:Props) {
+  return (
+    <Typography className="markdown-body">
+      <ReactMarkdown>{description}</ReactMarkdown>
+    </Typography>
+  );
+}

--- a/plugins/ros/src/components/riScInfo/RiScInfo.tsx
+++ b/plugins/ros/src/components/riScInfo/RiScInfo.tsx
@@ -7,8 +7,7 @@ import { pluginRiScTranslationRef } from '../../utils/translations';
 import { useFontStyles } from '../../utils/style';
 import EditButton from '../common/EditButton';
 import { useRiScs } from '../../contexts/RiScContext';
-import ReactMarkdown from 'react-markdown';
-import 'github-markdown-css/github-markdown.css';
+import { Markdown } from '../common/Markdown';
 
 interface RiScInfoProps {
   riScWithMetadata: RiScWithMetadata;
@@ -47,9 +46,7 @@ export function RiScInfo({ riScWithMetadata, edit }: RiScInfoProps) {
             <EditButton onClick={edit} />
           </Box>
           <Typography className={label}>{t('dictionary.scope')}</Typography>
-          <Typography className="markdown-body">
-            <ReactMarkdown>{riScWithMetadata.content.scope}</ReactMarkdown>
-          </Typography>
+          <Markdown description={riScWithMetadata.content.scope} />
         </InfoCard>
       </Grid>
       <Grid item xs={12} sm={6} md={6}>

--- a/plugins/ros/src/components/riScInfo/RiScInfo.tsx
+++ b/plugins/ros/src/components/riScInfo/RiScInfo.tsx
@@ -8,6 +8,7 @@ import { useFontStyles } from '../../utils/style';
 import EditButton from '../common/EditButton';
 import { useRiScs } from '../../contexts/RiScContext';
 import ReactMarkdown from 'react-markdown';
+import 'github-markdown-css/github-markdown.css';
 
 interface RiScInfoProps {
   riScWithMetadata: RiScWithMetadata;
@@ -16,7 +17,7 @@ interface RiScInfoProps {
 
 export function RiScInfo({ riScWithMetadata, edit }: RiScInfoProps) {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
-  const { label, body2 } = useFontStyles();
+  const { label } = useFontStyles();
 
   const { approveRiSc } = useRiScs();
 
@@ -46,9 +47,9 @@ export function RiScInfo({ riScWithMetadata, edit }: RiScInfoProps) {
             <EditButton onClick={edit} />
           </Box>
           <Typography className={label}>{t('dictionary.scope')}</Typography>
-          <Box className={body2}>
+          <Typography className="markdown-body">
             <ReactMarkdown>{riScWithMetadata.content.scope}</ReactMarkdown>
-          </Box>
+          </Typography>
         </InfoCard>
       </Grid>
       <Grid item xs={12} sm={6} md={6}>

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
@@ -22,8 +22,7 @@ import { useIsMounted } from '../../../utils/hooks';
 import CircularProgress from '@mui/material/CircularProgress';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { deleteAction } from '../../../utils/utilityfunctions';
-import ReactMarkdown from 'react-markdown';
-import 'github-markdown-css/github-markdown.css';
+import { Markdown } from '../../common/Markdown';
 
 interface ActionBoxProps {
   action: Action;
@@ -205,9 +204,7 @@ export function ActionBox({
         <Typography sx={{ ...label, marginTop: 1 }}>
           {t('dictionary.description')}
         </Typography>
-        <Typography className="markdown-body">
-          <ReactMarkdown>{action.description}</ReactMarkdown>
-        </Typography>
+        <Markdown description={action.description} />
 
         <Box
           sx={{

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
@@ -23,6 +23,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { deleteAction } from '../../../utils/utilityfunctions';
 import ReactMarkdown from 'react-markdown';
+import 'github-markdown-css/github-markdown.css';
 
 interface ActionBoxProps {
   action: Action;
@@ -204,14 +205,9 @@ export function ActionBox({
         <Typography sx={{ ...label, marginTop: 1 }}>
           {t('dictionary.description')}
         </Typography>
-        <Box
-          sx={{
-            ...body2,
-            wordBreak: 'break-all',
-          }}
-        >
+        <Typography className="markdown-body">
           <ReactMarkdown>{action.description}</ReactMarkdown>
-        </Box>
+        </Typography>
 
         <Box
           sx={{

--- a/plugins/ros/src/components/scenarioDrawer/components/ScopeSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ScopeSection.tsx
@@ -14,6 +14,7 @@ import {
   label,
 } from '../../common/typography';
 import ReactMarkdown from 'react-markdown';
+import 'github-markdown-css/github-markdown.css';
 
 export function ScopeSection() {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
@@ -28,9 +29,9 @@ export function ScopeSection() {
       <Box>
         <Typography sx={label}>{t('dictionary.description')}</Typography>
         {scenario.description ? (
-          <Box sx={body2}>
+          <Typography className="markdown-body">
             <ReactMarkdown>{scenario.description}</ReactMarkdown>
-          </Box>
+          </Typography>
         ) : (
           <Typography sx={emptyState}>
             {t('dictionary.emptyField', {

--- a/plugins/ros/src/components/scenarioDrawer/components/ScopeSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ScopeSection.tsx
@@ -13,8 +13,7 @@ import {
   heading3,
   label,
 } from '../../common/typography';
-import ReactMarkdown from 'react-markdown';
-import 'github-markdown-css/github-markdown.css';
+import { Markdown } from '../../common/Markdown';
 
 export function ScopeSection() {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
@@ -29,9 +28,7 @@ export function ScopeSection() {
       <Box>
         <Typography sx={label}>{t('dictionary.description')}</Typography>
         {scenario.description ? (
-          <Typography className="markdown-body">
-            <ReactMarkdown>{scenario.description}</ReactMarkdown>
-          </Typography>
+          <Markdown description={scenario.description} />
         ) : (
           <Typography sx={emptyState}>
             {t('dictionary.emptyField', {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7932,6 +7932,7 @@ __metadata:
     "@uiw/react-markdown-preview": "npm:^5.1.3"
     "@uiw/react-md-editor": "npm:^4.0.5"
     date-fns: "npm:^4.1.0"
+    github-markdown-css: "npm:^5.8.1"
     prettier: "npm:^3.5.3"
     react-dnd: "npm:^16.0.1"
     react-dnd-html5-backend: "npm:^16.0.1"
@@ -23092,6 +23093,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"github-markdown-css@npm:^5.8.1":
+  version: 5.8.1
+  resolution: "github-markdown-css@npm:5.8.1"
+  checksum: 10c0/67d3540731f9f1fc3b903362ef270e6db0ffe252fd4998a1a8777fc63b288b1904e5e57703e74a2ee04f1d613a4732b1949cb472b66a3c2e9e2b7a1750d1f0a6
+  languageName: node
+  linkType: hard
+
 "github-slugger@npm:^2.0.0":
   version: 2.0.0
   resolution: "github-slugger@npm:2.0.0"
@@ -34614,6 +34622,7 @@ __metadata:
     "@backstage/cli": "backstage:^"
     "@backstage/e2e-test-utils": "backstage:^"
     "@playwright/test": "npm:^1.51.1"
+    github-markdown-css: "npm:^5.8.1"
     lerna: "npm:^8.2.2"
     node-gyp: "npm:^11.2.0"
     prettier: "npm:^3.5.3"


### PR DESCRIPTION
Added github markdowncss style for Risc description, scenario description and action description.

Before:
<img width="607" src="https://github.com/user-attachments/assets/8a48d4f4-11f1-4b69-884a-16c36fbf3e9c" />

After:
<img width="608" alt="Screenshot 2025-04-11 at 14 03 46" src="https://github.com/user-attachments/assets/92c3af7d-ab4d-4932-91f8-848dfb266e79" />

