### PR TITLE
Progress bar for completed actions is now always have the same length for all rows

### DIFF
--- a/plugins/ros/src/components/scenarioTable/ScenarioTableProgressBar.tsx
+++ b/plugins/ros/src/components/scenarioTable/ScenarioTableProgressBar.tsx
@@ -26,19 +26,21 @@ export function ScenarioTableProgressBar({
 }: ScenarioTableProgressBarProps) {
   return (
     <Box display="flex" alignItems="center" gap={2} width="100%">
-      <Box sx={{ flexGrow: 1, minWidth: 100, width: '100%' }}>
+      <Box sx={{ flexGrow: 1, minWidth: 120 }}>
         <LinearProgressStyled
           variant="determinate"
           value={100 * (completedCount / totalCount)}
         />
       </Box>
-      <Typography
-        variant="body2"
-        sx={{ whiteSpace: 'nowrap', fontWeight: 500 }}
-      >
-        {completedCount} / {totalCount}
-        {completedCount === totalCount ? ' 👑' : ''}
-      </Typography>
+      <Box sx={{ width: 65, textAlign: 'left', ml: 1 }}>
+        <Typography
+          variant="body2"
+          sx={{ whiteSpace: 'nowrap', fontWeight: 500 }}
+        >
+          {completedCount} / {totalCount}
+          {completedCount === totalCount ? ' 👑' : ''}
+        </Typography>
+      </Box>
     </Box>
   );
 }


### PR DESCRIPTION
<img width="970" alt="Screenshot 2025-05-15 at 14 05 04" src="https://github.com/user-attachments/assets/a62dd9e7-0aa7-4468-b9d9-1d28df9eb511" />
