### PR TITLE
🕙 Luxon for dateparsing over date-fns

### DIFF
--- a/plugins/ros/package.json
+++ b/plugins/ros/package.json
@@ -51,7 +51,6 @@
     "@mui/x-date-pickers": "^6.20.2",
     "@uiw/react-markdown-preview": "^5.1.3",
     "@uiw/react-md-editor": "^4.0.5",
-    "date-fns": "^4.1.0",
     "github-markdown-css": "^5.8.1",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",

--- a/plugins/ros/package.json
+++ b/plugins/ros/package.json
@@ -52,6 +52,7 @@
     "@uiw/react-markdown-preview": "^5.1.3",
     "@uiw/react-md-editor": "^4.0.5",
     "github-markdown-css": "^5.8.1",
+    "luxon": "^3.6.1",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
     "react-hook-form": "^7.55.0",
@@ -71,6 +72,7 @@
     "@backstage/test-utils": "backstage:^",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@types/luxon": "^3",
     "@types/react": "^18.3.20",
     "prettier": "^3.5.3"
   },

--- a/plugins/ros/src/components/riScInfo/riScStatus/RiScDifferenceDialog.tsx
+++ b/plugins/ros/src/components/riScInfo/riScStatus/RiScDifferenceDialog.tsx
@@ -1,14 +1,14 @@
-import { DifferenceFetchState, DifferenceStatus } from '../../../utils/types';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { ErrorOutline, Favorite } from '@mui/icons-material';
 import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography';
 import Card from '@mui/material/Card';
 import CircularProgress from '@mui/material/CircularProgress';
-import { ErrorOutline, Favorite } from '@mui/icons-material';
-import { DifferenceText } from './DifferenceText';
-import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import Typography from '@mui/material/Typography';
+import { DateTime } from 'luxon';
 import { pluginRiScTranslationRef } from '../../../utils/translations';
+import { DifferenceFetchState, DifferenceStatus } from '../../../utils/types';
 import { parseISODateFromEncryptedROS } from '../../../utils/utilityfunctions';
-import { parseISO } from 'date-fns';
+import { DifferenceText } from './DifferenceText';
 
 type RiScDifferenceDialogProps = {
   differenceFetchState: DifferenceFetchState;
@@ -24,7 +24,7 @@ export function RiScDifferenceDialog({
   );
 
   const parsedDateString = formatedDateString
-    ? parseISO(formatedDateString).toLocaleDateString()
+    ? DateTime.fromISO(formatedDateString).toLocaleString()
     : null;
   return (
     <Box>

--- a/plugins/ros/src/utils/utilityfunctions.test.ts
+++ b/plugins/ros/src/utils/utilityfunctions.test.ts
@@ -17,6 +17,7 @@ import {
   formatNumber,
   generateRandomId,
   isDeeplyEqual,
+  parseISODateFromEncryptedROS,
   requiresNewApproval,
   roundConsequenceToNearestConsequenceOption,
   roundProbabilityToNearestProbabilityOption,
@@ -419,6 +420,32 @@ describe('formatNumber', () => {
 
   it('formats trillions correctly', () => {
     expect(formatNumber(3_200_000_000_000, mockT)).toBe('3 trillion');
+  });
+});
+
+describe('parseISODateFromEncryptedROS', () => {
+  it('should parse a valid ISO date string', () => {
+    const isoDate = '2023-10-01T12:00:00Z';
+    const result = parseISODateFromEncryptedROS(isoDate);
+    expect(result).toBe('2023-10-01T12:00:00Z');
+  });
+
+  it('should parse a valid ISO date string with extra escaped quotations', () => {
+    const isoDate = '\"2023-10-01T12:00:00Z\"';
+    const result = parseISODateFromEncryptedROS(isoDate);
+    expect(result).toBe('2023-10-01T12:00:00Z');
+  });
+
+  it('should return null for an invalid date string', () => {
+    const invalidDate = 'invalid-date';
+    const result = parseISODateFromEncryptedROS(invalidDate);
+    expect(result).toBeNull();
+  });
+
+  it('should return null for an empty string', () => {
+    const emptyString = '';
+    const result = parseISODateFromEncryptedROS(emptyString);
+    expect(result).toBeNull();
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7877,7 +7877,6 @@ __metadata:
     "@types/react": "npm:^18.3.20"
     "@uiw/react-markdown-preview": "npm:^5.1.3"
     "@uiw/react-md-editor": "npm:^4.0.5"
-    date-fns: "npm:^4.1.0"
     github-markdown-css: "npm:^5.8.1"
     prettier: "npm:^3.5.3"
     react-dnd: "npm:^16.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7874,10 +7874,12 @@ __metadata:
     "@mui/x-date-pickers": "npm:^6.20.2"
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^16.3.0"
+    "@types/luxon": "npm:^3"
     "@types/react": "npm:^18.3.20"
     "@uiw/react-markdown-preview": "npm:^5.1.3"
     "@uiw/react-md-editor": "npm:^4.0.5"
     github-markdown-css: "npm:^5.8.1"
+    luxon: "npm:^3.6.1"
     prettier: "npm:^3.5.3"
     react-dnd: "npm:^16.0.1"
     react-dnd-html5-backend: "npm:^16.0.1"
@@ -15297,7 +15299,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/luxon@npm:^3.0.0":
+"@types/luxon@npm:^3, @types/luxon@npm:^3.0.0":
   version: 3.6.2
   resolution: "@types/luxon@npm:3.6.2"
   checksum: 10c0/7572ee52b3d3e9dd10464b90561a728b90f34b9a257751cc3ce23762693dd1d14fa98b7f103e2efe2c6f49033331f91de5681ffd65cca88618cefe555be326db
@@ -27496,7 +27498,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"luxon@npm:^3.0.0, luxon@npm:^3.2.1, luxon@npm:^3.4.3":
+"luxon@npm:^3.0.0, luxon@npm:^3.2.1, luxon@npm:^3.4.3, luxon@npm:^3.6.1":
   version: 3.6.1
   resolution: "luxon@npm:3.6.1"
   checksum: 10c0/906d57a9dc4d1de9383f2e9223e378c298607c1b4d17b6657b836a3cd120feb1c1de3b5d06d846a3417e1ca764de8476e8c23b3cd4083b5cdb870adcb06a99d5


### PR DESCRIPTION
Use luxon for dateparsing instead of date-fns as we get luxon out of the box with backstage. Added tests for parseISODateFromEncryptedROS utility function