### PR TITLE
🧹 remove section when empty in accept risks

### DIFF
--- a/plugins/ros/src/components/riScInfo/riScStatus/DifferenceText.tsx
+++ b/plugins/ros/src/components/riScInfo/riScStatus/DifferenceText.tsx
@@ -13,121 +13,91 @@ export function DifferenceText({ differenceFetchState }: DifferenceTextProps) {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
   return (
     <>
-      <Typography
-        sx={{
-          fontWeight: 700,
-          paddingBottom: '4px',
-        }}
-      >
-        {t('rosStatus.difference.differences.titleRemoved')}
-      </Typography>
-      <List
-        sx={{ paddingBottom: '40px', paddingTop: 0, listStyleType: 'disc' }}
-      >
-        {differenceFetchState.differenceState.entriesOnLeft.length === 0 && (
-          <ListItem
+      {differenceFetchState.differenceState.entriesOnLeft.length !== 0 && (
+        <>
+          <Typography
             sx={{
-              display: 'list-item',
-              marginLeft: '26px',
-              paddingTop: '4px',
+              fontWeight: 700,
               paddingBottom: '4px',
             }}
           >
-            <Typography>
-              {t('rosStatus.difference.differences.noneRemoved')}
-            </Typography>
-          </ListItem>
-        )}
-        {differenceFetchState.differenceState.entriesOnLeft.map(item => (
-          <ListItem
-            key={item}
+            {t('rosStatus.difference.differences.titleRemoved')}
+          </Typography>
+          <List
+            sx={{ paddingBottom: '40px', paddingTop: 0, listStyleType: 'disc' }}
+          >
+            {differenceFetchState.differenceState.entriesOnLeft.map(item => (
+              <ListItem
+                key={item}
+                sx={{
+                  display: 'list-item',
+                  marginLeft: '26px',
+                  paddingTop: '4px',
+                  paddingBottom: '4px',
+                }}
+              >
+                <Typography>{item}</Typography>
+              </ListItem>
+            ))}
+          </List>
+        </>
+      )}
+      {differenceFetchState.differenceState.difference.length !== 0 && (
+        <>
+          <Typography
             sx={{
-              display: 'list-item',
-              marginLeft: '26px',
-              paddingTop: '4px',
+              fontWeight: 700,
               paddingBottom: '4px',
             }}
           >
-            <Typography>{item}</Typography>
-          </ListItem>
-        ))}
-      </List>
-      <Typography
-        sx={{
-          fontWeight: 700,
-          paddingBottom: '4px',
-        }}
-      >
-        {t('rosStatus.difference.differences.titleExisting')}
-      </Typography>
-      <List
-        sx={{ paddingBottom: '40px', paddingTop: 0, listStyleType: 'disc' }}
-      >
-        {differenceFetchState.differenceState.difference.length === 0 && (
-          <ListItem
+            {t('rosStatus.difference.differences.titleExisting')}
+          </Typography>
+          <List
+            sx={{ paddingBottom: '40px', paddingTop: 0, listStyleType: 'disc' }}
+          >
+            {differenceFetchState.differenceState.difference.map(item => (
+              <ListItem
+                key={item}
+                sx={{
+                  display: 'list-item',
+                  marginLeft: '26px',
+                  paddingTop: '4px',
+                  paddingBottom: '4px',
+                }}
+              >
+                <Typography>{item}</Typography>
+              </ListItem>
+            ))}
+          </List>
+        </>
+      )}
+      {differenceFetchState.differenceState.entriesOnRight.length !== 0 && (
+        <>
+          <Typography
             sx={{
-              display: 'list-item',
-              marginLeft: '26px',
-              paddingTop: '4px',
+              fontWeight: 700,
               paddingBottom: '4px',
             }}
           >
-            <Typography>
-              {t('rosStatus.difference.differences.noneExisting')}
-            </Typography>
-          </ListItem>
-        )}
-        {differenceFetchState.differenceState.difference.map(item => (
-          <ListItem
-            key={item}
-            sx={{
-              display: 'list-item',
-              marginLeft: '26px',
-              paddingTop: '4px',
-              paddingBottom: '4px',
-            }}
-          >
-            <Typography>{item}</Typography>
-          </ListItem>
-        ))}
-      </List>
-      <Typography
-        sx={{
-          fontWeight: 700,
-          paddingBottom: '4px',
-        }}
-      >
-        {t('rosStatus.difference.differences.titleAdded')}
-      </Typography>
-      <List sx={{ listStyleType: 'disc', paddingTop: 0 }}>
-        {differenceFetchState.differenceState.entriesOnRight.length === 0 && (
-          <ListItem
-            sx={{
-              display: 'list-item',
-              marginLeft: '26px',
-              paddingTop: '4px',
-              paddingBottom: '4px',
-            }}
-          >
-            <Typography>
-              {t('rosStatus.difference.differences.noneAdded')}
-            </Typography>
-          </ListItem>
-        )}
-        {differenceFetchState.differenceState.entriesOnRight.map(item => (
-          <ListItem
-            key={item}
-            sx={{
-              display: 'list-item',
-              marginLeft: '26px',
-              paddingTop: '4px',
-              paddingBottom: '4px',
-            }}
-          >
-            <Typography>{item}</Typography>
-          </ListItem>
-        ))}
-      </List>
+            {t('rosStatus.difference.differences.titleAdded')}
+          </Typography>
+          <List sx={{ listStyleType: 'disc', paddingTop: 0 }}>
+            {differenceFetchState.differenceState.entriesOnRight.map(item => (
+              <ListItem
+                key={item}
+                sx={{
+                  display: 'list-item',
+                  marginLeft: '26px',
+                  paddingTop: '4px',
+                  paddingBottom: '4px',
+                }}
+              >
+                <Typography>{item}</Typography>
+              </ListItem>
+            ))}
+          </List>
+        </>
+      )}
     </>
   );
 }


### PR DESCRIPTION
🧾 Remove empty sections to reduce the length of the "receipt"

## Before 
<img width="628" alt="Screenshot 2025-04-16 at 12 39 57" src="https://github.com/user-attachments/assets/26154c6d-af40-4a0a-849f-ed244c96ce50" />


## After
<img width="586" alt="Screenshot 2025-04-16 at 12 39 34" src="https://github.com/user-attachments/assets/3fe798d5-f0f8-4a91-a9e6-baf0a2f72897" />
