### PR TITLE
one outlined and one contained button side by side

### DIFF
--- a/plugins/ros/src/components/scenarioWizard/components/CloseConfirmation.tsx
+++ b/plugins/ros/src/components/scenarioWizard/components/CloseConfirmation.tsx
@@ -26,7 +26,7 @@ export function CloseConfirmation({
           {t('dictionary.discardChanges')}
         </Button>
 
-        <Button variant="outlined" onClick={save}>
+        <Button variant="contained" onClick={save}>
           {t('dictionary.save')}
         </Button>
       </DialogActions>


### PR DESCRIPTION
## Before
<img width="594" alt="Screenshot 2025-05-02 at 10 19 37" src="https://github.com/user-attachments/assets/7e9507db-1355-426c-95b1-d32c7f99c3e2" />

## After
<img width="428" alt="Screenshot 2025-05-02 at 10 19 28" src="https://github.com/user-attachments/assets/5764fe0f-397a-467f-a61c-661e43dd3e52" />

