### PR TITLE
Fiks desynk mellom toggle og tekst for ´Generer initiell Ros´

### DIFF
--- a/plugins/ros/src/components/riScDialog/ConfigRiscInfo.tsx
+++ b/plugins/ros/src/components/riScDialog/ConfigRiscInfo.tsx
@@ -80,7 +80,11 @@ function ConfigRiscInfo({
               {t('rosDialog.generateInitialToggleDescription')}
             </Typography>
             <FormControlLabel
-              control={<Switch onChange={handleChangeCreateRiScFrom} />}
+              control={<Switch
+                  checked={createRiScFrom === CreateRiScFrom.Default}
+                  onChange={handleChangeCreateRiScFrom}
+              />
+              }
               label={
                 createRiScFrom === CreateRiScFrom.Scratch
                   ? t('dictionary.no')

--- a/plugins/ros/src/components/riScDialog/ConfigRiscInfo.tsx
+++ b/plugins/ros/src/components/riScDialog/ConfigRiscInfo.tsx
@@ -80,10 +80,11 @@ function ConfigRiscInfo({
               {t('rosDialog.generateInitialToggleDescription')}
             </Typography>
             <FormControlLabel
-              control={<Switch
+              control={
+                <Switch
                   checked={createRiScFrom === CreateRiScFrom.Default}
                   onChange={handleChangeCreateRiScFrom}
-              />
+                />
               }
               label={
                 createRiScFrom === CreateRiScFrom.Scratch


### PR DESCRIPTION
### **Før:**

- Opprett ny analyse og trykk på opprett initiell ros slik at det ser sånn ut:

<img width="603" alt="pr1" src="https://github.com/user-attachments/assets/16268849-3d2d-4472-ab62-79d1cdc4abce" />

- Trykk neste, og så forrige

<img width="585" alt="pr2" src="https://github.com/user-attachments/assets/6db8ea57-6467-4886-9428-9910f2b8bd57" />

- Da vil det se ut som du ikke oppretter initiell ros, men det står ja

<img width="362" alt="pr3" src="https://github.com/user-attachments/assets/3e237cd4-d74a-4d33-811a-7f7c5886720b" />

- Hvis du igjen trykker på den, så ser den aktiv ut, men det står nei

<img width="358" alt="pr4" src="https://github.com/user-attachments/assets/7a054783-5310-445d-9fec-c53c472fc1e8" />


**### Etter:**

<img width="609" alt="image" src="https://github.com/user-attachments/assets/eaafc12e-93d5-438b-a9f0-13ccac52fc9c" />

<img width="603" alt="image" src="https://github.com/user-attachments/assets/2b818d4f-4a67-4ab9-90cb-73e856a37520" />

Så, trykk forrige

<img width="458" alt="image" src="https://github.com/user-attachments/assets/efefa27e-eeca-4b0e-93d4-a358cf03df17" />

<img width="463" alt="image" src="https://github.com/user-attachments/assets/c2dcc743-dd7b-464d-8e4b-d5c662ff7eca" />


