### PR TITLE
Center initial risk and remaining risk in risk scenarios table

### DIFF
--- a/plugins/ros/src/components/scenarioTable/ScenarioTableStyles.ts
+++ b/plugins/ros/src/components/scenarioTable/ScenarioTableStyles.ts
@@ -81,5 +81,6 @@ export const useTableStyles = makeStyles((theme: Theme) => ({
     display: 'flex',
     gap: theme.spacing(1),
     alignItems: 'center',
+    justifyContent: 'center',
   },
 }));


### PR DESCRIPTION
Currently the initial risk and remaining risk is left adjusted in the risk scenarios table, while the column title is centered. This changes the initial risk and remaining risk to be centered.

**Old:**
<img width="1537" alt="Screenshot 2025-05-19 at 11 55 34" src="https://github.com/user-attachments/assets/69921053-ae96-428d-b3c3-1d9afc065ca4" />

**New:**
<img width="1545" alt="Screenshot 2025-05-19 at 11 54 37" src="https://github.com/user-attachments/assets/7ed2503d-3dbe-4332-b450-02dd5134e484" />
