### PR TITLE
Add remark breaks to React Markdown component to display newlines

### DIFF
--- a/plugins/ros/package.json
+++ b/plugins/ros/package.json
@@ -56,7 +56,8 @@
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
     "react-hook-form": "^7.55.0",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "remark-breaks": "^4.0.0"
   },
   "peerDependencies": {
     "react": "^18.0.0",

--- a/plugins/ros/src/components/common/Markdown.tsx
+++ b/plugins/ros/src/components/common/Markdown.tsx
@@ -1,6 +1,7 @@
 import Typography from '@mui/material/Typography';
 import ReactMarkdown from 'react-markdown';
 import 'github-markdown-css/github-markdown.css';
+import remarkBreaks from 'remark-breaks';
 
 type Props = {
   description: string;
@@ -9,7 +10,9 @@ type Props = {
 export function Markdown({ description }: Props) {
   return (
     <Typography className="markdown-body">
-      <ReactMarkdown>{description}</ReactMarkdown>
+      <ReactMarkdown remarkPlugins={[remarkBreaks]}>
+        {description}
+      </ReactMarkdown>
     </Typography>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7798,6 +7798,7 @@ __metadata:
     react-dnd-html5-backend: "npm:^16.0.1"
     react-hook-form: "npm:^7.55.0"
     react-markdown: "npm:^10.1.0"
+    remark-breaks: "npm:^4.0.0"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
@@ -27879,6 +27880,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-newline-to-break@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mdast-util-newline-to-break@npm:2.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-find-and-replace: "npm:^3.0.0"
+  checksum: 10c0/756a5660b0a821e0d6d6a0b2d9b13ac32e41cc028c485a91bccf6300977e2557236c6cc93dbd55c68b785f1ed6eae69209a4ffe182533cd1cdfda369021bebd2
+  languageName: node
+  linkType: hard
+
 "mdast-util-phrasing@npm:^3.0.0":
   version: 3.0.1
   resolution: "mdast-util-phrasing@npm:3.0.1"
@@ -33845,6 +33856,17 @@ __metadata:
   version: 0.2.7
   resolution: "relateurl@npm:0.2.7"
   checksum: 10c0/c248b4e3b32474f116a804b537fa6343d731b80056fb506dffd91e737eef4cac6be47a65aae39b522b0db9d0b1011d1a12e288d82a109ecd94a5299d82f6573a
+  languageName: node
+  linkType: hard
+
+"remark-breaks@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "remark-breaks@npm:4.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-newline-to-break: "npm:^2.0.0"
+    unified: "npm:^11.0.0"
+  checksum: 10c0/d7b319a7993b54c5d574e9255080c5de68cfa24f993873b0ee296af13f478521c41d4b7ae0fc14b4607ea70c8f6967e998ab7a467de13139141e66a1a34cb6be
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Single newlines were not rendered as actual newlines in the displayed Markdown. Users had to insert two newlines to achieve the desired spacing.

**Solution:** 
Added the remark-breaks plugin in ReactMarkdown. Now single newlines works, improving readability and user experience.

Before:
<img width="645" alt="Screenshot 2025-04-14 at 13 34 49" src="https://github.com/user-attachments/assets/29c2c58d-76e3-4d88-aea3-c1c7f9c4fc70" />

After:
<img width="641" alt="Screenshot 2025-04-14 at 13 34 02" src="https://github.com/user-attachments/assets/26a83618-f599-4055-932a-0d05b9e2a0b2" />
