### PR TITLE
move primary buttons to the right of cancel

### DIFF
--- a/plugins/ros/src/components/riScInfo/MigrationDialog.tsx
+++ b/plugins/ros/src/components/riScInfo/MigrationDialog.tsx
@@ -70,15 +70,15 @@ export const RiScMigrationDialog = ({
         </Alert>
       </DialogContent>
       <DialogActions sx={dialogActions}>
+        <Button variant="outlined" color="primary" onClick={handleCancel}>
+          {t('dictionary.cancel')}
+        </Button>
         <Button
           variant="contained"
           onClick={handleUpdate}
           disabled={!saveMigration}
         >
           {t('dictionary.confirm')}
-        </Button>
-        <Button variant="outlined" color="primary" onClick={handleCancel}>
-          {t('dictionary.cancel')}
         </Button>
       </DialogActions>
     </Dialog>

--- a/plugins/ros/src/components/riScInfo/PublishDialog.tsx
+++ b/plugins/ros/src/components/riScInfo/PublishDialog.tsx
@@ -55,6 +55,9 @@ export const RiScPublishDialog = ({
         </>
       </DialogContent>
       <DialogActions sx={dialogActions}>
+        <Button variant="outlined" color="primary" onClick={handleCancel}>
+          {t('dictionary.cancel')}
+        </Button>
         <Button
           variant="contained"
           color="primary"
@@ -62,9 +65,6 @@ export const RiScPublishDialog = ({
           disabled={!riskOwnerApproves}
         >
           {t('dictionary.confirm')}
-        </Button>
-        <Button variant="outlined" color="primary" onClick={handleCancel}>
-          {t('dictionary.cancel')}
         </Button>
       </DialogActions>
     </Dialog>


### PR DESCRIPTION
Følge designstandarder - primary-knapp til høyre og secondary til venstre - eks. bilde 2 er nå endret til å ligne 1 og 3

<img width="739" alt="Screenshot 2025-05-02 at 10 29 43" src="https://github.com/user-attachments/assets/982b5910-dfdb-49bc-bc4b-9f875a777355" />
