### PR TITLE
🐛 remove required description and add required title

### DIFF
--- a/plugins/ros/src/components/scenarioWizard/steps/ActionsStep.tsx
+++ b/plugins/ros/src/components/scenarioWizard/steps/ActionsStep.tsx
@@ -84,15 +84,12 @@ export function ActionsStep({
                 </Box>
 
                 <Input
-                  {...register(`actions.${index}.title`)}
+                  required
+                  {...register(`actions.${index}.title`, { required: true })}
                   label={t('dictionary.title')}
                 />
-
                 <MarkdownInput
-                  required
-                  {...register(`actions.${index}.description`, {
-                    required: true,
-                  })}
+                  {...register(`actions.${index}.description`)}
                   error={
                     formState.errors?.actions?.[index]?.description !==
                     undefined


### PR DESCRIPTION
Remove required description and add required title on action steps

## Before
<img width="927" alt="Screenshot 2025-04-15 at 17 44 12" src="https://github.com/user-attachments/assets/8278b0ec-9924-4a92-9ca8-6de6696c8544" />

## After 
<img width="919" alt="Screenshot 2025-04-15 at 17 41 37" src="https://github.com/user-attachments/assets/f393ee6f-096f-4afa-96fd-bdbbe638692a" />
<img width="846" alt="Screenshot 2025-04-15 at 17 42 08" src="https://github.com/user-attachments/assets/29b3c78d-1431-4048-acfb-1aea5e63f366" />

## Overview over what is required - only titles, scope and status
<img width="321" alt="Screenshot 2025-04-15 at 17 42 32" src="https://github.com/user-attachments/assets/e6813bd1-0c42-4e2d-8799-ba40b9ed78ba" />

