### PR TITLE
🪄 update design edit encryption

### DIFF
--- a/plugins/ros/src/components/riScDialog/ConfigEncryptionDialog.tsx
+++ b/plugins/ros/src/components/riScDialog/ConfigEncryptionDialog.tsx
@@ -81,6 +81,13 @@ function ConfigEncryptionDialog({
       return gcpCryptoKeys[0];
     });
 
+  const [isAddPublicAgeKeyVisible, setIsAddPublicAgeKeyVisible] =
+    useState(false);
+
+  function showAddPublicAgeKey() {
+    setIsAddPublicAgeKeyVisible(true);
+  }
+
   useEffect(() => {
     setValue('sopsConfig', {
       shamir_threshold: 2,
@@ -174,24 +181,36 @@ function ConfigEncryptionDialog({
                   {t('sopsConfigDialog.publicAgeKeysAlreadyPresent')}
                 </FormLabel>
               )}
-              <List>
-                {publicAgeKeys.map(key => (
-                  <ListItem key={key} dense>
-                    <ListItemText>{key}</ListItemText>
-                    <ListItemSecondaryAction>
-                      <IconButton
-                        onClick={() => {
-                          setPublicAgeKeys(
-                            publicAgeKeys.filter(k => k !== key),
-                          );
-                        }}
-                      >
-                        <DeleteIcon />
-                      </IconButton>
-                    </ListItemSecondaryAction>
-                  </ListItem>
-                ))}
-              </List>
+              {publicAgeKeys.length > 0 && (
+                <Box
+                  sx={{
+                    border: '1px solid',
+                    borderColor: theme =>
+                      theme.palette.mode === 'dark' ? 'white' : 'grey.300',
+                    borderRadius: '4px',
+                    marginBottom: 2,
+                  }}
+                >
+                  <List>
+                    {publicAgeKeys.map(key => (
+                      <ListItem key={key} dense>
+                        <ListItemText>{key}</ListItemText>
+                        <ListItemSecondaryAction>
+                          <IconButton
+                            onClick={() => {
+                              setPublicAgeKeys(
+                                publicAgeKeys.filter(k => k !== key),
+                              );
+                            }}
+                          >
+                            <DeleteIcon />
+                          </IconButton>
+                        </ListItemSecondaryAction>
+                      </ListItem>
+                    ))}
+                  </List>
+                </Box>
+              )}
               <Typography>
                 {t('dictionary.click')}{' '}
                 <Link
@@ -220,34 +239,57 @@ function ConfigEncryptionDialog({
                   gap: 2,
                 }}
               >
-                <TextField
-                  label={t('sopsConfigDialog.publicAgeKey')}
-                  helperText={publicAgeKeyHelperText}
-                  error={publicAgeKeyError}
-                  onKeyDown={e => {
-                    if (e.key === 'Enter') {
-                      handleAddPublicAgeKey();
-                    }
-                  }}
-                  onFocus={() => {
-                    setPublicKeyTextFieldError(false);
-                    setPublicKeyTextFieldHelperText('');
-                  }}
-                  value={newPublicAgeKey}
-                  onChange={e => setNewPublicAgeKey(e.target.value)}
-                />
-                <Button
-                  startIcon={<AddCircle />}
-                  variant="text"
-                  color="primary"
-                  onClick={handleAddPublicAgeKey}
-                  sx={{
-                    maxWidth: 200,
-                    mt: 1,
-                  }}
-                >
-                  {t('sopsConfigDialog.addPublicAgeKey')}
-                </Button>
+                {!isAddPublicAgeKeyVisible && (
+                  <Button
+                    startIcon={<AddCircle />}
+                    variant="text"
+                    color="primary"
+                    onClick={showAddPublicAgeKey}
+                    sx={{
+                      maxWidth: 200,
+                      mt: 1,
+                    }}
+                  >
+                    {t('sopsConfigDialog.addPublicAgeKey')}
+                  </Button>
+                )}
+                {isAddPublicAgeKeyVisible && (
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1,
+                    }}
+                  >
+                    <TextField
+                      label={t('sopsConfigDialog.publicAgeKey')}
+                      helperText={publicAgeKeyHelperText}
+                      error={publicAgeKeyError}
+                      onKeyDown={e => {
+                        if (e.key === 'Enter') {
+                          handleAddPublicAgeKey();
+                        }
+                      }}
+                      onFocus={() => {
+                        setPublicKeyTextFieldError(false);
+                        setPublicKeyTextFieldHelperText('');
+                      }}
+                      value={newPublicAgeKey}
+                      onChange={e => setNewPublicAgeKey(e.target.value)}
+                      sx={{ flex: 1 }}
+                    />
+                    <Button
+                      variant="contained"
+                      color="primary"
+                      onClick={handleAddPublicAgeKey}
+                      sx={{
+                        maxWidth: 200,
+                      }}
+                    >
+                      {t('sopsConfigDialog.addPublicAgeKey')}
+                    </Button>
+                  </Box>
+                )}
               </Box>
             </Box>
           </AccordionDetails>

--- a/plugins/ros/src/components/riScDialog/ConfigEncryptionDialog.tsx
+++ b/plugins/ros/src/components/riScDialog/ConfigEncryptionDialog.tsx
@@ -237,6 +237,7 @@ function ConfigEncryptionDialog({
                   flexDirection: 'column',
                   alignItems: 'space-between',
                   gap: 2,
+                  marginTop: 2,
                 }}
               >
                 {!isAddPublicAgeKeyVisible && (

--- a/plugins/ros/src/components/riScPlugin/RiScPlugin.tsx
+++ b/plugins/ros/src/components/riScPlugin/RiScPlugin.tsx
@@ -22,7 +22,7 @@ import MenuItem from '@mui/material/MenuItem';
 import ListItemText from '@mui/material/ListItemText';
 import { ScenarioWizardSteps } from '../../contexts/ScenarioContext';
 import { ScenarioTableWrapper } from '../scenarioTable/ScenarioTable';
-import { Edit } from '@mui/icons-material';
+import { Settings } from '@mui/icons-material';
 
 export function RiScPlugin() {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
@@ -138,7 +138,7 @@ export function RiScPlugin() {
                 </Button>
                 {selectedRiSc && (
                   <Button
-                    startIcon={<Edit />}
+                    startIcon={<Settings />}
                     variant="text"
                     color="primary"
                     onClick={openEditEncryptionDialog}

--- a/plugins/ros/src/components/sopsConfigDialog/GcpCryptoKeyMenu.tsx
+++ b/plugins/ros/src/components/sopsConfigDialog/GcpCryptoKeyMenu.tsx
@@ -53,6 +53,10 @@ export function GcpCryptoKeyMenu({
         position: 'relative',
         left: 0,
         marginTop: 1,
+        border: '1px solid',
+        borderColor: theme =>
+          theme.palette.mode === 'dark' ? 'white' : 'grey.300',
+        borderRadius: '4px',
       }}
     >
       <ListItemButton

--- a/plugins/ros/src/components/sopsConfigDialog/GcpCryptoKeyMenu.tsx
+++ b/plugins/ros/src/components/sopsConfigDialog/GcpCryptoKeyMenu.tsx
@@ -81,7 +81,16 @@ export function GcpCryptoKeyMenu({
         ) : (
           <>
             <ListItemAvatar>
-              <Avatar>
+              <Avatar
+                sx={{
+                  backgroundColor:
+                    chosenGcpCryptoKey.projectId !== ''
+                      ? 'primary.main'
+                      : 'default',
+                  color:
+                    chosenGcpCryptoKey.projectId !== '' ? 'white' : 'inherit',
+                }}
+              >
                 <VpnKey />
               </Avatar>
             </ListItemAvatar>

--- a/plugins/ros/src/components/sopsConfigDialog/GcpCryptoKeyMenu.tsx
+++ b/plugins/ros/src/components/sopsConfigDialog/GcpCryptoKeyMenu.tsx
@@ -88,13 +88,7 @@ export function GcpCryptoKeyMenu({
 
             <ListItemText
               primary={chosenGcpCryptoKey.keyName}
-              secondary={
-                <>
-                  Project ID: {chosenGcpCryptoKey.projectId}
-                  <br />
-                  Key ring: {chosenGcpCryptoKey.keyRing}
-                </>
-              }
+              secondary={<>Project ID: {chosenGcpCryptoKey.projectId}</>}
             />
             <ExpandMoreIcon sx={{ marginLeft: 'auto' }} />
             {!chosenGcpCryptoKey.hasEncryptDecryptAccess && (

--- a/plugins/ros/src/components/sopsConfigDialog/GcpCryptoKeyMenu.tsx
+++ b/plugins/ros/src/components/sopsConfigDialog/GcpCryptoKeyMenu.tsx
@@ -9,6 +9,7 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { pluginRiScTranslationRef } from '../../utils/translations';
 import AddIcon from '@mui/icons-material/Add';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { useState, MouseEvent } from 'react';
 
 interface GcpCryptoKeyMenuProps {
@@ -95,6 +96,7 @@ export function GcpCryptoKeyMenu({
                 </>
               }
             />
+            <ExpandMoreIcon sx={{ marginLeft: 'auto' }} />
             {!chosenGcpCryptoKey.hasEncryptDecryptAccess && (
               <>
                 <WarningAmberIcon sx={{ color: 'red' }} />

--- a/plugins/ros/src/components/sopsConfigDialog/GcpCryptoKeyMenu.tsx
+++ b/plugins/ros/src/components/sopsConfigDialog/GcpCryptoKeyMenu.tsx
@@ -134,6 +134,11 @@ export function GcpCryptoKeyMenu({
                   gcpCryptoKey={gcpCryptoKey}
                   handleClick={handleClickMenuItem}
                   hasAccess={hasAccess === 'true'}
+                  isSelected={
+                    gcpCryptoKey.projectId === chosenGcpCryptoKey.projectId &&
+                    gcpCryptoKey.keyRing === chosenGcpCryptoKey.keyRing &&
+                    gcpCryptoKey.keyName === chosenGcpCryptoKey.keyName
+                  }
                 />
               ))}
             </ul>

--- a/plugins/ros/src/components/sopsConfigDialog/GcpCryptoKeyMenuItem.tsx
+++ b/plugins/ros/src/components/sopsConfigDialog/GcpCryptoKeyMenuItem.tsx
@@ -26,9 +26,9 @@ export function GcpCryptoKeyMenuItem({
       onClick={() => handleClick(JSON.parse(value) as GcpCryptoKeyObject)}
       disabled={!hasAccess}
       sx={{
-        backgroundColor: isSelected ? 'green.100' : 'inherit',
+        backgroundColor: isSelected ? 'inherit' : undefined,
         '&:hover': {
-          backgroundColor: isSelected ? 'green.200' : 'grey.100',
+          backgroundColor: isSelected ? 'inherit' : 'grey.100',
         },
       }}
     >
@@ -37,13 +37,7 @@ export function GcpCryptoKeyMenuItem({
       </ListItemAvatar>
       <ListItemText
         primary={gcpCryptoKey.keyName}
-        secondary={
-          <>
-            Project ID: {gcpCryptoKey.projectId}
-            <br />
-            Key ring: {gcpCryptoKey.keyRing}
-          </>
-        }
+        secondary={<>Project ID: {gcpCryptoKey.projectId}</>}
       />
     </MenuItem>
   );

--- a/plugins/ros/src/components/sopsConfigDialog/GcpCryptoKeyMenuItem.tsx
+++ b/plugins/ros/src/components/sopsConfigDialog/GcpCryptoKeyMenuItem.tsx
@@ -1,9 +1,8 @@
 import MenuItem from '@mui/material/MenuItem';
-
-import { VpnKey } from '@mui/icons-material';
+import { VpnKey, Check } from '@mui/icons-material';
 import { GcpCryptoKeyObject } from '../../utils/DTOs';
 import ListItemAvatar from '@mui/material/ListItemAvatar';
-import { Avatar, Tooltip } from '@mui/material';
+import { Avatar } from '@mui/material';
 import ListItemText from '@mui/material/ListItemText';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { pluginRiScTranslationRef } from '../../utils/translations';
@@ -13,6 +12,7 @@ interface GcpCryptoKeyMenuItemProps {
   gcpCryptoKey: GcpCryptoKeyObject;
   handleClick: (gcpCryptoKey: GcpCryptoKeyObject) => void;
   hasAccess: boolean;
+  isSelected: boolean;
 }
 
 export function GcpCryptoKeyMenuItem({
@@ -20,35 +20,35 @@ export function GcpCryptoKeyMenuItem({
   gcpCryptoKey,
   handleClick,
   hasAccess,
+  isSelected,
 }: GcpCryptoKeyMenuItemProps) {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
 
   return (
-    <Tooltip
-      title={t('sopsConfigDialog.gcpKeyDoNotHaveAccessDescription')}
-      disableHoverListener={hasAccess}
+    <MenuItem
+      value={value}
+      onClick={() => handleClick(JSON.parse(value) as GcpCryptoKeyObject)}
+      disabled={!hasAccess}
+      sx={{
+        backgroundColor: isSelected ? 'green.100' : 'inherit',
+        '&:hover': {
+          backgroundColor: isSelected ? 'green.200' : 'grey.100',
+        },
+      }}
     >
-      <MenuItem
-        value={value}
-        onClick={() => handleClick(JSON.parse(value) as GcpCryptoKeyObject)}
-        disabled={!hasAccess}
-      >
-        <ListItemAvatar>
-          <Avatar>
-            <VpnKey />
-          </Avatar>
-        </ListItemAvatar>
-        <ListItemText
-          primary={gcpCryptoKey.keyName}
-          secondary={
-            <>
-              Project ID: {gcpCryptoKey.projectId}
-              <br />
-              Key ring: {gcpCryptoKey.keyRing}
-            </>
-          }
-        />
-      </MenuItem>
-    </Tooltip>
+      <ListItemAvatar>
+        <Avatar>{isSelected ? <Check /> : <VpnKey />} </Avatar>
+      </ListItemAvatar>
+      <ListItemText
+        primary={gcpCryptoKey.keyName}
+        secondary={
+          <>
+            Project ID: {gcpCryptoKey.projectId}
+            <br />
+            Key ring: {gcpCryptoKey.keyRing}
+          </>
+        }
+      />
+    </MenuItem>
   );
 }

--- a/plugins/ros/src/components/sopsConfigDialog/GcpCryptoKeyMenuItem.tsx
+++ b/plugins/ros/src/components/sopsConfigDialog/GcpCryptoKeyMenuItem.tsx
@@ -4,8 +4,6 @@ import { GcpCryptoKeyObject } from '../../utils/DTOs';
 import ListItemAvatar from '@mui/material/ListItemAvatar';
 import { Avatar } from '@mui/material';
 import ListItemText from '@mui/material/ListItemText';
-import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
-import { pluginRiScTranslationRef } from '../../utils/translations';
 
 interface GcpCryptoKeyMenuItemProps {
   value: string;
@@ -22,8 +20,6 @@ export function GcpCryptoKeyMenuItem({
   hasAccess,
   isSelected,
 }: GcpCryptoKeyMenuItemProps) {
-  const { t } = useTranslationRef(pluginRiScTranslationRef);
-
   return (
     <MenuItem
       value={value}

--- a/plugins/ros/src/components/sopsConfigDialog/GcpCryptoKeyMenuItem.tsx
+++ b/plugins/ros/src/components/sopsConfigDialog/GcpCryptoKeyMenuItem.tsx
@@ -1,5 +1,5 @@
 import MenuItem from '@mui/material/MenuItem';
-import { VpnKey, Check } from '@mui/icons-material';
+import { VpnKey } from '@mui/icons-material';
 import { GcpCryptoKeyObject } from '../../utils/DTOs';
 import ListItemAvatar from '@mui/material/ListItemAvatar';
 import { Avatar } from '@mui/material';
@@ -33,7 +33,14 @@ export function GcpCryptoKeyMenuItem({
       }}
     >
       <ListItemAvatar>
-        <Avatar>{isSelected ? <Check /> : <VpnKey />} </Avatar>
+        <Avatar
+          sx={{
+            backgroundColor: isSelected ? 'primary.main' : 'default',
+            color: isSelected ? 'white' : 'inherit',
+          }}
+        >
+          <VpnKey />
+        </Avatar>
       </ListItemAvatar>
       <ListItemText
         primary={gcpCryptoKey.keyName}


### PR DESCRIPTION
🪄 An attempt to make small changes to make the edit encryption popup more user friendly:
- [x] Added borders to keys and age keys 
- [x] Added expandable icon to key to make it look more clickable 
- [x] Hide "add new public key" behind a button - reduce information overload
- [x] Chosen key has a blue key icon instead of looking like the other keys
- [x] Added more spacing 
- [x] Removed information "Key ring: ..."

## Before 
<img width="702" alt="Screenshot 2025-04-15 at 19 07 10" src="https://github.com/user-attachments/assets/f00c8095-f082-42ca-ac0d-512873f7f13f" />
<img width="700" alt="Screenshot 2025-04-15 at 19 07 29" src="https://github.com/user-attachments/assets/2e656675-5da3-4bc0-86c7-ed34b7e39d98" />


## 🪄 After

### Button 
<img width="234" alt="Screenshot 2025-04-16 at 08 57 52" src="https://github.com/user-attachments/assets/8de31d3d-cc5f-40b9-84d1-01d0fc32fbb5" />


### Light mode
<img width="682" alt="Screenshot 2025-04-22 at 12 58 18" src="https://github.com/user-attachments/assets/c1870cce-cd8d-41f7-8369-cfdcceed45f0" />
<img width="686" alt="Screenshot 2025-04-22 at 12 58 31" src="https://github.com/user-attachments/assets/9b4b6912-db8d-434e-a982-cc23dc77b3ef" />


### Dark mode
<img width="661" alt="Screenshot 2025-04-22 at 12 57 30" src="https://github.com/user-attachments/assets/873527a7-1ea6-410c-ac91-8d284dd00ef1" />
