### PR TITLE
tittelfelt er nå 1-linje-boks

### DIFF
--- a/plugins/ros/src/components/riScDialog/ConfigRiscInfo.tsx
+++ b/plugins/ros/src/components/riScDialog/ConfigRiscInfo.tsx
@@ -46,7 +46,6 @@ function ConfigRiscInfo({
         {...register('content.title', { required: true })}
         error={errors?.content?.title !== undefined}
         label={t('dictionary.title')}
-        minRows={4}
         helperText={errors?.content?.title && t('rosDialog.titleError')}
       />
       <MarkdownInput


### PR DESCRIPTION
Før:

<img width="621" alt="image" src="https://github.com/user-attachments/assets/2c8fb18f-5993-433c-a8e3-762c138a3707" />

<img width="619" alt="image" src="https://github.com/user-attachments/assets/6b32fe84-079e-4236-b8fd-48984fc7bef8" />

Etter:

<img width="628" alt="image" src="https://github.com/user-attachments/assets/5baab98d-8f2f-4a57-8c5b-5ee459543c7a" />

<img width="605" alt="image" src="https://github.com/user-attachments/assets/38906617-a1a7-4f94-8e2c-c28b8bc27177" />

