### PR TITLE
Changes in action now requires a new approval

### DIFF
--- a/plugins/ros/src/utils/utilityfunctions.test.ts
+++ b/plugins/ros/src/utils/utilityfunctions.test.ts
@@ -135,25 +135,25 @@ describe('requiresNewApproval', () => {
     ).toBe(false);
   });
 
-  it('returns false if diff on scenario title, description or url', () => {
+  it('returns true for diff on scenario title, description or url', () => {
     expect(
       requiresNewApproval(riSc, {
         ...riSc,
         scenarios: [{ ...scenario, title: 'new title' }],
       }),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       requiresNewApproval(riSc, {
         ...riSc,
         scenarios: [{ ...scenario, description: 'new description' }],
       }),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       requiresNewApproval(riSc, {
         ...riSc,
         scenarios: [{ ...scenario, url: 'new url' }],
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it('returns true for diff on action', () => {
@@ -221,6 +221,15 @@ describe('requiresNewApproval', () => {
         scenarios: [scenario, scenario],
       }),
     ).toBe(true);
+    expect(
+      requiresNewApproval(
+        {
+          ...riSc,
+          scenarios: [scenario, scenario],
+        },
+        riSc,
+      ),
+    ).toBe(true);
   });
 
   it('returns true if number of actions differ', () => {
@@ -229,6 +238,15 @@ describe('requiresNewApproval', () => {
         ...riSc,
         scenarios: [{ ...scenario, actions: [action, action, action] }],
       }),
+    ).toBe(true);
+    expect(
+      requiresNewApproval(
+        {
+          ...riSc,
+          scenarios: [{ ...scenario, actions: [action, action, action] }],
+        },
+        riSc,
+      ),
     ).toBe(true);
   });
 
@@ -291,21 +309,78 @@ describe('requiresNewApproval', () => {
   });
 
   it('returns true if diff on risk', () => {
-    const updatedScenario = {
-      ...scenario,
-      risk: { ...scenario.risk, probability: 5 },
-    };
-    const updatedRiSc = { ...riSc, scenarios: [updatedScenario] };
-    expect(requiresNewApproval(riSc, updatedRiSc)).toBe(true);
+    expect(
+      requiresNewApproval(riSc, {
+        ...riSc,
+        scenarios: [
+          {
+            ...scenario,
+            risk: { ...scenario.risk, summary: 'new summary' },
+          },
+        ],
+      }),
+    ).toBe(true);
+    expect(
+      requiresNewApproval(riSc, {
+        ...riSc,
+        scenarios: [
+          {
+            ...scenario,
+            risk: { ...scenario.risk, probability: 5 },
+          },
+        ],
+      }),
+    ).toBe(true);
+    expect(
+      requiresNewApproval(riSc, {
+        ...riSc,
+        scenarios: [
+          {
+            ...scenario,
+            risk: { ...scenario.risk, consequence: 5 },
+          },
+        ],
+      }),
+    ).toBe(true);
   });
 
   it('returns true if diff on remaining risk', () => {
-    const updatedScenario = {
-      ...scenario,
-      remainingRisk: { ...scenario.remainingRisk, consequence: 5 },
-    };
-    const updatedRiSc = { ...riSc, scenarios: [updatedScenario] };
-    expect(requiresNewApproval(riSc, updatedRiSc)).toBe(true);
+    expect(
+      requiresNewApproval(riSc, {
+        ...riSc,
+        scenarios: [
+          {
+            ...scenario,
+            remainingRisk: {
+              ...scenario.remainingRisk,
+              summary: 'new summary',
+            },
+          },
+        ],
+      }),
+    ).toBe(true);
+    expect(
+      requiresNewApproval(riSc, {
+        ...riSc,
+        scenarios: [
+          {
+            ...scenario,
+            remainingRisk: { ...scenario.remainingRisk, probability: 5 },
+          },
+        ],
+      }),
+    ).toBe(true);
+    expect(
+      requiresNewApproval(riSc, {
+        ...riSc,
+        scenarios: [
+          {
+            ...scenario,
+            remainingRisk: { ...scenario.remainingRisk, consequence: 5 },
+          },
+        ],
+      }),
+    ).toBe(true);
   });
 });
 

--- a/plugins/ros/src/utils/utilityfunctions.test.ts
+++ b/plugins/ros/src/utils/utilityfunctions.test.ts
@@ -118,61 +118,176 @@ describe('requiresNewApproval', () => {
     ],
   };
 
-  it('returns false if scenarios are equal', () => {
+  it('returns false if risc is equal', () => {
     expect(requiresNewApproval(riSc, riSc)).toBe(false);
   });
 
-  it('returns false if diff on title, description, summary, action.description, or action.status', () => {
-    const updatedScenario = {
-      ...scenario,
-      risk: { ...scenario.risk, summary: 'New summary' },
-      remainingRisk: { ...scenario.remainingRisk, summary: 'New summary' },
-    };
-    const updatedRiSc = {
+  it('returns false if risc is equal for several scenarios', () => {
+    const riScWithSeveralScenarios: RiSc = {
       ...riSc,
-      title: 'New title',
-      scenarios: [updatedScenario],
-    };
-    expect(requiresNewApproval(riSc, updatedRiSc)).toBe(false);
-  });
-
-  it('returns false for any diff in action', () => {
-    const updatedScenario = {
-      ...scenario,
-      actions: [
-        {
-          ...action,
-          description: 'New description',
-          status: 'New status',
-          title: 'New title',
-          url: 'New url',
-          ID: 'New ID',
-        },
+      scenarios: [
+        scenario,
+        { ...scenario, ID: '2', actions: [action, { ...action, ID: '2' }] },
       ],
     };
-    const updatedRiSc = {
-      ...riSc,
-      scenarios: [updatedScenario],
-    };
-    expect(requiresNewApproval(riSc, updatedRiSc)).toBe(false);
+    expect(
+      requiresNewApproval(riScWithSeveralScenarios, riScWithSeveralScenarios),
+    ).toBe(false);
+  });
+
+  it('returns false if diff on scenario title, description or url', () => {
+    expect(
+      requiresNewApproval(riSc, {
+        ...riSc,
+        scenarios: [{ ...scenario, title: 'new title' }],
+      }),
+    ).toBe(false);
+    expect(
+      requiresNewApproval(riSc, {
+        ...riSc,
+        scenarios: [{ ...scenario, description: 'new description' }],
+      }),
+    ).toBe(false);
+    expect(
+      requiresNewApproval(riSc, {
+        ...riSc,
+        scenarios: [{ ...scenario, url: 'new url' }],
+      }),
+    ).toBe(false);
+  });
+
+  it('returns true for diff on action', () => {
+    expect(
+      requiresNewApproval(riSc, {
+        ...riSc,
+        scenarios: [
+          {
+            ...scenario,
+            actions: [{ ...action, ID: 'new id' }],
+          },
+        ],
+      }),
+    ).toBe(true);
+    expect(
+      requiresNewApproval(riSc, {
+        ...riSc,
+        scenarios: [
+          {
+            ...scenario,
+            actions: [{ ...action, title: 'new title' }],
+          },
+        ],
+      }),
+    ).toBe(true);
+    expect(
+      requiresNewApproval(riSc, {
+        ...riSc,
+        scenarios: [
+          {
+            ...scenario,
+            actions: [{ ...action, description: 'new description' }],
+          },
+        ],
+      }),
+    ).toBe(true);
+    expect(
+      requiresNewApproval(riSc, {
+        ...riSc,
+        scenarios: [
+          {
+            ...scenario,
+            actions: [{ ...action, status: 'new status' }],
+          },
+        ],
+      }),
+    ).toBe(true);
+    expect(
+      requiresNewApproval(riSc, {
+        ...riSc,
+        scenarios: [
+          {
+            ...scenario,
+            actions: [{ ...action, url: 'new url' }],
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true if number of scenarios differ', () => {
+    expect(
+      requiresNewApproval(riSc, {
+        ...riSc,
+        scenarios: [scenario, scenario],
+      }),
+    ).toBe(true);
   });
 
   it('returns true if number of actions differ', () => {
-    const updatedScenario = {
-      ...scenario,
-      actions: [action, action, action],
-    };
-    const updatedRiSc = {
-      ...riSc,
-      scenarios: [updatedScenario],
-    };
-    expect(requiresNewApproval(riSc, updatedRiSc)).toBe(true);
+    expect(
+      requiresNewApproval(riSc, {
+        ...riSc,
+        scenarios: [{ ...scenario, actions: [action, action, action] }],
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true if riSc doesnt contain previously existing scenarios', () => {
+    expect(
+      requiresNewApproval(riSc, {
+        ...riSc,
+        scenarios: [{ ...scenario, ID: 'new Id' }],
+      }),
+    ).toBe(true);
   });
 
   it('returns true if diff on threatActors', () => {
-    const updatedScenario = { ...scenario, threatActors: ['actor2'] };
-    const updatedRiSc = { ...riSc, scenarios: [updatedScenario] };
-    expect(requiresNewApproval(riSc, updatedRiSc)).toBe(true);
+    expect(
+      requiresNewApproval(riSc, {
+        ...riSc,
+        scenarios: [{ ...scenario, threatActors: ['new threat actor'] }],
+      }),
+    ).toBe(true);
+
+    expect(
+      requiresNewApproval(riSc, {
+        ...riSc,
+        scenarios: [
+          {
+            ...scenario,
+            threatActors: [scenario.threatActors[0], scenario.threatActors[0]],
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true if diff on vulnerabilities', () => {
+    expect(
+      requiresNewApproval(riSc, {
+        ...riSc,
+        scenarios: [
+          {
+            ...scenario,
+            vulnerabilities: ['new vulnerability'],
+          },
+        ],
+      }),
+    ).toBe(true);
+    expect(
+      requiresNewApproval(riSc, {
+        ...riSc,
+        scenarios: [
+          {
+            ...scenario,
+            vulnerabilities: [
+              scenario.vulnerabilities[0],
+              scenario.vulnerabilities[0],
+            ],
+          },
+        ],
+      }),
+    ).toBe(true);
   });
 
   it('returns true if diff on risk', () => {

--- a/plugins/ros/src/utils/utilityfunctions.ts
+++ b/plugins/ros/src/utils/utilityfunctions.ts
@@ -159,6 +159,24 @@ export function requiresNewApproval(oldRiSc: RiSc, updatedRiSc: RiSc): boolean {
       requiresApproval = true;
     }
 
+    if (oldScenario.actions.length !== updatedScenario.actions.length) {
+      requiresApproval = true;
+    }
+
+    oldScenario.actions.forEach(oldAction => {
+      const updatedAction = updatedScenario.actions.find(
+        action => action.ID === oldAction.ID,
+      );
+
+      if (!updatedAction) {
+        requiresApproval = true;
+      }
+
+      if (!isDeeplyEqual(oldAction, updatedAction)) {
+        requiresApproval = true;
+      }
+    });
+
     if (!isDeeplyEqual(oldScenario.actions, updatedScenario.actions)) {
       requiresApproval = true;
     }

--- a/plugins/ros/src/utils/utilityfunctions.ts
+++ b/plugins/ros/src/utils/utilityfunctions.ts
@@ -159,9 +159,10 @@ export function requiresNewApproval(oldRiSc: RiSc, updatedRiSc: RiSc): boolean {
       requiresApproval = true;
     }
 
-    if (oldScenario.actions.length !== updatedScenario.actions.length) {
+    if (!isDeeplyEqual(oldScenario.actions, updatedScenario.actions)) {
       requiresApproval = true;
     }
+
     if (
       oldScenario.remainingRisk.probability !==
       updatedScenario.remainingRisk.probability

--- a/plugins/ros/src/utils/utilityfunctions.ts
+++ b/plugins/ros/src/utils/utilityfunctions.ts
@@ -117,26 +117,15 @@ export function calculateUpdatedStatus(
   return UpdatedStatusEnum.VERY_OUTDATED;
 }
 
-// keys that does not change the approval status: tittel, beskrivelse, oppsummering, tiltak.beskrivelse, tiltak.tiltakseier, tiltak.status
 export function requiresNewApproval(oldRiSc: RiSc, updatedRiSc: RiSc): boolean {
-  if (oldRiSc.scenarios.length !== updatedRiSc.scenarios.length) {
-    return true;
-  }
-  let requiresApproval = false;
-
-  const updatedScenarioMap = new Map<string, Scenario>(
-    updatedRiSc.scenarios.map(scenario => [scenario.ID, scenario]),
+  return !isDeeplyEqual(
+    oldRiSc.scenarios.sort(
+      (scenario1, scenario2) => Number(scenario1.ID) - Number(scenario2.ID),
+    ),
+    updatedRiSc.scenarios.sort(
+      (scenario1, scenario2) => Number(scenario1.ID) - Number(scenario2.ID),
+    ),
   );
-
-  oldRiSc.scenarios.forEach(oldScenario => {
-    const updatedScenario = updatedScenarioMap.get(oldScenario.ID);
-
-    if (!isDeeplyEqual(oldScenario, updatedScenario)) {
-      requiresApproval = true;
-    }
-  });
-
-  return requiresApproval;
 }
 
 export function formatNumber(

--- a/plugins/ros/src/utils/utilityfunctions.ts
+++ b/plugins/ros/src/utils/utilityfunctions.ts
@@ -131,55 +131,11 @@ export function requiresNewApproval(oldRiSc: RiSc, updatedRiSc: RiSc): boolean {
   oldRiSc.scenarios.forEach(oldScenario => {
     const updatedScenario = updatedScenarioMap.get(oldScenario.ID);
 
-    if (!updatedScenario) {
-      requiresApproval = true;
-      return;
-    }
-
-    if (
-      !isDeeplyEqual(oldScenario.threatActors, updatedScenario.threatActors)
-    ) {
-      requiresApproval = true;
-    }
-
-    if (
-      !isDeeplyEqual(
-        oldScenario.vulnerabilities,
-        updatedScenario.vulnerabilities,
-      )
-    ) {
-      requiresApproval = true;
-    }
-
-    if (oldScenario.risk.probability !== updatedScenario.risk.probability) {
-      requiresApproval = true;
-    }
-
-    if (oldScenario.risk.consequence !== updatedScenario.risk.consequence) {
-      requiresApproval = true;
-    }
-
-    if (oldScenario.actions.length !== updatedScenario.actions.length) {
-      requiresApproval = true;
-    }
-
-    if (!isDeeplyEqual(oldScenario.actions, updatedScenario.actions)) {
-      requiresApproval = true;
-    }
-
-    if (
-      oldScenario.remainingRisk.probability !==
-      updatedScenario.remainingRisk.probability
-    ) {
-      requiresApproval = true;
-    }
-    if (
-      oldScenario.remainingRisk.consequence !==
-      updatedScenario.remainingRisk.consequence
-    ) {
+    if (!isDeeplyEqual(oldScenario, updatedScenario)) {
       requiresApproval = true;
     }
   });
+
   return requiresApproval;
 }
 

--- a/plugins/ros/src/utils/utilityfunctions.ts
+++ b/plugins/ros/src/utils/utilityfunctions.ts
@@ -163,20 +163,6 @@ export function requiresNewApproval(oldRiSc: RiSc, updatedRiSc: RiSc): boolean {
       requiresApproval = true;
     }
 
-    oldScenario.actions.forEach(oldAction => {
-      const updatedAction = updatedScenario.actions.find(
-        action => action.ID === oldAction.ID,
-      );
-
-      if (!updatedAction) {
-        requiresApproval = true;
-      }
-
-      if (!isDeeplyEqual(oldAction, updatedAction)) {
-        requiresApproval = true;
-      }
-    });
-
     if (!isDeeplyEqual(oldScenario.actions, updatedScenario.actions)) {
       requiresApproval = true;
     }


### PR DESCRIPTION
- Any changes in an action now requires a new approval
- Simplified some tests for requireNewApproval and increased coverage

This closes the remarks on #553 