### PR TITLE
🗑️  add functionality to delete risc

### DIFF
--- a/plugins/ros/src/components/riScDialog/RiScDialog.tsx
+++ b/plugins/ros/src/components/riScDialog/RiScDialog.tsx
@@ -120,7 +120,7 @@ export function RiScDialog({ onClose, dialogState }: RiScDialogProps) {
     if (dialogState === RiScDialogStates.Create) {
       createNewRiSc(data, createRiScFrom === CreateRiScFrom.Default);
     } else if (dialogState === RiScDialogStates.Delete) {
-      deleteRiSc(data);
+      deleteRiSc();
     } else {
       // Do manual comparison of contents, as the sopsConfig field contains many values from the backend that are not
       // used or set by the frontend.

--- a/plugins/ros/src/components/riScDialog/RiScDialog.tsx
+++ b/plugins/ros/src/components/riScDialog/RiScDialog.tsx
@@ -21,6 +21,7 @@ export enum RiScDialogStates {
   Create = 1,
   EditRiscInfo = 2,
   EditEncryption = 3,
+  Delete = 4,
 }
 
 interface RiScDialogProps {
@@ -117,6 +118,8 @@ export function RiScDialog({ onClose, dialogState }: RiScDialogProps) {
   const handleFinish = handleSubmit((data: RiScWithMetadata) => {
     if (dialogState === RiScDialogStates.Create) {
       createNewRiSc(data, createRiScFrom === CreateRiScFrom.Default);
+    } else if (dialogState === RiScDialogStates.Delete) {
+      deleteRiSc(data);
     } else {
       // Do manual comparison of contents, as the sopsConfig field contains many values from the backend that are not
       // used or set by the frontend.
@@ -203,6 +206,25 @@ export function RiScDialog({ onClose, dialogState }: RiScDialogProps) {
               {t('dictionary.save')}
             </Button>
           )}
+        </DialogActions>
+      </Dialog>
+    );
+  }
+
+  if (dialogState === RiScDialogStates.Delete) {
+    return (
+      <Dialog open={true} onClose={onClose}>
+        <DialogTitle>{t('deleteDialog.title')}</DialogTitle>
+        <DialogContent>
+          <DialogContent>{t('deleteDialog.confirmationMessage')}</DialogContent>
+        </DialogContent>
+        <DialogActions>
+          <Button variant="outlined" onClick={onClose}>
+            {t('dictionary.cancel')}
+          </Button>
+          <Button variant="contained" onClick={handleFinish}>
+            {t('dictionary.delete')}
+          </Button>
         </DialogActions>
       </Dialog>
     );

--- a/plugins/ros/src/components/riScDialog/RiScDialog.tsx
+++ b/plugins/ros/src/components/riScDialog/RiScDialog.tsx
@@ -60,7 +60,8 @@ function RiScStepper({
 
 export function RiScDialog({ onClose, dialogState }: RiScDialogProps) {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
-  const { selectedRiSc, createNewRiSc, updateRiSc, gcpCryptoKeys } = useRiScs();
+  const { selectedRiSc, createNewRiSc, deleteRiSc, updateRiSc, gcpCryptoKeys } =
+    useRiScs();
 
   const {
     register,

--- a/plugins/ros/src/components/riScInfo/PublishDialog.tsx
+++ b/plugins/ros/src/components/riScInfo/PublishDialog.tsx
@@ -15,6 +15,7 @@ import { dialogActions } from '../common/mixins';
 
 interface RiScPublishDialogProps {
   openDialog: boolean;
+  isDeletion: boolean;
   handleCancel: () => void;
   handlePublish: () => void;
   differenceFetchState: DifferenceFetchState;
@@ -22,6 +23,7 @@ interface RiScPublishDialogProps {
 
 export const RiScPublishDialog = ({
   openDialog,
+  isDeletion,
   handleCancel,
   handlePublish,
   differenceFetchState,
@@ -36,10 +38,16 @@ export const RiScPublishDialog = ({
 
   return (
     <Dialog open={openDialog}>
-      <DialogTitle>{t('publishDialog.title')}</DialogTitle>
+      <DialogTitle>
+        {isDeletion
+          ? t('publishDialog.titleDelete')
+          : t('publishDialog.titleUpdate')}
+      </DialogTitle>
       <DialogContent>
         <>
-          <RiScDifferenceDialog differenceFetchState={differenceFetchState} />
+          {!isDeletion && (
+            <RiScDifferenceDialog differenceFetchState={differenceFetchState} />
+          )}
           <Alert severity="info" icon={false}>
             <FormControlLabel
               control={
@@ -49,7 +57,11 @@ export const RiScPublishDialog = ({
                   onChange={handleCheckboxInput}
                 />
               }
-              label={t('publishDialog.checkboxLabel')}
+              label={
+                isDeletion
+                  ? t('publishDialog.checkboxLabelDelete')
+                  : t('publishDialog.checkboxLabelUpdate')
+              }
             />
           </Alert>
         </>

--- a/plugins/ros/src/components/riScInfo/riScStatus/Progress.tsx
+++ b/plugins/ros/src/components/riScInfo/riScStatus/Progress.tsx
@@ -1,20 +1,18 @@
 import { CircularProgressProps } from '@mui/material/CircularProgress';
 import { LinearProgress } from '@material-ui/core';
+import { RiScStatusEnum, RiScStatusEnumType } from './utils.ts';
 
-function CircularProgressWithLabel(
-  props: CircularProgressProps & { step: number },
-) {
-  const progress = props.step * 33.33;
+function Progress(props: CircularProgressProps & { step: RiScStatusEnumType }) {
+  const progress = {
+    [RiScStatusEnum.CREATED]: 0,
+    [RiScStatusEnum.DRAFT]: 33.33,
+    [RiScStatusEnum.DELETION_DRAFT]: 33.33,
+    [RiScStatusEnum.WAITING]: 66.67,
+    [RiScStatusEnum.DELETION_WAITING]: 66.67,
+    [RiScStatusEnum.PUBLISHED]: 100,
+  }[props.step];
 
   return <LinearProgress variant="determinate" value={progress} />;
-}
-
-interface CircularWithValueLabelProps {
-  step: 0 | 1 | 2 | 3;
-}
-
-function Progress({ step }: CircularWithValueLabelProps) {
-  return <CircularProgressWithLabel step={step} />;
 }
 
 export default Progress;

--- a/plugins/ros/src/components/riScInfo/riScStatus/RiScStatusComponent.tsx
+++ b/plugins/ros/src/components/riScInfo/riScStatus/RiScStatusComponent.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 import {
   DifferenceFetchState,
+  DifferenceStatus,
   RiScStatus,
   RiScWithMetadata,
-  DifferenceStatus,
 } from '../../../utils/types';
 import Button from '@mui/material/Button';
 import Link from '@mui/material/Link';
@@ -35,6 +35,7 @@ import {
 } from '../../../utils/utilityfunctions';
 import { RiScStatusEnum, RiScStatusEnumType, StatusIconMapType } from './utils';
 import { StatusIconWithText } from './StatusIconWithText';
+import DeleteIcon from '@mui/icons-material/Delete';
 
 const emptyDifferenceFetchState: DifferenceFetchState = {
   differenceState: {
@@ -147,7 +148,11 @@ export function RiScStatusComponent({
   );
 
   useEffect(() => {
-    if (selectedRiSc.content.scenarios.length === 0) {
+    if (selectedRiSc.status === RiScStatus.DeletionDraft) {
+      setStatus(RiScStatusEnum.DELETION_DRAFT);
+    } else if (selectedRiSc.status === RiScStatus.DeletionSentForApproval) {
+      setStatus(RiScStatusEnum.DELETION_WAITING);
+    } else if (selectedRiSc.content.scenarios.length === 0) {
       setStatus(RiScStatusEnum.CREATED);
     } else if (selectedRiSc.status === RiScStatus.Draft) {
       setStatus(RiScStatusEnum.DRAFT);
@@ -199,6 +204,14 @@ export function RiScStatusComponent({
       icon: CheckCircleOutlineIcon,
       text: t('rosStatus.statusBadge.published'),
     },
+    [RiScStatusEnum.DELETION_DRAFT]: {
+      icon: DeleteIcon,
+      text: t('rosStatus.statusBadge.draftDeletion'),
+    },
+    [RiScStatusEnum.DELETION_WAITING]: {
+      icon: DeleteIcon,
+      text: t('rosStatus.statusBadge.waitingDeletion'),
+    },
   };
 
   return (
@@ -235,7 +248,13 @@ export function RiScStatusComponent({
                 {t('rosStatus.statusBadge.missing')}
               </Typography>
             )}
-            {status === RiScStatusEnum.WAITING && (
+            {status === RiScStatusEnum.DELETION_DRAFT && (
+              <Typography paragraph variant="subtitle1" ml={5} align="right">
+                {t('rosStatus.statusBadge.deletionApproval')}
+              </Typography>
+            )}
+            {(status === RiScStatusEnum.WAITING ||
+              status === RiScStatusEnum.DELETION_WAITING) && (
               <Typography
                 paragraph
                 variant="subtitle1"
@@ -247,7 +266,10 @@ export function RiScStatusComponent({
                 <Link target="_blank" href={selectedRiSc.pullRequestUrl}>
                   Github
                 </Link>
-                {t('rosStatus.prStatus2')}
+                {status === RiScStatusEnum.WAITING &&
+                  t('rosStatus.prStatus2Update')}
+                {status === RiScStatusEnum.DELETION_WAITING &&
+                  t('rosStatus.prStatus2Delete')}
               </Typography>
             )}
             {status === RiScStatusEnum.PUBLISHED && (
@@ -262,7 +284,8 @@ export function RiScStatusComponent({
               </Typography>
             )}
           </Box>
-          {status === RiScStatusEnum.DRAFT && (
+          {(status === RiScStatusEnum.DRAFT ||
+            status === RiScStatusEnum.DELETION_DRAFT) && (
             <>
               <Button
                 color="primary"
@@ -270,10 +293,14 @@ export function RiScStatusComponent({
                 onClick={handleOpenPublishRiScDialog}
                 sx={{ display: 'block', marginLeft: 'auto' }}
               >
-                {t('rosStatus.approveButton')}
+                {status === RiScStatusEnum.DRAFT &&
+                  t('rosStatus.approveButtonUpdate')}
+                {status === RiScStatusEnum.DELETION_DRAFT &&
+                  t('rosStatus.approveButtonDelete')}
               </Button>
               <RiScPublishDialog
                 openDialog={publishRiScDialogIsOpen}
+                isDeletion={status === RiScStatusEnum.DELETION_DRAFT}
                 handlePublish={handleApproveAndPublish}
                 handleCancel={handleClosePublishRiScDialog}
                 differenceFetchState={differenceFetchState}

--- a/plugins/ros/src/components/riScInfo/riScStatus/utils.ts
+++ b/plugins/ros/src/components/riScInfo/riScStatus/utils.ts
@@ -3,6 +3,8 @@ export const RiScStatusEnum = {
   DRAFT: 1,
   WAITING: 2,
   PUBLISHED: 3,
+  DELETION_DRAFT: 4,
+  DELETION_WAITING: 5,
 } as const;
 
 export type RiScStatusEnumType =

--- a/plugins/ros/src/components/riScPlugin/RiScPlugin.tsx
+++ b/plugins/ros/src/components/riScPlugin/RiScPlugin.tsx
@@ -22,8 +22,8 @@ import MenuItem from '@mui/material/MenuItem';
 import ListItemText from '@mui/material/ListItemText';
 import { ScenarioWizardSteps } from '../../contexts/ScenarioContext';
 import { ScenarioTableWrapper } from '../scenarioTable/ScenarioTable';
-import { Settings } from '@mui/icons-material';
-import { Delete } from '@mui/icons-material';
+import { Delete, Settings } from '@mui/icons-material';
+import { RiScStatus } from '../../utils/types';
 
 export function RiScPlugin() {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
@@ -143,26 +143,29 @@ export function RiScPlugin() {
                 >
                   {t('contentHeader.createNewButton')}
                 </Button>
-                <Button
-                  startIcon={<Delete />}
-                  variant="text"
-                  color="error"
-                  onClick={openDeleteRiScDialog}
-                >
-                  {t('contentHeader.deleteButton')}
-                </Button>
-                {selectedRiSc && (
-                  <>
-                    <Button
-                      startIcon={<Settings />}
-                      variant="text"
-                      color="primary"
-                      onClick={openEditEncryptionDialog}
-                    >
-                      {t('contentHeader.editEncryption')}
-                    </Button>
-                  </>
-                )}
+                {selectedRiSc &&
+                  selectedRiSc.status !== RiScStatus.DeletionDraft &&
+                  selectedRiSc.status !==
+                    RiScStatus.DeletionSentForApproval && (
+                    <>
+                      <Button
+                        startIcon={<Delete />}
+                        variant="text"
+                        color="error"
+                        onClick={openDeleteRiScDialog}
+                      >
+                        {t('contentHeader.deleteButton')}
+                      </Button>
+                      <Button
+                        startIcon={<Settings />}
+                        variant="text"
+                        color="primary"
+                        onClick={openEditEncryptionDialog}
+                      >
+                        {t('contentHeader.editEncryption')}
+                      </Button>
+                    </>
+                  )}
               </Grid>
             )}
 
@@ -178,7 +181,7 @@ export function RiScPlugin() {
                   <ScenarioTableWrapper riScWithMetadata={selectedRiSc} />
                 </Grid>
                 <Grid item xs md={5} lg={4}>
-                  <RiskMatrix riSc={selectedRiSc.content} />
+                  <RiskMatrix riScWithMetadata={selectedRiSc} />
                 </Grid>
               </>
             )}

--- a/plugins/ros/src/components/riScPlugin/RiScPlugin.tsx
+++ b/plugins/ros/src/components/riScPlugin/RiScPlugin.tsx
@@ -23,6 +23,7 @@ import ListItemText from '@mui/material/ListItemText';
 import { ScenarioWizardSteps } from '../../contexts/ScenarioContext';
 import { ScenarioTableWrapper } from '../scenarioTable/ScenarioTable';
 import { Settings } from '@mui/icons-material';
+import { Delete } from '@mui/icons-material';
 
 export function RiScPlugin() {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
@@ -35,12 +36,18 @@ export function RiScPlugin() {
     return setRiScDialogState(RiScDialogStates.Create);
   }
 
+  function openDeleteRiScDialog() {
+    return setRiScDialogState(RiScDialogStates.Delete);
+  }
+
   function openEditRiScDialog() {
     return setRiScDialogState(RiScDialogStates.EditRiscInfo);
   }
+
   function openEditEncryptionDialog() {
     return setRiScDialogState(RiScDialogStates.EditEncryption);
   }
+
   function closeRiScDialog() {
     return setRiScDialogState(RiScDialogStates.Closed);
   }
@@ -128,7 +135,7 @@ export function RiScPlugin() {
                 <Button
                   startIcon={<AddCircle />}
                   variant="text"
-                  color="primary"
+                  color="success"
                   onClick={openCreateRiScDialog}
                   sx={{
                     minWidth: '205px',
@@ -136,15 +143,25 @@ export function RiScPlugin() {
                 >
                   {t('contentHeader.createNewButton')}
                 </Button>
+                <Button
+                  startIcon={<Delete />}
+                  variant="text"
+                  color="error"
+                  onClick={openDeleteRiScDialog}
+                >
+                  {t('contentHeader.deleteButton')}
+                </Button>
                 {selectedRiSc && (
-                  <Button
-                    startIcon={<Settings />}
-                    variant="text"
-                    color="primary"
-                    onClick={openEditEncryptionDialog}
-                  >
-                    {t('contentHeader.editEncryption')}
-                  </Button>
+                  <>
+                    <Button
+                      startIcon={<Settings />}
+                      variant="text"
+                      color="primary"
+                      onClick={openEditEncryptionDialog}
+                    >
+                      {t('contentHeader.editEncryption')}
+                    </Button>
+                  </>
                 )}
               </Grid>
             )}

--- a/plugins/ros/src/components/riskMatrix/RiskMatrix.tsx
+++ b/plugins/ros/src/components/riskMatrix/RiskMatrix.tsx
@@ -4,7 +4,7 @@ import { InfoCard } from '@backstage/core-components';
 import Box from '@mui/material/Box';
 import { RiskMatrixScenarioCount } from './RiskMatrixScenarioCount';
 import { AggregatedCost } from './AggregatedCost';
-import { RiSc } from '../../utils/types';
+import { RiScWithMetadata } from '../../utils/types';
 import TabContext from '@material-ui/lab/TabContext';
 import { Tabs } from './Tabs';
 import { riskMatrix } from '../../utils/constants';
@@ -14,7 +14,11 @@ import { useFontStyles } from '../../utils/style';
 import { useRiskMatrixStyles } from './riskMatrixStyle';
 import { RiskMatrixTabs } from './utils';
 
-export function RiskMatrix({ riSc }: { riSc: RiSc }) {
+export function RiskMatrix({
+  riScWithMetadata,
+}: {
+  riScWithMetadata: RiScWithMetadata;
+}) {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
   const { label2 } = useFontStyles();
   const {
@@ -37,10 +41,10 @@ export function RiskMatrix({ riSc }: { riSc: RiSc }) {
     >
       <TabContext value={tab}>
         <Tabs setTab={setTab} />
-        {riSc.scenarios.length > 0 && (
+        {riScWithMetadata.content.scenarios.length > 0 && (
           <Box className={riskSummary}>
             <AggregatedCost
-              riSc={riSc}
+              riSc={riScWithMetadata.content}
               initialRisk={tab === RiskMatrixTabs.initialRisk}
             />
           </Box>
@@ -64,7 +68,7 @@ export function RiskMatrix({ riSc }: { riSc: RiSc }) {
                     key={colIndex}
                   >
                     <RiskMatrixScenarioCount
-                      riSc={riSc}
+                      riScWithMetadata={riScWithMetadata}
                       probability={colIndex}
                       consequence={4 - rowIndex}
                       initialRisk={tab === RiskMatrixTabs.initialRisk}

--- a/plugins/ros/src/components/riskMatrix/RiskMatrixScenarioCount.tsx
+++ b/plugins/ros/src/components/riskMatrix/RiskMatrixScenarioCount.tsx
@@ -10,7 +10,7 @@ import {
 } from '@material-ui/core';
 import { useState } from 'react';
 import CircleIcon from '@material-ui/icons/FiberManualRecord';
-import { RiSc } from '../../utils/types';
+import { RiScStatus, RiScWithMetadata } from '../../utils/types';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { pluginRiScTranslationRef } from '../../utils/translations';
 import { useRiskMatrixStyles } from './riskMatrixStyle';
@@ -21,14 +21,14 @@ import {
 } from '../../utils/utilityfunctions';
 
 interface ScenarioCountProps {
-  riSc: RiSc;
+  riScWithMetadata: RiScWithMetadata;
   probability: number;
   consequence: number;
   initialRisk: boolean;
 }
 
 export function RiskMatrixScenarioCount({
-  riSc,
+  riScWithMetadata,
   probability,
   consequence,
   initialRisk,
@@ -49,10 +49,14 @@ export function RiskMatrixScenarioCount({
 
   function handleScenarioClick(ID: string) {
     setTooltipOpen(false);
-    openScenarioDrawer(ID);
+    openScenarioDrawer(
+      ID,
+      riScWithMetadata.status !== RiScStatus.DeletionDraft &&
+        riScWithMetadata.status !== RiScStatus.DeletionSentForApproval,
+    );
   }
 
-  const scenarios = riSc.scenarios.filter(
+  const scenarios = riScWithMetadata.content.scenarios.filter(
     scenario =>
       findProbabilityIndex(
         initialRisk

--- a/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
@@ -28,6 +28,7 @@ export function ScenarioDrawer() {
   const {
     scenario,
     isDrawerOpen,
+    isEditingAllowed,
     closeScenarioForm,
     submitEditedScenarioToRiSc,
     mapScenarioToFormScenario,
@@ -122,7 +123,7 @@ export function ScenarioDrawer() {
           marginLeft: 'auto',
         }}
       >
-        {!isEditing && (
+        {!isEditing && isEditingAllowed && (
           <Button
             color="primary"
             variant="contained"
@@ -181,17 +182,19 @@ export function ScenarioDrawer() {
             )}
           </Button>
         )}
-        <div ref={deleteScenarioRef}>
-          <Button
-            startIcon={<DeleteIcon />}
-            variant="text"
-            color="primary"
-            onClick={() => setDeleteConfirmationIsOpen(true)}
-            sx={{ marginLeft: 'auto' }}
-          >
-            {t('scenarioDrawer.deleteScenarioButton')}
-          </Button>
-        </div>
+        {isEditingAllowed && (
+          <div ref={deleteScenarioRef}>
+            <Button
+              startIcon={<DeleteIcon />}
+              variant="text"
+              color="primary"
+              onClick={() => setDeleteConfirmationIsOpen(true)}
+              sx={{ marginLeft: 'auto' }}
+            >
+              {t('scenarioDrawer.deleteScenarioButton')}
+            </Button>
+          </div>
+        )}
       </Box>
 
       {response &&

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
@@ -53,8 +53,12 @@ export function ActionBox({
     useState(false);
 
   const { updateStatus } = useRiScs();
-  const { submitEditedScenarioToRiSc, mapFormScenarioToScenario, scenario } =
-    useScenario();
+  const {
+    isEditingAllowed,
+    submitEditedScenarioToRiSc,
+    mapFormScenarioToScenario,
+    scenario,
+  } = useScenario();
 
   const isActionTitlePresent = action.title !== null && action.title !== '';
 
@@ -165,17 +169,19 @@ export function ActionBox({
               : `${t('dictionary.measure')} ${index + 1}`}
           </Typography>
         </Box>
-        <IconButton
-          disabled={isExpanded ? false : true}
-          sx={{
-            marginLeft: 'auto',
-            opacity: isExpanded ? 1 : 0,
-            transition: 'opacity 300ms ease-in',
-          }}
-          onClick={() => setIsEditing(!isEditing)}
-        >
-          <Edit />
-        </IconButton>
+        {isEditingAllowed && (
+          <IconButton
+            disabled={isExpanded ? false : true}
+            sx={{
+              marginLeft: 'auto',
+              opacity: isExpanded ? 1 : 0,
+              transition: 'opacity 300ms ease-in',
+            }}
+            onClick={() => setIsEditing(!isEditing)}
+          >
+            <Edit />
+          </IconButton>
+        )}
         <Chip
           label={translatedActionStatus}
           sx={{
@@ -185,7 +191,7 @@ export function ActionBox({
                 ? { backgroundColor: '#6BC6A4' }
                 : undefined,
           }}
-          onClick={handleChipClick}
+          onClick={isEditingAllowed ? handleChipClick : () => null}
         />
         <Menu
           anchorEl={anchorEl}
@@ -206,9 +212,11 @@ export function ActionBox({
             </MenuItem>
           ))}
         </Menu>
-        <IconButton onClick={handleDeleteAction}>
-          <DeleteIcon />
-        </IconButton>
+        {isEditingAllowed && (
+          <IconButton onClick={handleDeleteAction}>
+            <DeleteIcon />
+          </IconButton>
+        )}
       </Box>
       <Collapse in={isExpanded}>
         <Typography sx={{ ...label, marginTop: 1 }}>

--- a/plugins/ros/src/components/scenarioTable/ScenarioTable.tsx
+++ b/plugins/ros/src/components/scenarioTable/ScenarioTable.tsx
@@ -16,15 +16,19 @@ import { useRiScs } from '../../contexts/RiScContext';
 import { useScenario } from '../../contexts/ScenarioContext';
 import { useFontStyles } from '../../utils/style';
 import { pluginRiScTranslationRef } from '../../utils/translations';
-import { RiSc, RiScWithMetadata } from '../../utils/types';
+import { RiSc, RiScStatus, RiScWithMetadata } from '../../utils/types';
 import { ScenarioTableRow } from './ScenarioTableRow';
 import { useTableStyles } from './ScenarioTableStyles';
 
 interface ScenarioTableProps {
   riScWithMetadata: RiScWithMetadata;
+  editingAllowed: boolean;
 }
 
-export function ScenarioTable({ riScWithMetadata }: ScenarioTableProps) {
+export function ScenarioTable({
+  riScWithMetadata,
+  editingAllowed,
+}: ScenarioTableProps) {
   const riSc = riScWithMetadata.content;
   const { t } = useTranslationRef(pluginRiScTranslationRef);
   const { label } = useFontStyles();
@@ -86,7 +90,7 @@ export function ScenarioTable({ riScWithMetadata }: ScenarioTableProps) {
             {t('scenarioTable.title')}
           </Typography>
 
-          {riSc.scenarios.length > 0 && (
+          {riSc.scenarios.length > 0 && editingAllowed && (
             <Box
               style={{
                 display: 'flex',
@@ -118,7 +122,7 @@ export function ScenarioTable({ riScWithMetadata }: ScenarioTableProps) {
             </Box>
           )}
         </Box>
-        {riSc.scenarios.length === 0 ? (
+        {riSc.scenarios.length === 0 && editingAllowed ? (
           <Box
             style={{
               display: 'flex',
@@ -188,7 +192,9 @@ export function ScenarioTable({ riScWithMetadata }: ScenarioTableProps) {
                       key={scenario.ID}
                       index={idx}
                       scenario={scenario}
-                      viewRow={openScenarioDrawer}
+                      viewRow={(id: string) =>
+                        openScenarioDrawer(id, editingAllowed)
+                      }
                       moveRowFinal={moveRowFinal}
                       moveRowLocal={moveRowLocal}
                       isLastRow={idx === riSc.scenarios.length - 1}
@@ -215,6 +221,10 @@ export function ScenarioTableWrapper({
   return (
     <DndProvider backend={HTML5Backend}>
       <ScenarioTable
+        editingAllowed={
+          riScWithMetadata.status !== RiScStatus.DeletionDraft &&
+          riScWithMetadata.status !== RiScStatus.DeletionSentForApproval
+        }
         key={riScWithMetadata.id}
         riScWithMetadata={riScWithMetadata}
       />

--- a/plugins/ros/src/contexts/RiScContext.tsx
+++ b/plugins/ros/src/contexts/RiScContext.tsx
@@ -74,6 +74,7 @@ export function RiScProvider({ children }: { children: ReactNode }) {
     fetchRiScs,
     fetchGcpCryptoKeys,
     postRiScs,
+    deleteRiScs,
     putRiScs,
     publishRiScs,
     response,
@@ -321,6 +322,9 @@ export function RiScProvider({ children }: { children: ReactNode }) {
   }
 
   function deleteRiSc(riSc: RiScWithMetadata) {
+    setIsFetching(true);
+    setSelectedRiSc(riSc);
+    deleteRiScs(riSc);
     // TODO : Implement delete functionality where a deletion request is sent to the backend and a PR is made with the deletion - needs to be approved?
   }
 

--- a/plugins/ros/src/contexts/RiScContext.tsx
+++ b/plugins/ros/src/contexts/RiScContext.tsx
@@ -321,21 +321,7 @@ export function RiScProvider({ children }: { children: ReactNode }) {
   }
 
   function deleteRiSc(riSc: RiScWithMetadata) {
-    setIsRequesting(true);
-    setUpdateStatus({
-      isLoading: true,
-      isError: false,
-      isSuccess: false,
-    });
-    if (riScs) {
-      const updatedRiScs = riScs.filter(r => r.id !== riSc.id);
-      setRiScs(updatedRiScs);
-      setResponse({
-        statusMessage: t('infoMessages.RiScDeleted'),
-        status: ProcessingStatus.Success,
-      });
-    }
-    setIsRequesting(false);
+    // TODO : Implement delete functionality where a deletion request is sent to the backend and a PR is made with the deletion - needs to be approved?
   }
 
   function updateRiSc(

--- a/plugins/ros/src/contexts/RiScContext.tsx
+++ b/plugins/ros/src/contexts/RiScContext.tsx
@@ -43,6 +43,7 @@ type RiScDrawerProps = {
   selectRiSc: (title: string) => void;
   selectedRiSc: RiScWithMetadata | null;
   createNewRiSc: (riSc: RiScWithMetadata, generateDefault: boolean) => void;
+  deleteRiSc: (riSc: RiScWithMetadata) => void;
   updateRiSc: (
     riSc: RiScWithMetadata,
     onSuccess?: () => void,
@@ -319,6 +320,24 @@ export function RiScProvider({ children }: { children: ReactNode }) {
     );
   }
 
+  function deleteRiSc(riSc: RiScWithMetadata) {
+    setIsRequesting(true);
+    setUpdateStatus({
+      isLoading: true,
+      isError: false,
+      isSuccess: false,
+    });
+    if (riScs) {
+      const updatedRiScs = riScs.filter(r => r.id !== riSc.id);
+      setRiScs(updatedRiScs);
+      setResponse({
+        statusMessage: t('infoMessages.RiScDeleted'),
+        status: ProcessingStatus.Success,
+      });
+    }
+    setIsRequesting(false);
+  }
+
   function updateRiSc(
     riSc: RiScWithMetadata,
     onSuccess?: () => void,
@@ -450,6 +469,7 @@ export function RiScProvider({ children }: { children: ReactNode }) {
     selectRiSc,
     selectedRiSc,
     createNewRiSc,
+    deleteRiSc,
     updateRiSc,
     approveRiSc,
     updateStatus,

--- a/plugins/ros/src/contexts/ScenarioContext.tsx
+++ b/plugins/ros/src/contexts/ScenarioContext.tsx
@@ -48,6 +48,7 @@ const emptyScenario = (): Scenario => ({
 
 type ScenarioDrawerProps = {
   isDrawerOpen: boolean;
+  isEditingAllowed: boolean;
 
   isActionExpanded: (actionId: string) => boolean;
   toggleActionExpanded: (actionId: string) => void;
@@ -66,7 +67,7 @@ type ScenarioDrawerProps = {
     onError?: () => void,
   ) => void;
 
-  openScenarioDrawer: (id: string) => void;
+  openScenarioDrawer: (id: string, isEditingAllowed: boolean) => void;
   openNewScenarioWizard: () => void;
   closeScenarioForm: () => void;
   mapFormScenarioToScenario: (formScenario: FormScenario) => Scenario;
@@ -98,6 +99,7 @@ export function ScenarioProvider({ children }: { children: ReactNode }) {
   const [scenario, setScenario] = useState(emptyScenario());
 
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [isEditingAllowed, setIsEditingAllowed] = useState(true);
 
   const { t } = useTranslationRef(pluginRiScTranslationRef);
 
@@ -182,8 +184,9 @@ export function ScenarioProvider({ children }: { children: ReactNode }) {
   }, [riSc, scenarioIdFromParams, getRiScPath, navigate, searchParams, t]);
 
   // SCENARIO DRAWER FUNCTIONS
-  function openScenarioDrawer(id: string) {
+  function openScenarioDrawer(id: string, canEdit: boolean) {
     if (riSc) {
+      setIsEditingAllowed(canEdit);
       navigate(getScenarioPath({ riScId: riSc.id, scenarioId: id }));
     }
   }
@@ -286,6 +289,7 @@ export function ScenarioProvider({ children }: { children: ReactNode }) {
 
   const value = {
     isDrawerOpen,
+    isEditingAllowed,
 
     isActionExpanded,
     toggleActionExpanded,

--- a/plugins/ros/src/urls/backend.ts
+++ b/plugins/ros/src/urls/backend.ts
@@ -11,5 +11,6 @@ export const BACKEND_URLS = {
 	fetchAllRiScs: '/api/proxy/risc-proxy/api/risc/:repoOwner/:repoName/:version/all', // (1)
 	fetchDifference: '/api/proxy/risc-proxy/api/risc/:repoOwner/:repoName/:id/difference', // (1)
 	fetchRiSc: '/api/proxy/risc-proxy/api/risc/:repoOwner/:repoName/:id', // (1)
+  deleteRiSc: 'api/proxy/risc-proxy/api/risc/:repoOwner/:repoName/:id', // (1)
 	publishRiSc: '/api/proxy/risc-proxy/api/risc/:repoOwner/:repoName/publish/:id', // (1)
 };

--- a/plugins/ros/src/utils/DTOs.ts
+++ b/plugins/ros/src/utils/DTOs.ts
@@ -42,6 +42,8 @@ export type CreateRiScResultDTO = {
   sopsConfig: SopsConfigDTO;
 } & ProcessRiScResultDTO;
 
+export type DeleteRiScResultDTO = ProcessRiScResultDTO;
+
 export type RiScContentResultDTO = {
   riScStatus: RiScStatus;
   riScContent: string;

--- a/plugins/ros/src/utils/hooks.ts
+++ b/plugins/ros/src/utils/hooks.ts
@@ -96,7 +96,7 @@ export function useAuthenticatedFetch() {
 
   function fullyAuthenticatedFetch<T, K>(
     uri: string,
-    method: 'GET' | 'POST' | 'PUT',
+    method: 'GET' | 'POST' | 'PUT' | 'DELETE',
     onSuccess: (response: T) => void,
     onError: (error: K, rejectedLogin: boolean) => void,
     body?: string,
@@ -325,11 +325,29 @@ export function useAuthenticatedFetch() {
     );
   }
 
+  function deleteRiScs(
+    riSc: RiScWithMetadata,
+    onSuccess?: () => void,
+    onError?: (error: ProcessRiScResultDTO, loginRejected: boolean) => void,
+  ) {
+    fullyAuthenticatedFetch<void, ProcessRiScResultDTO>(
+      uriToFetchRiSc(riSc.id),
+      'DELETE',
+      () => {
+        if (onSuccess) onSuccess();
+      },
+      (error, rejectedLogin) => {
+        if (onError) onError(error, rejectedLogin);
+      },
+    );
+  }
+
   return {
     fetchRiScs,
     fetchGcpCryptoKeys,
     postRiScs,
     putRiScs,
+    deleteRiScs,
     publishRiScs,
     response,
     setResponse,

--- a/plugins/ros/src/utils/hooks.ts
+++ b/plugins/ros/src/utils/hooks.ts
@@ -18,6 +18,7 @@ import {
   SopsConfigDTO,
   profileInfoToDTOString,
   riScToDTOString,
+  DeleteRiScResultDTO,
 } from './DTOs';
 import { latestSupportedVersion } from './constants';
 import {
@@ -58,6 +59,11 @@ export function useAuthenticatedFetch() {
 
   function uriToFetchRiSc(id: string) {
     // URLS.backend.fetchRiSc
+    return `${riScUri}/${id}`;
+  }
+
+  function uriToDeleteRiSc(id: string) {
+    // URLS.backend.deleteRiSc
     return `${riScUri}/${id}`;
   }
 
@@ -326,15 +332,15 @@ export function useAuthenticatedFetch() {
   }
 
   function deleteRiScs(
-    riSc: RiScWithMetadata,
-    onSuccess?: () => void,
+    riScId: string,
+    onSuccess?: (response: DeleteRiScResultDTO) => void,
     onError?: (error: ProcessRiScResultDTO, loginRejected: boolean) => void,
   ) {
-    fullyAuthenticatedFetch<void, ProcessRiScResultDTO>(
-      uriToFetchRiSc(riSc.id),
+    fullyAuthenticatedFetch<DeleteRiScResultDTO, ProcessRiScResultDTO>(
+      uriToDeleteRiSc(riScId),
       'DELETE',
-      () => {
-        if (onSuccess) onSuccess();
+      res => {
+        if (onSuccess) onSuccess(res);
       },
       (error, rejectedLogin) => {
         if (onError) onError(error, rejectedLogin);

--- a/plugins/ros/src/utils/translations.ts
+++ b/plugins/ros/src/utils/translations.ts
@@ -8,6 +8,7 @@ export const pluginRiScMessages = {
     title: 'Risk scorecard',
     createNewButton: 'Create new scorecard',
     editEncryption: 'Edit encryption',
+    deleteButton: 'Delete scoreboard'
   },
   dictionary: {
     click: 'Click',
@@ -459,6 +460,11 @@ export const pluginRiScMessages = {
       'No SOPS configuration present on default branch of the GitHub repository',
     CreatedSops: 'SOPS configuration created successfully',
   },
+  deleteDialog: {
+    title: 'Delete Risk Scorecard',
+    confirmationMessage:
+      'Are you sure you want to delete this risk scorecard?',
+  },
 } as const;
 
 export const pluginRiScTranslationRef = createTranslationRef({
@@ -475,6 +481,7 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
           'contentHeader.title': 'Risiko- og sårbarhetsanalyse',
           'contentHeader.createNewButton': 'Opprett ny analyse',
           'contentHeader.editEncryption': 'Rediger kryptering',
+          'contentHeader.deleteButton': 'Slett analyse',
           'dictionary.rejectedLogin': 'Innlogging avbrutt av bruker.',
           'dictionary.click': 'Klikk',
           'dictionary.here': 'her',
@@ -913,6 +920,9 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
           'infoMessages.NoSopsConfigFound':
             'Ingen SOPS-konfigurasjon funnet på default branchen til GitHub-repoet',
           'infoMessages.CreatedSops': 'SOPS-konfigurasjon opprettet',
+          'deleteDialog.title': 'Slett risiko- og sårbarhetsanalyse',
+          'deleteDialog.confirmationMessage':
+            'Er du sikker på at du vil slette denne risiko- og sårbarhetsanalysen?',
         },
       }),
   },

--- a/plugins/ros/src/utils/translations.ts
+++ b/plugins/ros/src/utils/translations.ts
@@ -8,7 +8,7 @@ export const pluginRiScMessages = {
     title: 'Risk scorecard',
     createNewButton: 'Create new scorecard',
     editEncryption: 'Edit encryption',
-    deleteButton: 'Delete scoreboard'
+    deleteButton: 'Delete scoreboard',
   },
   dictionary: {
     click: 'Click',
@@ -84,6 +84,9 @@ export const pluginRiScMessages = {
       draft: 'Draft',
       waiting: 'Awaiting approval',
       published: 'Published',
+      draftDeletion: 'Marked for deletion',
+      waitingDeletion: 'Awaiting deletion',
+      deletionApproval: 'The risk owner can review and accept the deletion.',
     },
     updatedStatus: {
       UPDATED: 'Updated status icon',
@@ -114,15 +117,20 @@ export const pluginRiScMessages = {
       },
     },
     editing: 'You can now start editing',
-    approveButton: 'Accept risks', // Godkjenn ROS
+    approveButtonUpdate: 'Accept risks', // Approve RiSc
+    approveButtonDelete: 'Accept deletion', // Approve deletion of RiSc
     prStatus: ' Merge the PR in ', // Avventer godkjenning av PR i Github
-    prStatus2: ' to publish the scorecard.',
+    prStatus2Update: ' to publish the scorecard.', // Approve RiSc
+    prStatus2Delete: ' to delete the scorecard.', // Approve deletion of RiSc
     moreInformationButton: 'More information', // Lagre ROS migrering
   },
   publishDialog: {
-    title: 'Accept risks', // Godkjenn ROS
-    checkboxLabel:
+    titleUpdate: 'Accept risks', // Approve ROS
+    titleDelete: 'Accept deletion', // Delete ROS
+    checkboxLabelUpdate:
       'I confirm that I am the risk owner and accept the risks detailed in this risk scorecard.',
+    checkboxLabelDelete:
+      'I confirm that I am the risk owner and accept the deletion of this risk scorecard.',
   },
   migrationDialog: {
     description:
@@ -434,6 +442,7 @@ export const pluginRiScMessages = {
     NoWriteAccessToRepository:
       'Unable to update RiSc. You do not have write access to this repository.',
     ErrorWhenUpdatingRiSc: 'Failed to update risk scorecard',
+    ErrorWhenDeletingRiSc: 'Failed to delete risk scorecard',
     ErrorWhenCreatingPullRequest: 'Failed to save approval of risk scorecard',
     ErrorWhenCreatingRiSc: 'Failed to create risk scorecard',
     ErrorWhenFetchingRiScs: 'Failed to fetch risk scorecards with ids: ',
@@ -449,6 +458,9 @@ export const pluginRiScMessages = {
   infoMessages: {
     OpenedPullRequest: 'Successfully opened pull request',
     CreatedPullRequest: 'Successfully saved approval of risk scorecard ',
+    DeletedRiSc: 'Risk scorecard deleted',
+    DeletedRiScRequiresApproval:
+      'Risk scorecard staged for deletion, requires approval',
     UpdatedRiSc: 'Risk scorecard updated',
     UpdatedSops: 'SOPS configuration updated',
     UpdatedRiScRequiresNewApproval:
@@ -462,8 +474,7 @@ export const pluginRiScMessages = {
   },
   deleteDialog: {
     title: 'Delete Risk Scorecard',
-    confirmationMessage:
-      'Are you sure you want to delete this risk scorecard?',
+    confirmationMessage: 'Are you sure you want to delete this risk scorecard?',
   },
 } as const;
 
@@ -562,15 +573,21 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
           'rosStatus.statusBadge.draft': 'Utkast',
           'rosStatus.statusBadge.waiting': 'Avventer godkjenning',
           'rosStatus.statusBadge.published': 'Publisert',
+          'rosStatus.statusBadge.draftDeletion': 'Markert for sletting',
+          'rosStatus.statusBadge.waitingDeletion': 'Venter på sletting',
+          'rosStatus.statusBadge.deletionApproval':
+            'Risikoeier kan gå igjennom og godkjenne slettingen.',
           'rosStatus.lastModified': 'Sist publisert: ',
           'rosStatus.daysSinceLastModified':
             '{{days}} dager og {{numCommits}} commits siden',
           'rosStatus.notPublishedYet': 'RoS er ikke publisert enda',
           'rosStatus.errorMessage': 'Kunne ikke hente status',
           'rosStatus.editing': 'Du kan nå gjøre endringer',
-          'rosStatus.approveButton': 'Godkjenn ROS',
+          'rosStatus.approveButtonUpdate': 'Godkjenn ROS',
+          'rosStatus.approveButtonDelete': 'Godkjenn sletting',
           'rosStatus.prStatus': ' Merge pull requesten i ',
-          'rosStatus.prStatus2': " for å publisere ROS'en.",
+          'rosStatus.prStatus2Update': " for å publisere ROS'en.",
+          'rosStatus.prStatus2Delete': " for å slette ROS'en.",
           'rosStatus.moreInformationButton': 'Mer informasjon',
           'rosStatus.difference.description':
             'Oppsummering av endringer som må godkjennes av risikoeier.',
@@ -598,9 +615,12 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
           'rosStatus.updatedStatus.VERY_OUTDATED': 'Veldig utdatert statusikon',
           'rosStatus.updatedStatus.error': 'Feil statusikon',
           'rosStatus.updatedStatus.disabled': 'Deaktivert statusikon',
-          'publishDialog.title': 'Godkjenn ROS-analyse',
-          'publishDialog.checkboxLabel':
+          'publishDialog.titleUpdate': 'Godkjenn ROS-analyse',
+          'publishDialog.titleDelete': 'Godkjenn sletting',
+          'publishDialog.checkboxLabelUpdate':
             'Jeg bekrefter at jeg er risikoeier og godtar risikoen beskrevet i denne risiko- og sårbarhetsanalysen.',
+          'publishDialog.checkboxLabelDelete':
+            'Jeg bekrefter at jeg er risikoeier og godtar slettingen av denne risiko- og sårbarhetsanalysen.',
 
           'migrationDialog.title': 'Lagre endringer',
           'migrationDialog.description':
@@ -885,6 +905,8 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
             'Kunne ikke oppdatere ROS. Du har ikke skrivetilgang til dette repoet.',
           'errorMessages.ErrorWhenUpdatingRiSc':
             'Kunne ikke lagre risiko- og sårbarhetsanalyse',
+          'errorMessages.ErrorWhenDeletingRiSc':
+            'Kunne ikke slette risiko- og sårbarhetsanalyse',
           'errorMessages.ErrorWhenCreatingRiSc':
             'Kunne ikke opprette risiko- og sårbarhetsanalyse',
           'errorMessages.RiScDoesNotExist':
@@ -908,6 +930,10 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
           'infoMessages.OpenedPullRequest': 'Åpnet pull request',
           'infoMessages.CreatedPullRequest':
             'Godkjenning av risiko- og sårbarhetsanalysen ble lagret',
+          'infoMessages.DeletedRiSc':
+            'Risiko- og sårbarhetsanalysen ble slettet',
+          'infoMessages.DeletedRiScRequiresApproval':
+            'Risiko- og sårbarhetsanalysen ble markert for sletting og trenger godkjenning',
           'infoMessages.UpdatedRiSc':
             'Risiko- og sårbarhetsanalysen ble oppdatert',
           'infoMessages.UpdatedSops': 'SOPS-konfigurasjon oppdatert',

--- a/plugins/ros/src/utils/types.ts
+++ b/plugins/ros/src/utils/types.ts
@@ -104,6 +104,8 @@ export enum RiScStatus {
   Draft = 'Draft',
   Published = 'Published',
   SentForApproval = 'SentForApproval',
+  DeletionDraft = 'DeletionDraft',
+  DeletionSentForApproval = 'DeletionSentForApproval',
 }
 
 export enum ProcessingStatus {
@@ -111,6 +113,8 @@ export enum ProcessingStatus {
   EncryptionFailed = 'EncryptionFailed',
   CouldNotCreateBranch = 'CouldNotCreateBranch',
   UpdatedRiSc = 'UpdatedRiSc',
+  DeletedRiSc = 'DeletedRiSc',
+  DeletedRiScRequiresApproval = 'DeletedRiScRequiresApproval',
   UpdatedSops = 'UpdatedSops',
   UpdatedRiScRequiresNewApproval = 'UpdatedRiScRequiresNewApproval',
   UpdatedRiScAndCreatedPullRequest = 'UpdatedRiScAndCreatedPullRequest',
@@ -119,6 +123,7 @@ export enum ProcessingStatus {
   CreatedPullRequest = 'CreatedPullRequest',
   ErrorWhenCreatingRiSc = 'ErrorWhenCreatingRiSc',
   ErrorWhenUpdatingRiSc = 'ErrorWhenUpdatingRiSc',
+  ErrorWhenDeletingRiSc = 'ErrorWhenDeletingRiSc',
   ErrorWhenPublishingRiSc = 'ErrorWhenPublishingRiSc',
   ErrorWhenNoWriteAccessToRepository = 'ErrorWhenNoWriteAccessToRepository',
   ErrorWhenFetchingRiScs = 'ErrorWhenFetchingRiScs',
@@ -129,6 +134,7 @@ export enum ProcessingStatus {
 
 export enum ContentStatus {
   Success = 'Success',
+  Deleted = 'Deleted',
   Failure = 'Failure',
   FileNotFound = 'FileNotFound',
   DecryptionFailed = 'DecryptionFailed',


### PR DESCRIPTION
Det er lagt til en knapp "Delete RiSc" som trigger en dialog som spør om du er sikker på at du vil slette. Det å godkjenne at den kan slettes bør kanskje gjøres av en risikoeier/sikkerhetschampion? Tanken er at når man trykker på "Delete" i dialogen så lages en PR som sletter den éne RoS-yaml-filen som da må gdkjennes og merges i GitHub før RoSen slettes. Bør man da i Backstage få opp et banner som sier "Det er lagt inn en PR for å slette denne RoSen" slik at det blir kommunisert i denne "venteperioden".

## 🦺 Hva gjort?
- [x] Lagt til "Slett RoS"-knapp
- [x] Knappen trigger en dialog - kan gjøres "finere" med bedre padding, osv.
- [ ] Koble til funksjonalitet i backend slik at knappene faktisk gjør noe

## 📸 Screenshots (after)
<img width="1477" alt="Screenshot 2025-04-23 at 17 13 51" src="https://github.com/user-attachments/assets/4fa82629-cae0-45b9-8b18-f3da04e459f4" />
<img width="887" alt="Screenshot 2025-04-23 at 17 14 01" src="https://github.com/user-attachments/assets/0ae89894-2ec6-4f2b-9b98-f44b6c6e4f5e" />
