### PR TITLE
Increase height of description fields

### DIFF
--- a/plugins/ros/src/components/scenarioDrawer/components/ScopeFormSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ScopeFormSection.tsx
@@ -73,7 +73,7 @@ function ScopeFormSection({
             value={value}
             onMarkdownChange={onChange}
             label={t('dictionary.description')}
-            minRows={4}
+            minRows={8}
             error={!!error}
           />
         )}

--- a/plugins/ros/src/components/scenarioWizard/steps/ScenarioStep.tsx
+++ b/plugins/ros/src/components/scenarioWizard/steps/ScenarioStep.tsx
@@ -87,7 +87,7 @@ export function ScenarioStep({
         label={t('dictionary.description')}
         value={currentDescription}
         onMarkdownChange={value => setValue('description', value)}
-        minRows={4}
+        minRows={8}
       />
     </Stack>
   );


### PR DESCRIPTION
It was mentioned that the description fields when adding and editing riscs felt too small and claustrophobic. This change increases the height of the fields.

### Before

<img width="594" alt="Screenshot 2025-05-05 at 09 38 45" src="https://github.com/user-attachments/assets/1e8d062c-79e3-4fa3-8c3c-7d5e05626efb" />

![Screenshot 2025-05-05 at 09 40 46](https://github.com/user-attachments/assets/91cc8080-50ef-41f9-bdf3-4d785423ca97)

### After

<img width="804" alt="Screenshot 2025-05-05 at 09 36 47" src="https://github.com/user-attachments/assets/2e3070fd-5305-4084-ab2b-e3ba362a8421" />

![Screenshot 2025-05-05 at 09 41 54](https://github.com/user-attachments/assets/4714d757-21ec-4f21-9da7-010c1d8529fd)