### PR TITLE
🐛  fix for dark theme markdown

### DIFF
--- a/plugins/ros/src/components/common/Input.tsx
+++ b/plugins/ros/src/components/common/Input.tsx
@@ -4,6 +4,7 @@ import FormLabel from '@mui/material/FormLabel';
 import TextField, { TextFieldProps } from '@mui/material/TextField';
 import { forwardRef } from 'react';
 import { formHelperText, formLabel } from './typography';
+import { commonTextColor, formControlStyles } from '../../utils/style';
 
 type Props = TextFieldProps & {
   sublabel?: string;
@@ -12,11 +13,7 @@ type Props = TextFieldProps & {
 export const Input = forwardRef<HTMLInputElement, Props>(
   ({ label, sublabel, error, helperText, required, ...props }, ref) => {
     return (
-      <FormControl
-        sx={{ width: '100%', gap: '4px' }}
-        error={error}
-        required={required}
-      >
+      <FormControl sx={formControlStyles} error={error} required={required}>
         {label && (
           <FormLabel required={required} sx={formLabel}>
             {label}
@@ -35,7 +32,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(
           InputProps={{
             sx: theme => ({
               '&.Mui-disabled': {
-                color: theme.palette.mode === 'dark' ? '#FFFFFF80' : '#757575',
+                color: commonTextColor(theme, true),
               },
             }),
           }}

--- a/plugins/ros/src/components/common/Markdown.tsx
+++ b/plugins/ros/src/components/common/Markdown.tsx
@@ -3,6 +3,7 @@ import ReactMarkdown from 'react-markdown';
 import { useTheme } from '@mui/material/styles';
 import 'github-markdown-css/github-markdown.css';
 import remarkBreaks from 'remark-breaks';
+import { commonTextColor, commonBackgroundColor } from '../../utils/style';
 
 type Props = {
   description: string;
@@ -12,22 +13,12 @@ type Props = {
 export function Markdown({ description, disabled }: Props) {
   const theme = useTheme();
 
-  const textColor = disabled
-    ? theme.palette.mode === 'dark'
-      ? '#FFFFFF80'
-      : '#757575'
-    : 'inherit';
-
-  const backgroundColor = disabled
-    ? theme.palette.action.disabledBackground
-    : 'inherit';
-
   return (
     <Typography
       className="markdown-body"
       sx={{
-        color: textColor,
-        backgroundColor: backgroundColor,
+        color: commonTextColor(theme, disabled ?? false),
+        backgroundColor: commonBackgroundColor(theme, disabled ?? false),
       }}
     >
       <ReactMarkdown remarkPlugins={[remarkBreaks]}>

--- a/plugins/ros/src/components/common/Markdown.tsx
+++ b/plugins/ros/src/components/common/Markdown.tsx
@@ -1,14 +1,31 @@
 import Typography from '@mui/material/Typography';
 import ReactMarkdown from 'react-markdown';
+import { useTheme } from '@mui/material/styles';
 import 'github-markdown-css/github-markdown.css';
 
 type Props = {
   description: string;
+  disabled?: boolean;
 };
 
-export function Markdown({ description }: Props) {
+export function Markdown({ description, disabled }: Props) {
+  const theme = useTheme();
+
   return (
-    <Typography className="markdown-body">
+    <Typography
+      className="markdown-body"
+      sx={{
+        color: disabled
+          ? theme.palette.mode === 'dark'
+            ? '#FFFFFF80'
+            : '#757575'
+          : 'inherit',
+        backgroundColor: disabled
+          ? theme.palette.action.disabledBackground
+          : 'inherit',
+        cursor: disabled ? 'not-allowed' : 'text',
+      }}
+    >
       <ReactMarkdown>{description}</ReactMarkdown>
     </Typography>
   );

--- a/plugins/ros/src/components/common/Markdown.tsx
+++ b/plugins/ros/src/components/common/Markdown.tsx
@@ -12,19 +12,22 @@ type Props = {
 export function Markdown({ description, disabled }: Props) {
   const theme = useTheme();
 
+  const textColor = disabled
+    ? theme.palette.mode === 'dark'
+      ? '#FFFFFF80'
+      : '#757575'
+    : 'inherit';
+
+  const backgroundColor = disabled
+    ? theme.palette.action.disabledBackground
+    : 'inherit';
+
   return (
     <Typography
       className="markdown-body"
       sx={{
-        color: disabled
-          ? theme.palette.mode === 'dark'
-            ? '#FFFFFF80'
-            : '#757575'
-          : 'inherit',
-        backgroundColor: disabled
-          ? theme.palette.action.disabledBackground
-          : 'inherit',
-        cursor: disabled ? 'not-allowed' : 'text',
+        color: textColor,
+        backgroundColor: backgroundColor,
       }}
     >
       <ReactMarkdown remarkPlugins={[remarkBreaks]}>

--- a/plugins/ros/src/components/common/Markdown.tsx
+++ b/plugins/ros/src/components/common/Markdown.tsx
@@ -10,15 +10,15 @@ type Props = {
   disabled?: boolean;
 };
 
-export function Markdown({ description, disabled }: Props) {
+export function Markdown({ description, disabled = false }: Props) {
   const theme = useTheme();
 
   return (
     <Typography
       className="markdown-body"
       sx={{
-        color: commonTextColor(theme, disabled ?? false),
-        backgroundColor: commonBackgroundColor(theme, disabled ?? false),
+        color: commonTextColor(theme, disabled),
+        backgroundColor: commonBackgroundColor(theme, disabled),
       }}
     >
       <ReactMarkdown remarkPlugins={[remarkBreaks]}>

--- a/plugins/ros/src/components/common/MarkdownInput.tsx
+++ b/plugins/ros/src/components/common/MarkdownInput.tsx
@@ -6,6 +6,11 @@ import MDEditor from '@uiw/react-md-editor';
 import { formHelperText, formLabel } from './typography';
 import { TextFieldProps } from '@material-ui/core';
 import { useTheme } from '@mui/material/styles';
+import {
+  commonTextColor,
+  commonBackgroundColor,
+  formControlStyles,
+} from '../../utils/style';
 
 type Props = TextFieldProps & {
   sublabel?: string;
@@ -43,18 +48,8 @@ export const MarkdownInput = forwardRef<HTMLDivElement, Props>(
       onMarkdownChange?.(newValue || '');
     };
 
-    const textColor = disabled
-      ? theme.palette.mode === 'dark'
-        ? '#FFFFFF80'
-        : '#757575'
-      : 'inherit';
-
-    const backgroundColor = disabled
-      ? theme.palette.action.disabledBackground
-      : 'inherit';
-
     return (
-      <FormControl sx={{ width: '100%', gap: '4px' }} error={error}>
+      <FormControl sx={formControlStyles} error={error}>
         {label && <FormLabel sx={formLabel}>{label}</FormLabel>}
         {sublabel && (
           <FormHelperText sx={formHelperText}>{sublabel}</FormHelperText>
@@ -66,8 +61,8 @@ export const MarkdownInput = forwardRef<HTMLDivElement, Props>(
           preview="edit"
           height={minRows ? minRows * 24 : 64}
           style={{
-            color: textColor,
-            backgroundColor: backgroundColor,
+            color: commonTextColor(theme, disabled ?? false),
+            backgroundColor: commonBackgroundColor(theme, disabled ?? false),
           }}
         />
         {helperText && <FormHelperText>{helperText}</FormHelperText>}

--- a/plugins/ros/src/components/common/MarkdownInput.tsx
+++ b/plugins/ros/src/components/common/MarkdownInput.tsx
@@ -32,7 +32,7 @@ export const MarkdownInput = forwardRef<HTMLDivElement, Props>(
       value,
     );
 
-    const theme = useTheme(); // Access the theme for dynamic styling
+    const theme = useTheme();
 
     useEffect(() => {
       setMarkdownContent(value);

--- a/plugins/ros/src/components/common/MarkdownInput.tsx
+++ b/plugins/ros/src/components/common/MarkdownInput.tsx
@@ -43,6 +43,16 @@ export const MarkdownInput = forwardRef<HTMLDivElement, Props>(
       onMarkdownChange?.(newValue || '');
     };
 
+    const textColor = disabled
+      ? theme.palette.mode === 'dark'
+        ? '#FFFFFF80'
+        : '#757575'
+      : 'inherit';
+
+    const backgroundColor = disabled
+      ? theme.palette.action.disabledBackground
+      : 'inherit';
+
     return (
       <FormControl sx={{ width: '100%', gap: '4px' }} error={error}>
         {label && <FormLabel sx={formLabel}>{label}</FormLabel>}
@@ -56,15 +66,8 @@ export const MarkdownInput = forwardRef<HTMLDivElement, Props>(
           preview="edit"
           height={minRows ? minRows * 24 : 64}
           style={{
-            color: disabled
-              ? theme.palette.mode === 'dark'
-                ? '#FFFFFF80'
-                : '#757575'
-              : 'inherit',
-            backgroundColor: disabled
-              ? theme.palette.action.disabledBackground
-              : 'inherit',
-            cursor: disabled ? 'not-allowed' : 'text',
+            color: textColor,
+            backgroundColor: backgroundColor,
           }}
         />
         {helperText && <FormHelperText>{helperText}</FormHelperText>}

--- a/plugins/ros/src/components/common/MarkdownInput.tsx
+++ b/plugins/ros/src/components/common/MarkdownInput.tsx
@@ -5,6 +5,7 @@ import FormLabel from '@mui/material/FormLabel';
 import MDEditor from '@uiw/react-md-editor';
 import { formHelperText, formLabel } from './typography';
 import { TextFieldProps } from '@material-ui/core';
+import { useTheme } from '@mui/material/styles';
 
 type Props = TextFieldProps & {
   sublabel?: string;
@@ -24,12 +25,15 @@ export const MarkdownInput = forwardRef<HTMLDivElement, Props>(
       minRows,
       value,
       onMarkdownChange,
+      disabled,
     },
     ref,
   ) => {
     const [markdownContent, setMarkdownContent] = useState<string | undefined>(
       value,
     );
+
+    const theme = useTheme(); // Access the theme for dynamic styling
 
     useEffect(() => {
       setMarkdownContent(value);
@@ -60,6 +64,17 @@ export const MarkdownInput = forwardRef<HTMLDivElement, Props>(
           onChange={handleMarkdownChange}
           preview="edit"
           height={minRows ? minRows * 24 : 64}
+          style={{
+            color: disabled
+              ? theme.palette.mode === 'dark'
+                ? '#FFFFFF80'
+                : '#757575'
+              : 'inherit',
+            backgroundColor: disabled
+              ? theme.palette.action.disabledBackground
+              : 'inherit',
+            cursor: disabled ? 'not-allowed' : 'text',
+          }}
         />
         {helperText && <FormHelperText>{helperText}</FormHelperText>}
       </FormControl>

--- a/plugins/ros/src/components/common/MarkdownInput.tsx
+++ b/plugins/ros/src/components/common/MarkdownInput.tsx
@@ -29,7 +29,7 @@ export const MarkdownInput = forwardRef<HTMLDivElement, Props>(
       minRows,
       value,
       onMarkdownChange,
-      disabled,
+      disabled = false,
     },
     ref,
   ) => {
@@ -61,8 +61,8 @@ export const MarkdownInput = forwardRef<HTMLDivElement, Props>(
           preview="edit"
           height={minRows ? minRows * 24 : 64}
           style={{
-            color: commonTextColor(theme, disabled ?? false),
-            backgroundColor: commonBackgroundColor(theme, disabled ?? false),
+            color: commonTextColor(theme, disabled),
+            backgroundColor: commonBackgroundColor(theme, disabled),
           }}
         />
         {helperText && <FormHelperText>{helperText}</FormHelperText>}

--- a/plugins/ros/src/utils/style.ts
+++ b/plugins/ros/src/utils/style.ts
@@ -1,4 +1,5 @@
 import { makeStyles } from '@material-ui/core';
+import { Theme } from '@mui/material/styles';
 
 export const useFontStyles = makeStyles(theme => ({
   h1: {
@@ -42,7 +43,6 @@ export const useFontStyles = makeStyles(theme => ({
     textTransform: 'uppercase',
     color: theme.palette.type === 'dark' ? '#F8F8F8' : 'rgba(0, 0, 0, 0.87)',
   },
-
   subtitle1: {
     fontSize: theme.spacing(2),
     fontWeight: 700,
@@ -58,3 +58,19 @@ export const useFontStyles = makeStyles(theme => ({
     marginTop: '-0.2rem',
   },
 }));
+
+// Common styles for Input, MarkdownInput, and Markdown components
+export const commonTextColor = (theme: Theme, disabled: boolean) =>
+  disabled
+    ? theme.palette.mode === 'dark'
+      ? '#FFFFFF80'
+      : '#757575'
+    : 'inherit';
+
+export const commonBackgroundColor = (theme: Theme, disabled: boolean) =>
+  disabled ? theme.palette.action.disabledBackground : 'inherit';
+
+export const formControlStyles = {
+  width: '100%',
+  gap: '4px',
+};

--- a/plugins/ros/src/utils/style.ts
+++ b/plugins/ros/src/utils/style.ts
@@ -60,12 +60,12 @@ export const useFontStyles = makeStyles(theme => ({
 }));
 
 // Common styles for Input, MarkdownInput, and Markdown components
-export const commonTextColor = (theme: Theme, disabled: boolean) =>
-  disabled
-    ? theme.palette.mode === 'dark'
-      ? '#FFFFFF80'
-      : '#757575'
-    : 'inherit';
+export const commonTextColor = (theme: Theme, disabled: boolean) => {
+  if (disabled) {
+    return theme.palette.mode === 'dark' ? '#FFFFFF80' : '#757575';
+  }
+  return 'inherit';
+};
 
 export const commonBackgroundColor = (theme: Theme, disabled: boolean) =>
   disabled ? theme.palette.action.disabledBackground : 'inherit';


### PR DESCRIPTION
Bugfix to fix dark theme on markdown

## Before
<img width="914" alt="Screenshot 2025-04-14 at 19 10 00" src="https://github.com/user-attachments/assets/d8cb2af5-9ea0-4ce5-aefb-ae2e5f818bdc" />

## After
<img width="1047" alt="Screenshot 2025-04-14 at 19 08 22" src="https://github.com/user-attachments/assets/d80c72fb-d6b3-4301-934a-945191d96b12" />
<img width="1125" alt="Screenshot 2025-04-14 at 19 08 55" src="https://github.com/user-attachments/assets/d61bee2f-41bb-4056-b0b8-0221cfbc3929" />
