### PR TITLE
Cleanup accept risk - do not show empty sections

### DIFF
--- a/plugins/ros/src/components/riScInfo/riScStatus/DifferenceText.tsx
+++ b/plugins/ros/src/components/riScInfo/riScStatus/DifferenceText.tsx
@@ -1,10 +1,77 @@
+import React from 'react';
 import { DifferenceFetchState } from '../../../utils/types';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import Typography from '@mui/material/Typography';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { pluginRiScTranslationRef } from '../../../utils/translations';
-import React from 'react';
+
+function renderListItems(
+  items: string[],
+  _processItem: (item: string) => Record<string, any> | string,
+) {
+  const processedItems = items.reduce(
+    (acc: Record<string, any>, entry) => {
+      const [path, value] = entry.split(': ');
+      const keys = path.split('/');
+      keys.shift();
+      let current: Record<string, any> = acc;
+
+      keys.forEach((key, index) => {
+        if (!current[key]) {
+          current[key] = index === keys.length - 1 ? JSON.parse(value) : {};
+        }
+        current = current[key];
+      });
+
+      return acc;
+    },
+    {} as Record<string, any>,
+  );
+
+  return Object.entries(processedItems).map(([key, value]) => (
+    <ListItem
+      key={key}
+      sx={{
+        display: 'block',
+        marginLeft: '26px',
+        paddingTop: '4px',
+        paddingBottom: '4px',
+      }}
+    >
+      <Typography sx={{ marginBottom: '4px' }}>
+        {key}:{' '}
+        {typeof value === 'object' ? (
+          <br />
+        ) : (
+          String(value).replace(/[{}"]/g, '')
+        )}
+      </Typography>
+      {typeof value === 'object' && value
+        ? Object.entries(value).map(([subKey, subValue]) => (
+            <Typography
+              key={subKey}
+              sx={{ marginLeft: '16px', marginBottom: '4px' }}
+            >
+              <strong>{subKey}:</strong>{' '}
+              {typeof subValue === 'object' && subValue !== null
+                ? JSON.stringify(subValue, null, 2)
+                    .replace(/[{}"]/g, '')
+                    .replace(/,/g, '\n')
+                    .split('\n')
+                    .map((line, index) => (
+                      <React.Fragment key={index}>
+                        {line}
+                        <br />
+                      </React.Fragment>
+                    ))
+                : String(subValue).replace(/[{}"]/g, '')}
+            </Typography>
+          ))
+        : null}
+    </ListItem>
+  ));
+}
 
 type DifferenceTextProps = {
   differenceFetchState: DifferenceFetchState;
@@ -40,19 +107,10 @@ export function DifferenceText({ differenceFetchState }: DifferenceTextProps) {
             </Typography>
           </ListItem>
         )}
-        {differenceFetchState.differenceState.entriesOnLeft.map(item => (
-          <ListItem
-            key={item}
-            sx={{
-              display: 'list-item',
-              marginLeft: '26px',
-              paddingTop: '4px',
-              paddingBottom: '4px',
-            }}
-          >
-            <Typography>{item}</Typography>
-          </ListItem>
-        ))}
+        {renderListItems(
+          differenceFetchState.differenceState.entriesOnLeft,
+          item => item,
+        )}
       </List>
       <Typography
         sx={{
@@ -116,68 +174,10 @@ export function DifferenceText({ differenceFetchState }: DifferenceTextProps) {
             </Typography>
           </ListItem>
         )}
-        {Object.entries(
-          differenceFetchState.differenceState.entriesOnRight.reduce(
-            (acc: Record<string, any>, entry) => {
-              const [path, value] = entry.split(': ');
-              const keys = path.split('/');
-              keys.shift();
-              let current: Record<string, any> = acc;
-
-              keys.forEach((key, index) => {
-                if (!current[key]) {
-                  current[key] =
-                    index === keys.length - 1 ? JSON.parse(value) : {};
-                }
-                current = current[key];
-              });
-
-              return acc;
-            },
-            {} as Record<string, any>,
-          ),
-        ).map(([key, value]) => (
-          <ListItem
-            key={key}
-            sx={{
-              display: 'block',
-              marginLeft: '26px',
-              paddingTop: '4px',
-              paddingBottom: '4px',
-            }}
-          >
-            <Typography sx={{ marginBottom: '4px' }}>
-              {key}:{' '}
-              {typeof value === 'object' ? (
-                <br />
-              ) : (
-                String(value).replace(/[{}"]/g, '')
-              )}
-            </Typography>
-            {typeof value === 'object' && value
-              ? Object.entries(value).map(([subKey, subValue]) => (
-                  <Typography
-                    key={subKey}
-                    sx={{ marginLeft: '16px', marginBottom: '4px' }}
-                  >
-                    <strong>{subKey}:</strong>{' '}
-                    {typeof subValue === 'object' && subValue !== null
-                      ? JSON.stringify(subValue, null, 2)
-                          .replace(/[{}"]/g, '')
-                          .replace(/,/g, '\n')
-                          .split('\n')
-                          .map((line, index) => (
-                            <React.Fragment key={index}>
-                              {line}
-                              <br />
-                            </React.Fragment>
-                          ))
-                      : String(subValue).replace(/[{}"]/g, '')}
-                  </Typography>
-                ))
-              : null}
-          </ListItem>
-        ))}
+        {renderListItems(
+          differenceFetchState.differenceState.entriesOnRight,
+          entry => entry,
+        )}
       </List>
     </>
   );


### PR DESCRIPTION
Remove empty sections to reduce the length of the "receipt"

## Before 
<img width="628" alt="Screenshot 2025-04-16 at 12 39 57" src="https://github.com/user-attachments/assets/26154c6d-af40-4a0a-849f-ed244c96ce50" />


## After
<img width="586" alt="Screenshot 2025-04-16 at 12 39 34" src="https://github.com/user-attachments/assets/3fe798d5-f0f8-4a91-a9e6-baf0a2f72897" />
