### PR TITLE
Remaining risk must be equal or lower than the start risk

### DIFF
--- a/plugins/ros/src/components/common/Select.tsx
+++ b/plugins/ros/src/components/common/Select.tsx
@@ -1,21 +1,22 @@
-import {
-  Control,
-  FieldValues,
-  Path,
-  useController,
-  type UseControllerReturn,
-} from 'react-hook-form';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
-import { pluginRiScTranslationRef } from '../../utils/translations';
 import Box from '@mui/material/Box';
+import Checkbox from '@mui/material/Checkbox';
 import Chip from '@mui/material/Chip';
 import FormControl from '@mui/material/FormControl';
 import FormHelperText from '@mui/material/FormHelperText';
 import FormLabel from '@mui/material/FormLabel';
-import MUISelect, { SelectProps } from '@mui/material/Select';
-import Checkbox from '@mui/material/Checkbox';
-import MenuItem from '@mui/material/MenuItem';
 import ListItemText from '@mui/material/ListItemText';
+import MenuItem from '@mui/material/MenuItem';
+import MUISelect, { SelectProps } from '@mui/material/Select';
+import {
+  Control,
+  FieldValues,
+  Path,
+  RegisterOptions,
+  useController,
+  type UseControllerReturn,
+} from 'react-hook-form';
+import { pluginRiScTranslationRef } from '../../utils/translations';
 import { formHelperText, formLabel } from './typography';
 
 type Props<T extends FieldValues> = SelectProps & {
@@ -25,6 +26,10 @@ type Props<T extends FieldValues> = SelectProps & {
   name: Path<T>;
   labelTranslationKey?: string;
   options: { value: string | number; renderedValue: string | number }[];
+  rules?: Omit<
+    RegisterOptions<T, string & Path<T>>,
+    'disabled' | 'valueAsNumber' | 'valueAsDate' | 'setValueAs'
+  >;
 };
 
 export function Select<T extends FieldValues>({
@@ -38,13 +43,15 @@ export function Select<T extends FieldValues>({
   multiple,
   labelTranslationKey,
   options,
+  rules,
   ...props
 }: Props<T>) {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
+
   const { field } = useController({
     name,
     control,
-    rules: { required },
+    rules: { ...rules, required },
   });
 
   // values er strengt tatt unknown, men da må vi bruke mye ts-ignore for å komme i mål

--- a/plugins/ros/src/components/common/Select.tsx
+++ b/plugins/ros/src/components/common/Select.tsx
@@ -92,7 +92,7 @@ export function Select<T extends FieldValues>({
   }
 
   return (
-    <FormControl sx={{ width: '100%', gap: '4px' }}>
+    <FormControl error={error} sx={{ width: '100%', gap: '4px' }}>
       {label && (
         <FormLabel sx={formLabel} required={required}>
           {label}
@@ -106,6 +106,7 @@ export function Select<T extends FieldValues>({
         MenuProps={{
           disablePortal: true,
         }}
+        error={error}
         variant="outlined"
         renderValue={renderValue}
         multiple={multiple}

--- a/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
@@ -1,26 +1,26 @@
-import { useEffect, useRef, useState } from 'react';
-import Box from '@mui/material/Box';
-import { useScenario } from '../../contexts/ScenarioContext';
-import { RiskSection } from './components/RiskSection';
-import { ActionsSection } from './components/ActionsSection';
-import DeleteIcon from '@mui/icons-material/Delete';
-import { DeleteConfirmation } from './components/DeleteConfirmation';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
-import { pluginRiScTranslationRef } from '../../utils/translations';
-import { ScopeSection } from './components/ScopeSection';
-import { useForm } from 'react-hook-form';
-import { FormScenario, ProcessingStatus } from '../../utils/types';
-import RiskFormSection from './components/RiskFormSection';
-import ScopeFormSection from './components/ScopeFormSection';
-import Drawer from '@mui/material/Drawer';
-import Button from '@mui/material/Button';
-import { useRiScs } from '../../contexts/RiScContext';
-import CircularProgress from '@mui/material/CircularProgress';
+import DeleteIcon from '@mui/icons-material/Delete';
 import Alert from '@mui/material/Alert';
-import { getAlertSeverity } from '../../utils/utilityfunctions';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Drawer from '@mui/material/Drawer';
 import Typography from '@mui/material/Typography';
+import { useEffect, useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useRiScs } from '../../contexts/RiScContext';
+import { useScenario } from '../../contexts/ScenarioContext';
+import { pluginRiScTranslationRef } from '../../utils/translations';
+import { FormScenario, ProcessingStatus } from '../../utils/types';
+import { getAlertSeverity } from '../../utils/utilityfunctions';
 import { MatrixDialog } from '../riScDialog/MatrixDialog';
 import { CloseConfirmation } from '../scenarioWizard/components/CloseConfirmation';
+import { ActionsSection } from './components/ActionsSection';
+import { DeleteConfirmation } from './components/DeleteConfirmation';
+import RiskFormSection from './components/RiskFormSection';
+import { RiskSection } from './components/RiskSection';
+import ScopeFormSection from './components/ScopeFormSection';
+import { ScopeSection } from './components/ScopeSection';
 
 export function ScenarioDrawer() {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
@@ -50,7 +50,7 @@ export function ScenarioDrawer() {
 
   const formMethods = useForm<FormScenario>({
     defaultValues: mapScenarioToFormScenario(scenario),
-    mode: 'onBlur',
+    mode: 'onChange',
   });
 
   function onCancel() {

--- a/plugins/ros/src/components/scenarioDrawer/components/RiskFormSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/RiskFormSection.tsx
@@ -1,15 +1,17 @@
-import { UseFormReturn } from 'react-hook-form';
-import { FormScenario } from '../../../utils/types';
-import { pluginRiScTranslationRef } from '../../../utils/translations';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import InfoIcon from '@mui/icons-material/Info';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import { UseFormReturn } from 'react-hook-form';
 import {
   consequenceOptions,
   probabilityOptions,
 } from '../../../utils/constants';
+import { pluginRiScTranslationRef } from '../../../utils/translations';
+import { FormScenario } from '../../../utils/types';
 import { Select } from '../../common/Select';
-import Box from '@mui/material/Box';
-import Paper from '@mui/material/Paper';
-import Typography from '@mui/material/Typography';
 import { heading3 } from '../../common/typography';
 import {
   headerSection,
@@ -17,8 +19,6 @@ import {
   section,
   selectSection,
 } from '../scenarioDrawerComponents';
-import IconButton from '@mui/material/IconButton';
-import InfoIcon from '@mui/icons-material/Info';
 
 function ScenarioForm({
   formMethods,
@@ -89,12 +89,24 @@ function ScenarioForm({
               name="remainingRisk.probability"
               label={t('dictionary.probability')}
               options={probabilityValues}
+              rules={{
+                validate: (value, _) =>
+                  Number(value) <=
+                    Number(control._formValues.risk?.probability) ||
+                  t('scenarioDrawer.errors.remainingProbabilityTooHigh'),
+              }}
             />
             <Select<FormScenario>
               control={control}
               name="remainingRisk.consequence"
               label={t('dictionary.consequence')}
               options={consequenceValues}
+              rules={{
+                validate: (value, _) =>
+                  Number(value) <=
+                    Number(control._formValues.risk?.consequence) ||
+                  t('scenarioDrawer.errors.remainingConsequenceTooHigh'),
+              }}
             />
           </Box>
         </Paper>

--- a/plugins/ros/src/components/scenarioDrawer/components/RiskFormSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/RiskFormSection.tsx
@@ -28,7 +28,10 @@ function ScenarioForm({
   setIsMatrixDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
-  const { control } = formMethods;
+  const {
+    control,
+    formState: { errors },
+  } = formMethods;
 
   const probabilityValues = probabilityOptions.map((value, index) => ({
     value: `${value}`,
@@ -51,39 +54,32 @@ function ScenarioForm({
         }}
       >
         <Paper sx={riscSection}>
-          <Box sx={headerSection}>
-            <Typography sx={{ ...heading3, justifySelf: 'start' }}>
-              {t('dictionary.initialRisk')}
-            </Typography>
-            <Typography>
-              {t('scenarioDrawer.riskMatrixModal.startRisk')}
-            </Typography>
-          </Box>
           <Box sx={selectSection}>
+            {/* Row 1 */}
+            <Box sx={headerSection}>
+              <Typography sx={{ ...heading3, justifySelf: 'start' }}>
+                {t('dictionary.initialRisk')}
+              </Typography>
+              <Typography>
+                {t('scenarioDrawer.riskMatrixModal.startRisk')}
+              </Typography>
+            </Box>
+            <Box sx={headerSection}>
+              <Typography sx={{ ...heading3, justifySelf: 'flex-start' }}>
+                {t('dictionary.restRisk')}
+              </Typography>
+              <Typography>
+                {t('scenarioDrawer.riskMatrixModal.restRisk')}
+              </Typography>
+            </Box>
+
+            {/* Row 2 */}
             <Select<FormScenario>
               control={control}
               name="risk.probability"
               label={t('dictionary.probability')}
               options={probabilityValues}
             />
-            <Select<FormScenario>
-              control={control}
-              name="risk.consequence"
-              label={t('dictionary.consequence')}
-              options={consequenceValues}
-            />
-          </Box>
-        </Paper>
-        <Paper sx={riscSection}>
-          <Box sx={headerSection}>
-            <Typography sx={{ ...heading3, justifySelf: 'flex-start' }}>
-              {t('dictionary.restRisk')}
-            </Typography>
-            <Typography>
-              {t('scenarioDrawer.riskMatrixModal.restRisk')}
-            </Typography>
-          </Box>
-          <Box sx={selectSection}>
             <Select<FormScenario>
               control={control}
               name="remainingRisk.probability"
@@ -95,6 +91,16 @@ function ScenarioForm({
                     Number(control._formValues.risk?.probability) ||
                   t('scenarioDrawer.errors.remainingProbabilityTooHigh'),
               }}
+              error={errors.remainingRisk?.probability !== undefined}
+              helperText={errors.remainingRisk?.probability?.message}
+            />
+
+            {/* Row 3 */}
+            <Select<FormScenario>
+              control={control}
+              name="risk.consequence"
+              label={t('dictionary.consequence')}
+              options={consequenceValues}
             />
             <Select<FormScenario>
               control={control}
@@ -107,6 +113,8 @@ function ScenarioForm({
                     Number(control._formValues.risk?.consequence) ||
                   t('scenarioDrawer.errors.remainingConsequenceTooHigh'),
               }}
+              error={errors.remainingRisk?.consequence !== undefined}
+              helperText={errors.remainingRisk?.consequence?.message}
             />
           </Box>
         </Paper>

--- a/plugins/ros/src/components/scenarioDrawer/scenarioDrawerComponents.ts
+++ b/plugins/ros/src/components/scenarioDrawer/scenarioDrawerComponents.ts
@@ -28,8 +28,8 @@ export const headerSection: SxProps<Theme> = {
 };
 
 export const selectSection: SxProps<Theme> = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '16px',
-  width: '100%',
+  display: 'grid',
+  gridTemplateColumns: '1fr 1fr',
+  gap: '24px',
+  rowGap: '16px',
 };

--- a/plugins/ros/src/utils/translations.ts
+++ b/plugins/ros/src/utils/translations.ts
@@ -322,6 +322,12 @@ export const pluginRiScMessages = {
     deleteActionButton: 'Delete action',
     deleteActionConfirmation: 'Are you sure you want to delete this action?',
     closeConfirmation: 'Do you want to save your changes?',
+    errors: {
+      remainingProbabilityTooHigh:
+        'Remaining probability cannot be higher than initial probability',
+      remainingConsequenceTooHigh:
+        'Remaining consequence cannot be higher than initial consequence',
+    },
   },
   consequenceTable: {
     rows: {
@@ -518,6 +524,10 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
           'scenarioDrawer.action.requiredError': 'Feltet er påkrevd',
           'scenarioDrawer.action.emptyState':
             'Scenariet har ingen definerte tiltak',
+          'scenarioDrawer.errors.remainingConsequenceTooHigh':
+            'Restkonsekvens kan ikke være høyere enn startkonsekvens',
+          'scenarioDrawer.errors.remainingProbabilityTooHigh':
+            'Restsannsynlighet kan ikke være høyere enn startsannsynlighet',
 
           'encryption.title': 'Kryptering',
 


### PR DESCRIPTION
- Validate remaining risk in scenario drawer to ensure that the remaining probability and consequence are equal or lower than the starting probability and consequence
- User feedback given by red outline and helper text
- Changed the select section styling to grid to ensure that the Selects are aligned even when error helper text is shown on one side
- Changed useForm method from onBlur to onChange to ensure that the error feedback is given instantly when an invalid value is selected

**Before:**

<img width="801" alt="Screenshot 2025-05-14 at 15 43 26" src="https://github.com/user-attachments/assets/fd4cdffd-1017-43c9-b3d9-5b234b24dc83" />

**After:**

<img width="805" alt="Screenshot 2025-05-14 at 15 42 56" src="https://github.com/user-attachments/assets/c4bd5735-f90d-4056-9115-7f28868388fe" />
