### PR TITLE
🐛fix: Use react-hook-form Controller to detect changes in MarkdownInput

### DIFF
--- a/plugins/ros/src/components/common/MarkdownInput.tsx
+++ b/plugins/ros/src/components/common/MarkdownInput.tsx
@@ -15,16 +15,7 @@ type Props = TextFieldProps & {
 
 export const MarkdownInput = forwardRef<HTMLDivElement, Props>(
   (
-    {
-      label,
-      sublabel,
-      error,
-      helperText,
-      required,
-      minRows,
-      value,
-      onMarkdownChange,
-    },
+    { label, sublabel, error, helperText, minRows, value, onMarkdownChange },
     ref,
   ) => {
     const [markdownContent, setMarkdownContent] = useState<string | undefined>(
@@ -41,16 +32,8 @@ export const MarkdownInput = forwardRef<HTMLDivElement, Props>(
     };
 
     return (
-      <FormControl
-        sx={{ width: '100%', gap: '4px' }}
-        error={error}
-        required={required}
-      >
-        {label && (
-          <FormLabel required={required} sx={formLabel}>
-            {label}
-          </FormLabel>
-        )}
+      <FormControl sx={{ width: '100%', gap: '4px' }} error={error}>
+        {label && <FormLabel sx={formLabel}>{label}</FormLabel>}
         {sublabel && (
           <FormHelperText sx={formHelperText}>{sublabel}</FormHelperText>
         )}

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionFormItem.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionFormItem.tsx
@@ -83,10 +83,8 @@ export function ActionFormItem({
         <Controller
           control={control}
           name={`actions.${index}.description`}
-          rules={{ required: true }}
           render={({ field: { onChange, value }, fieldState: { error } }) => (
             <MarkdownInput
-              required
               label={t('dictionary.description')}
               value={value}
               onMarkdownChange={onChange}

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionFormItem.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionFormItem.tsx
@@ -5,7 +5,11 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { pluginRiScTranslationRef } from '../../../utils/translations';
 import { heading3 } from '../../common/typography';
-import { UseFieldArrayRemove, UseFormReturn } from 'react-hook-form';
+import {
+  Controller,
+  UseFieldArrayRemove,
+  UseFormReturn,
+} from 'react-hook-form';
 import { FormScenario } from '../../../utils/types';
 import {
   actionStatusOptions,
@@ -32,15 +36,13 @@ export function ActionFormItem({
 }: ActionFormItemProps) {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
 
-  const { control, register, setValue, watch, formState } = formMethods;
+  const { control, register, formState } = formMethods;
 
   const translatedActionStatuses = actionStatusOptions.map(actionStatus => ({
     value: actionStatus,
     /* @ts-ignore Because ts can't typecheck strings against our keys */
     renderedValue: t(`actionStatus.${actionStatus}`),
   }));
-
-  const currentActionDescription = watch(`actions.${index}.description`);
 
   return (
     <>
@@ -78,14 +80,20 @@ export function ActionFormItem({
           error={formState.errors?.actions?.[index]?.title !== undefined}
           label={t('dictionary.title')}
         />
-        <MarkdownInput
-          {...register(`actions.${index}.description`)}
-          label={t('dictionary.description')}
-          value={currentActionDescription}
-          onMarkdownChange={value =>
-            setValue(`actions.${index}.description`, value)
-          }
-          minRows={4}
+        <Controller
+          control={control}
+          name={`actions.${index}.description`}
+          rules={{ required: true }}
+          render={({ field: { onChange, value }, fieldState: { error } }) => (
+            <MarkdownInput
+              required
+              label={t('dictionary.description')}
+              value={value}
+              onMarkdownChange={onChange}
+              error={!!error}
+              minRows={4}
+            />
+          )}
         />
         <Box
           sx={{

--- a/plugins/ros/src/components/scenarioDrawer/components/ScopeFormSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ScopeFormSection.tsx
@@ -68,7 +68,6 @@ function ScopeFormSection({
       <Controller
         control={control}
         name="description"
-        rules={{ required: true }}
         render={({ field: { onChange, value }, fieldState: { error } }) => (
           <MarkdownInput
             value={value}

--- a/plugins/ros/src/components/scenarioDrawer/components/ScopeFormSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ScopeFormSection.tsx
@@ -1,4 +1,4 @@
-import { UseFormReturn } from 'react-hook-form';
+import { Controller, UseFormReturn } from 'react-hook-form';
 import { FormScenario } from '../../../utils/types';
 import { pluginRiScTranslationRef } from '../../../utils/translations';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
@@ -23,8 +23,6 @@ function ScopeFormSection({
   const {
     control,
     register,
-    setValue,
-    watch,
     formState: { errors },
   } = formMethods;
 
@@ -41,8 +39,6 @@ function ScopeFormSection({
       renderedValue: t(`vulnerabilities.${vulnerability}`),
     }),
   );
-
-  const currentDescription = watch('description');
 
   return (
     <Paper sx={section}>
@@ -69,12 +65,19 @@ function ScopeFormSection({
         labelTranslationKey="vulnerabilities"
         options={translatedVulnerabilities}
       />
-      <MarkdownInput
-        {...register('description')}
-        value={currentDescription}
-        onMarkdownChange={value => setValue('description', value)}
-        label={t('dictionary.description')}
-        minRows={4}
+      <Controller
+        control={control}
+        name="description"
+        rules={{ required: true }}
+        render={({ field: { onChange, value }, fieldState: { error } }) => (
+          <MarkdownInput
+            value={value}
+            onMarkdownChange={onChange}
+            label={t('dictionary.description')}
+            minRows={4}
+            error={!!error}
+          />
+        )}
       />
     </Paper>
   );


### PR DESCRIPTION
The MarkdownInput component wasn’t triggering state changes when using react-hook-form’s register, so changes weren’t detected and the save button stayed disabled.

**Solution:**
Switched to using the Controller from react-hook-form for the MarkdownInput. This update ensures that onChange events from MarkdownInput are correctly propagated to the form’s state.