### PR TITLE
Improved changelog for migrations

### DIFF
--- a/plugins/ros/src/components/riScInfo/MigrationDialog.tsx
+++ b/plugins/ros/src/components/riScInfo/MigrationDialog.tsx
@@ -5,7 +5,6 @@ import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogActions from '@mui/material/DialogActions';
-import Link from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
 import Checkbox from '@mui/material/Checkbox';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
@@ -14,7 +13,6 @@ import Box from '@mui/material/Box';
 import { pluginRiScTranslationRef } from '../../utils/translations';
 import { MigrationStatus } from '../../utils/types';
 import { dialogActions } from '../common/mixins';
-import { URLS } from '../../urls';
 import { RiScMigrationChanges41 } from './migrations/RiScMigrationChanges41.tsx';
 import { ChangeSetBox } from './migrations/components/ChangeSetBox.tsx';
 import { ChangeSetTitle } from './migrations/components/ChangeSetTitle.tsx';
@@ -47,27 +45,13 @@ export const RiScMigrationDialog = ({
       <DialogTitle>{t('migrationDialog.title')}</DialogTitle>
       <DialogContent>
         <Box sx={{ marginBottom: '16px' }}>
-          <Typography>
-            {t('migrationDialog.description')}
-            {migrationStatus.migrationVersions?.toVersion}{' '}
-            {t('migrationDialog.description2')}{' '}
-            {migrationStatus.migrationVersions?.fromVersion}
-            {t('migrationDialog.description3')}
-            <Link
-              underline="always"
-              target="_blank"
-              href={URLS.external.github_com__kartverket_changelog}
-            >
-              {t('migrationDialog.changelog')}
-            </Link>{' '}
-            {t('migrationDialog.description4')}
-          </Typography>
+          <Typography>{t('migrationDialog.description')}</Typography>
         </Box>
         <div>
-          <ChangeSetTitle text="Schema Version" />
+          <ChangeSetTitle text={t('migrationDialog.schemaVersion')} />
           <ChangeSetBox type="primary">
             <ChangeSetChangedValue
-              propertyName="Schema version"
+              propertyName={t('migrationDialog.schemaVersion')}
               oldValue={migrationStatus.migrationVersions?.fromVersion || ''}
               newValue={migrationStatus.migrationVersions?.toVersion || ''}
             />

--- a/plugins/ros/src/components/riScInfo/MigrationDialog.tsx
+++ b/plugins/ros/src/components/riScInfo/MigrationDialog.tsx
@@ -1,4 +1,4 @@
-import { ReactComponentElement, useState } from 'react';
+import { useState } from 'react';
 import Alert from '@mui/material/Alert';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -12,23 +12,27 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Box from '@mui/material/Box';
 import { pluginRiScTranslationRef } from '../../utils/translations';
-import { MigrationVersions } from '../../utils/types';
+import { MigrationStatus } from '../../utils/types';
 import { dialogActions } from '../common/mixins';
 import { URLS } from '../../urls';
+import { RiScMigrationChanges41 } from './migrations/RiScMigrationChanges41.tsx';
+import { ChangeSetBox } from './migrations/components/ChangeSetBox.tsx';
+import { ChangeSetTitle } from './migrations/components/ChangeSetTitle.tsx';
+import { ChangeSetChangedValue } from './migrations/components/ChangeSetChangedValue.tsx';
 
 interface RiScMigrationDialogProps {
   openDialog: boolean;
   handleCancel: () => void;
   handleUpdate: () => void;
-  migrationVersions?: MigrationVersions;
+  migrationStatus: MigrationStatus;
 }
 
 export const RiScMigrationDialog = ({
   openDialog,
   handleCancel,
   handleUpdate,
-  migrationVersions,
-}: RiScMigrationDialogProps): ReactComponentElement<any> => {
+  migrationStatus,
+}: RiScMigrationDialogProps) => {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
 
   const [saveMigration, setSaveMigration] = useState<boolean>(false);
@@ -38,14 +42,15 @@ export const RiScMigrationDialog = ({
   }
 
   return (
-    <Dialog open={openDialog}>
+    <Dialog maxWidth="md" open={openDialog}>
       <DialogTitle>{t('migrationDialog.title')}</DialogTitle>
       <DialogContent>
         <Box sx={{ marginBottom: '16px' }}>
           <Typography>
             {t('migrationDialog.description')}
-            {migrationVersions?.toVersion} {t('migrationDialog.description2')}{' '}
-            {migrationVersions?.fromVersion}
+            {migrationStatus.migrationVersions?.toVersion}{' '}
+            {t('migrationDialog.description2')}{' '}
+            {migrationStatus.migrationVersions?.fromVersion}
             {t('migrationDialog.description3')}
             <Link
               underline="always"
@@ -57,6 +62,21 @@ export const RiScMigrationDialog = ({
             {t('migrationDialog.description4')}
           </Typography>
         </Box>
+        <div>
+          <ChangeSetTitle text="Schema Version" />
+          <ChangeSetBox type="primary">
+            <ChangeSetChangedValue
+              property="Schema version"
+              oldValue={migrationStatus.migrationVersions?.fromVersion || ''}
+              newValue={migrationStatus.migrationVersions?.toVersion || ''}
+            />
+          </ChangeSetBox>
+          {migrationStatus.migrationChanges41 && (
+            <RiScMigrationChanges41
+              changes={migrationStatus.migrationChanges41}
+            />
+          )}
+        </div>
         <Alert severity="info" icon={false}>
           <FormControlLabel
             control={

--- a/plugins/ros/src/components/riScInfo/MigrationDialog.tsx
+++ b/plugins/ros/src/components/riScInfo/MigrationDialog.tsx
@@ -67,7 +67,7 @@ export const RiScMigrationDialog = ({
           <ChangeSetTitle text="Schema Version" />
           <ChangeSetBox type="primary">
             <ChangeSetChangedValue
-              property="Schema version"
+              propertyName="Schema version"
               oldValue={migrationStatus.migrationVersions?.fromVersion || ''}
               newValue={migrationStatus.migrationVersions?.toVersion || ''}
             />
@@ -95,7 +95,7 @@ export const RiScMigrationDialog = ({
           />
         </Alert>
       </DialogContent>
-      <DialogActions sx={dialogActions}>
+      <DialogActions sx={dialogActions} style={{ paddingTop: '16px' }}>
         <Button variant="outlined" color="primary" onClick={handleCancel}>
           {t('dictionary.cancel')}
         </Button>

--- a/plugins/ros/src/components/riScInfo/MigrationDialog.tsx
+++ b/plugins/ros/src/components/riScInfo/MigrationDialog.tsx
@@ -19,6 +19,7 @@ import { RiScMigrationChanges41 } from './migrations/RiScMigrationChanges41.tsx'
 import { ChangeSetBox } from './migrations/components/ChangeSetBox.tsx';
 import { ChangeSetTitle } from './migrations/components/ChangeSetTitle.tsx';
 import { ChangeSetChangedValue } from './migrations/components/ChangeSetChangedValue.tsx';
+import { RiScMigrationChanges40 } from './migrations/RiScMigrationChanges40.tsx';
 
 interface RiScMigrationDialogProps {
   openDialog: boolean;
@@ -71,6 +72,11 @@ export const RiScMigrationDialog = ({
               newValue={migrationStatus.migrationVersions?.toVersion || ''}
             />
           </ChangeSetBox>
+          {migrationStatus.migrationChanges40 && (
+            <RiScMigrationChanges40
+              changes={migrationStatus.migrationChanges40}
+            />
+          )}
           {migrationStatus.migrationChanges41 && (
             <RiScMigrationChanges41
               changes={migrationStatus.migrationChanges41}

--- a/plugins/ros/src/components/riScInfo/migrations/RiScMigrationChanges40.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/RiScMigrationChanges40.tsx
@@ -1,0 +1,76 @@
+import { MigrationChanges40 } from '../../../utils/types.ts';
+import { MigrationTitle } from './components/MigrationTitle.tsx';
+import { ChangeSetBox } from './components/ChangeSetBox.tsx';
+import { ChangeSetTag } from './components/ChangeSetTag.tsx';
+import { ChangeSetChangedValue } from './components/ChangeSetChangedValue.tsx';
+import { ChangeSetBoxTitle } from './components/ChangeSetBoxTitle.tsx';
+import { ChangeSetTags } from './components/ChangeSetTags.tsx';
+import { ChangeSetText } from './components/ChangeSetText.tsx';
+import { ChangeSetRemovedProperty } from './components/ChangeSetRemovedProperty.tsx';
+
+interface RiScMigrationChanges40Props {
+  changes: MigrationChanges40;
+}
+
+export function RiScMigrationChanges40({
+  changes,
+}: RiScMigrationChanges40Props) {
+  return (
+    <>
+      <MigrationTitle
+        from="3.3"
+        to="4.0"
+        migrationExplanation="This migration removes the owner and deadline fields from actions, removes existing actions and updates values for vulnerabilities."
+        changelogUrl="https://github.com/kartverket/backstage-plugin-risk-scorecard-backend/blob/main/docs/schemaChangelog.md#40"
+      />
+      {changes.scenarios.map(scenario => (
+        <ChangeSetBox type="primary">
+          <ChangeSetTags>
+            <ChangeSetTag type="primary" text="Risk scenario" />
+          </ChangeSetTags>
+          <ChangeSetBoxTitle title={scenario.title} />
+          {scenario.changedVulnerabilities.length > 0 && (
+            <ChangeSetBox type="secondary">
+              <ChangeSetBoxTitle title="Vulnerabilities" />
+              {scenario.changedVulnerabilities.map(change => (
+                <ChangeSetChangedValue
+                  oldValue={change.oldValue}
+                  newValue={change.newValue}
+                />
+              ))}
+            </ChangeSetBox>
+          )}
+          {scenario.removedExistingActions && (
+            <ChangeSetBox type="secondary">
+              <ChangeSetTags>
+                <ChangeSetTag type="delete" text="Removed" />
+              </ChangeSetTags>
+              <ChangeSetBoxTitle title="Existing actions"/>
+              <ChangeSetText text={scenario.removedExistingActions} />
+            </ChangeSetBox>
+          )}
+          {scenario.changedActions.map(action => (
+            <ChangeSetBox type="secondary">
+              <ChangeSetTags>
+                <ChangeSetTag text="Action" type="primary" />
+              </ChangeSetTags>
+              <ChangeSetBoxTitle title={action.title} />
+              {action.removedOwner && (
+                <ChangeSetRemovedProperty
+                  propertyName="Owner"
+                  value={action.removedOwner}
+                />
+              )}
+              {action.removedDeadline && (
+                <ChangeSetRemovedProperty
+                  propertyName="Deadline"
+                  value={action.removedDeadline}
+                />
+              )}
+            </ChangeSetBox>
+          ))}
+        </ChangeSetBox>
+      ))}
+    </>
+  );
+}

--- a/plugins/ros/src/components/riScInfo/migrations/RiScMigrationChanges40.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/RiScMigrationChanges40.tsx
@@ -7,6 +7,8 @@ import { ChangeSetBoxTitle } from './components/ChangeSetBoxTitle.tsx';
 import { ChangeSetTags } from './components/ChangeSetTags.tsx';
 import { ChangeSetText } from './components/ChangeSetText.tsx';
 import { ChangeSetRemovedProperty } from './components/ChangeSetRemovedProperty.tsx';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { pluginRiScTranslationRef } from '../../../utils/translations.ts';
 
 interface RiScMigrationChanges40Props {
   changes: MigrationChanges40;
@@ -15,6 +17,7 @@ interface RiScMigrationChanges40Props {
 export function RiScMigrationChanges40({
   changes,
 }: RiScMigrationChanges40Props) {
+  const { t } = useTranslationRef(pluginRiScTranslationRef);
   return (
     <>
       <MigrationTitle
@@ -26,16 +29,23 @@ export function RiScMigrationChanges40({
       {changes.scenarios.map(scenario => (
         <ChangeSetBox type="primary">
           <ChangeSetTags>
-            <ChangeSetTag type="primary" text="Risk scenario" />
+            <ChangeSetTag
+              type="primary"
+              text={t('migrationDialog.tagScenario')}
+            />
           </ChangeSetTags>
           <ChangeSetBoxTitle title={scenario.title} />
           {scenario.changedVulnerabilities.length > 0 && (
             <ChangeSetBox type="secondary">
-              <ChangeSetBoxTitle title="Vulnerabilities" />
+              <ChangeSetBoxTitle
+                title={t('migrationDialog.migration40.vulnerabilitiesTitle')}
+              />
               {scenario.changedVulnerabilities.map(change => (
                 <ChangeSetChangedValue
-                  oldValue={change.oldValue}
-                  newValue={change.newValue}
+                  /* @ts-ignore Because ts can't typecheck strings against our keys */
+                  oldValue={t(`migrationDialog.migration40.vulnerabilities.${change.oldValue}`)}
+                  /* @ts-ignore Because ts can't typecheck strings against our keys */
+                  newValue={t(`migrationDialog.migration40.vulnerabilities.${change.newValue}`)}
                 />
               ))}
             </ChangeSetBox>
@@ -43,27 +53,35 @@ export function RiScMigrationChanges40({
           {scenario.removedExistingActions && (
             <ChangeSetBox type="secondary">
               <ChangeSetTags>
-                <ChangeSetTag type="delete" text="Removed" />
+                <ChangeSetTag
+                  type="delete"
+                  text={t('migrationDialog.tagRemoved')}
+                />
               </ChangeSetTags>
-              <ChangeSetBoxTitle title="Existing actions"/>
+              <ChangeSetBoxTitle
+                title={t('migrationDialog.migration40.existingActions')}
+              />
               <ChangeSetText text={scenario.removedExistingActions} />
             </ChangeSetBox>
           )}
           {scenario.changedActions.map(action => (
             <ChangeSetBox type="secondary">
               <ChangeSetTags>
-                <ChangeSetTag text="Action" type="primary" />
+                <ChangeSetTag
+                  type="primary"
+                  text={t('migrationDialog.tagAction')}
+                />
               </ChangeSetTags>
               <ChangeSetBoxTitle title={action.title} />
               {action.removedOwner && (
                 <ChangeSetRemovedProperty
-                  propertyName="Owner"
+                  propertyName={t('migrationDialog.migration40.owner')}
                   value={action.removedOwner}
                 />
               )}
               {action.removedDeadline && (
                 <ChangeSetRemovedProperty
-                  propertyName="Deadline"
+                  propertyName={t('migrationDialog.migration40.deadline')}
                   value={action.removedDeadline}
                 />
               )}

--- a/plugins/ros/src/components/riScInfo/migrations/RiScMigrationChanges40.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/RiScMigrationChanges40.tsx
@@ -43,9 +43,13 @@ export function RiScMigrationChanges40({
               {scenario.changedVulnerabilities.map(change => (
                 <ChangeSetChangedValue
                   /* @ts-ignore Because ts can't typecheck strings against our keys */
-                  oldValue={t(`migrationDialog.migration40.vulnerabilities.${change.oldValue}`)}
+                  oldValue={t(
+                    `migrationDialog.migration40.vulnerabilities.${change.oldValue}`,
+                  )}
                   /* @ts-ignore Because ts can't typecheck strings against our keys */
-                  newValue={t(`migrationDialog.migration40.vulnerabilities.${change.newValue}`)}
+                  newValue={t(
+                    `migrationDialog.migration40.vulnerabilities.${change.newValue}`,
+                  )}
                 />
               ))}
             </ChangeSetBox>

--- a/plugins/ros/src/components/riScInfo/migrations/RiScMigrationChanges40.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/RiScMigrationChanges40.tsx
@@ -23,7 +23,9 @@ export function RiScMigrationChanges40({
       <MigrationTitle
         from="3.3"
         to="4.0"
-        migrationExplanation="This migration removes the owner and deadline fields from actions, removes existing actions and updates values for vulnerabilities."
+        migrationExplanation={t(
+          'migrationDialog.migration41.changeExplanation',
+        )}
         changelogUrl="https://github.com/kartverket/backstage-plugin-risk-scorecard-backend/blob/main/docs/schemaChangelog.md#40"
       />
       {changes.scenarios.map(scenario => (

--- a/plugins/ros/src/components/riScInfo/migrations/RiScMigrationChanges41.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/RiScMigrationChanges41.tsx
@@ -6,6 +6,8 @@ import { ChangeSetTag } from './components/ChangeSetTag.tsx';
 import { ChangeSetBoxTitle } from './components/ChangeSetBoxTitle.tsx';
 import { ChangeSetChangedValue } from './components/ChangeSetChangedValue.tsx';
 import { ChangeSetTags } from './components/ChangeSetTags.tsx';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { pluginRiScTranslationRef } from '../../../utils/translations.ts';
 
 interface RiScMigrationChanges41Props {
   changes: MigrationChanges41;
@@ -14,6 +16,7 @@ interface RiScMigrationChanges41Props {
 export function RiScMigrationChanges41({
   changes,
 }: RiScMigrationChanges41Props) {
+  const { t } = useTranslationRef(pluginRiScTranslationRef);
   return (
     <>
       <MigrationTitle
@@ -25,7 +28,7 @@ export function RiScMigrationChanges41({
       {changes.scenarios.map(scenario => (
         <ChangeSetBox type="primary">
           <ChangeSetTags>
-            <ChangeSetTag type="primary" text="Risk scenario" />
+            <ChangeSetTag type="primary" text={t('migrationDialog.tagScenario')}/>
           </ChangeSetTags>
           <ChangeSetBoxTitle title={scenario.title} />
           <div

--- a/plugins/ros/src/components/riScInfo/migrations/RiScMigrationChanges41.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/RiScMigrationChanges41.tsx
@@ -1,0 +1,94 @@
+import { MigrationChanges41 } from '../../../utils/types.ts';
+import { formatNOK } from '../../../utils/utilityfunctions.ts';
+import { ChangeSetBox } from './components/ChangeSetBox.tsx';
+import { MigrationTitle } from './components/MigrationTitle.tsx';
+import { ChangeSetTag } from './components/ChangeSetTag.tsx';
+import { ChangeSetBoxTitle } from './components/ChangeSetBoxTitle.tsx';
+import { ChangeSetChangedValue } from './components/ChangeSetChangedValue.tsx';
+
+export function RiScMigrationChanges41({
+  changes,
+}: {
+  changes: MigrationChanges41;
+}) {
+  return (
+    <>
+      <MigrationTitle
+        from="4.0"
+        to="4.1"
+        migrationExplanation="This migration changes preset values for consequence and probability."
+        changelogUrl="https://github.com/kartverket/backstage-plugin-risk-scorecard-backend/blob/main/docs/schemaChangelog.md#41"
+      />
+      {changes.scenarios.map(scenario => (
+        <ChangeSetBox type="primary">
+          <ChangeSetTag text="Risk scenario" />
+          <ChangeSetBoxTitle title={scenario.title} />
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr',
+              gap: '18px',
+            }}
+          >
+            {(scenario.changedRiskConsequence ||
+              scenario.changedRiskProbability) && (
+              <div style={{ gridColumn: 1 }}>
+                <ChangeSetBox type="secondary">
+                  <ChangeSetBoxTitle title="Initial risk" />
+                  {scenario.changedRiskConsequence && (
+                    <ChangeSetChangedValue
+                      property="Consequence"
+                      oldValue={formatNOK(
+                        scenario.changedRiskConsequence.oldValue,
+                      )}
+                      newValue={formatNOK(
+                        scenario.changedRiskConsequence.newValue,
+                      )}
+                      denominator="NOK/incident"
+                    />
+                  )}
+                  {scenario.changedRiskProbability && (
+                    <ChangeSetChangedValue
+                      property="Probability"
+                      oldValue={scenario.changedRiskProbability.oldValue.toString()}
+                      newValue={scenario.changedRiskProbability.newValue.toString()}
+                      denominator="occurrences/year"
+                    />
+                  )}
+                </ChangeSetBox>
+              </div>
+            )}
+            {(scenario.changedRemainingRiskConsequence ||
+              scenario.changedRemainingRiskProbability) && (
+              <div style={{ gridColumn: 2 }}>
+                <ChangeSetBox type="secondary">
+                  <ChangeSetBoxTitle title="Remaining risk" />
+                  {scenario.changedRemainingRiskConsequence && (
+                      <ChangeSetChangedValue
+                          property="Consequence"
+                          oldValue={formatNOK(
+                              scenario.changedRemainingRiskConsequence.oldValue,
+                          )}
+                          newValue={formatNOK(
+                              scenario.changedRemainingRiskConsequence.newValue,
+                          )}
+                          denominator="NOK/incident"
+                      />
+                  )}
+                  {scenario.changedRemainingRiskProbability && (
+                      <ChangeSetChangedValue
+                          property="Probability"
+                          oldValue={scenario.changedRemainingRiskProbability.oldValue.toString()}
+                          newValue={scenario.changedRemainingRiskProbability.newValue.toString()}
+                          denominator="occurrences/year"
+                      />
+                  )}
+                </ChangeSetBox>
+              </div>
+            )}
+          </div>
+        </ChangeSetBox>
+      ))}
+    </>
+  );
+}

--- a/plugins/ros/src/components/riScInfo/migrations/RiScMigrationChanges41.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/RiScMigrationChanges41.tsx
@@ -42,7 +42,7 @@ export function RiScMigrationChanges41({
                   <ChangeSetBoxTitle title="Initial risk" />
                   {scenario.changedRiskConsequence && (
                     <ChangeSetChangedValue
-                      property="Consequence"
+                      propertyName="Consequence"
                       oldValue={formatNOK(
                         scenario.changedRiskConsequence.oldValue,
                       )}
@@ -54,7 +54,7 @@ export function RiScMigrationChanges41({
                   )}
                   {scenario.changedRiskProbability && (
                     <ChangeSetChangedValue
-                      property="Probability"
+                      propertyName="Probability"
                       oldValue={scenario.changedRiskProbability.oldValue.toString()}
                       newValue={scenario.changedRiskProbability.newValue.toString()}
                       denominator="occurrences/year"
@@ -70,7 +70,7 @@ export function RiScMigrationChanges41({
                   <ChangeSetBoxTitle title="Remaining risk" />
                   {scenario.changedRemainingRiskConsequence && (
                     <ChangeSetChangedValue
-                      property="Consequence"
+                      propertyName="Consequence"
                       oldValue={formatNOK(
                         scenario.changedRemainingRiskConsequence.oldValue,
                       )}
@@ -82,7 +82,7 @@ export function RiScMigrationChanges41({
                   )}
                   {scenario.changedRemainingRiskProbability && (
                     <ChangeSetChangedValue
-                      property="Probability"
+                      propertyName="Probability"
                       oldValue={scenario.changedRemainingRiskProbability.oldValue.toString()}
                       newValue={scenario.changedRemainingRiskProbability.newValue.toString()}
                       denominator="occurrences/year"

--- a/plugins/ros/src/components/riScInfo/migrations/RiScMigrationChanges41.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/RiScMigrationChanges41.tsx
@@ -22,7 +22,9 @@ export function RiScMigrationChanges41({
       <MigrationTitle
         from="4.0"
         to="4.1"
-        migrationExplanation="This migration changes preset values for consequence and probability."
+        migrationExplanation={t(
+          'migrationDialog.migration41.changeExplanation',
+        )}
         changelogUrl="https://github.com/kartverket/backstage-plugin-risk-scorecard-backend/blob/main/docs/schemaChangelog.md#41"
       />
       {changes.scenarios.map(scenario => (
@@ -45,25 +47,29 @@ export function RiScMigrationChanges41({
               scenario.changedRiskProbability) && (
               <div style={{ gridColumn: 1 }}>
                 <ChangeSetBox type="secondary">
-                  <ChangeSetBoxTitle title="Initial risk" />
+                  <ChangeSetBoxTitle title={t('dictionary.initialRisk')} />
                   {scenario.changedRiskConsequence && (
                     <ChangeSetChangedValue
-                      propertyName="Consequence"
+                      propertyName={t('dictionary.consequence')}
                       oldValue={formatNOK(
                         scenario.changedRiskConsequence.oldValue,
                       )}
                       newValue={formatNOK(
                         scenario.changedRiskConsequence.newValue,
                       )}
-                      denominator="NOK/incident"
+                      denominator={t(
+                        'migrationDialog.migration41.nokPerIncident',
+                      )}
                     />
                   )}
                   {scenario.changedRiskProbability && (
                     <ChangeSetChangedValue
-                      propertyName="Probability"
+                      propertyName={t('dictionary.probability')}
                       oldValue={scenario.changedRiskProbability.oldValue.toString()}
                       newValue={scenario.changedRiskProbability.newValue.toString()}
-                      denominator="occurrences/year"
+                      denominator={t(
+                        'migrationDialog.migration41.occurrencesPerYear',
+                      )}
                     />
                   )}
                 </ChangeSetBox>
@@ -73,25 +79,29 @@ export function RiScMigrationChanges41({
               scenario.changedRemainingRiskProbability) && (
               <div style={{ gridColumn: 2 }}>
                 <ChangeSetBox type="secondary">
-                  <ChangeSetBoxTitle title="Remaining risk" />
+                  <ChangeSetBoxTitle title={t('dictionary.restRisk')} />
                   {scenario.changedRemainingRiskConsequence && (
                     <ChangeSetChangedValue
-                      propertyName="Consequence"
+                      propertyName={t('dictionary.consequence')}
                       oldValue={formatNOK(
                         scenario.changedRemainingRiskConsequence.oldValue,
                       )}
                       newValue={formatNOK(
                         scenario.changedRemainingRiskConsequence.newValue,
                       )}
-                      denominator="NOK/incident"
+                      denominator={t(
+                        'migrationDialog.migration41.nokPerIncident',
+                      )}
                     />
                   )}
                   {scenario.changedRemainingRiskProbability && (
                     <ChangeSetChangedValue
-                      propertyName="Probability"
+                      propertyName={t('dictionary.probability')}
                       oldValue={scenario.changedRemainingRiskProbability.oldValue.toString()}
                       newValue={scenario.changedRemainingRiskProbability.newValue.toString()}
-                      denominator="occurrences/year"
+                      denominator={t(
+                        'migrationDialog.migration41.occurrencesPerYear',
+                      )}
                     />
                   )}
                 </ChangeSetBox>

--- a/plugins/ros/src/components/riScInfo/migrations/RiScMigrationChanges41.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/RiScMigrationChanges41.tsx
@@ -28,7 +28,10 @@ export function RiScMigrationChanges41({
       {changes.scenarios.map(scenario => (
         <ChangeSetBox type="primary">
           <ChangeSetTags>
-            <ChangeSetTag type="primary" text={t('migrationDialog.tagScenario')}/>
+            <ChangeSetTag
+              type="primary"
+              text={t('migrationDialog.tagScenario')}
+            />
           </ChangeSetTags>
           <ChangeSetBoxTitle title={scenario.title} />
           <div

--- a/plugins/ros/src/components/riScInfo/migrations/RiScMigrationChanges41.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/RiScMigrationChanges41.tsx
@@ -5,12 +5,15 @@ import { MigrationTitle } from './components/MigrationTitle.tsx';
 import { ChangeSetTag } from './components/ChangeSetTag.tsx';
 import { ChangeSetBoxTitle } from './components/ChangeSetBoxTitle.tsx';
 import { ChangeSetChangedValue } from './components/ChangeSetChangedValue.tsx';
+import { ChangeSetTags } from './components/ChangeSetTags.tsx';
+
+interface RiScMigrationChanges41Props {
+  changes: MigrationChanges41;
+}
 
 export function RiScMigrationChanges41({
   changes,
-}: {
-  changes: MigrationChanges41;
-}) {
+}: RiScMigrationChanges41Props) {
   return (
     <>
       <MigrationTitle
@@ -21,7 +24,9 @@ export function RiScMigrationChanges41({
       />
       {changes.scenarios.map(scenario => (
         <ChangeSetBox type="primary">
-          <ChangeSetTag text="Risk scenario" />
+          <ChangeSetTags>
+            <ChangeSetTag type="primary" text="Risk scenario" />
+          </ChangeSetTags>
           <ChangeSetBoxTitle title={scenario.title} />
           <div
             style={{
@@ -64,24 +69,24 @@ export function RiScMigrationChanges41({
                 <ChangeSetBox type="secondary">
                   <ChangeSetBoxTitle title="Remaining risk" />
                   {scenario.changedRemainingRiskConsequence && (
-                      <ChangeSetChangedValue
-                          property="Consequence"
-                          oldValue={formatNOK(
-                              scenario.changedRemainingRiskConsequence.oldValue,
-                          )}
-                          newValue={formatNOK(
-                              scenario.changedRemainingRiskConsequence.newValue,
-                          )}
-                          denominator="NOK/incident"
-                      />
+                    <ChangeSetChangedValue
+                      property="Consequence"
+                      oldValue={formatNOK(
+                        scenario.changedRemainingRiskConsequence.oldValue,
+                      )}
+                      newValue={formatNOK(
+                        scenario.changedRemainingRiskConsequence.newValue,
+                      )}
+                      denominator="NOK/incident"
+                    />
                   )}
                   {scenario.changedRemainingRiskProbability && (
-                      <ChangeSetChangedValue
-                          property="Probability"
-                          oldValue={scenario.changedRemainingRiskProbability.oldValue.toString()}
-                          newValue={scenario.changedRemainingRiskProbability.newValue.toString()}
-                          denominator="occurrences/year"
-                      />
+                    <ChangeSetChangedValue
+                      property="Probability"
+                      oldValue={scenario.changedRemainingRiskProbability.oldValue.toString()}
+                      newValue={scenario.changedRemainingRiskProbability.newValue.toString()}
+                      denominator="occurrences/year"
+                    />
                   )}
                 </ChangeSetBox>
               </div>

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetBox.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetBox.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+
+interface ChangeSetBoxProps {
+  type: 'primary' | 'secondary'
+  children: ReactNode[] | ReactNode;
+}
+
+export function ChangeSetBox({ children, type }: ChangeSetBoxProps) {
+  return (
+    <div
+      style={{
+        backgroundColor: type === 'primary' ? '#FCEBCD' : '#FFFFFF',
+        color: '#333333',
+        padding: '14px 18px',
+        marginBottom: type === 'primary' ? '24px' : '0',
+        height: '100%',
+        borderRadius: '24px',
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetBox.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetBox.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { useChangeSetStyles } from './changeSetStyles.ts';
 
 interface ChangeSetBoxProps {
   type: 'primary' | 'secondary'
@@ -6,16 +7,11 @@ interface ChangeSetBoxProps {
 }
 
 export function ChangeSetBox({ children, type }: ChangeSetBoxProps) {
+  const {box, boxPrimary, boxSecondary} = useChangeSetStyles()
+
   return (
     <div
-      style={{
-        backgroundColor: type === 'primary' ? '#FCEBCD' : '#FFFFFF',
-        color: '#333333',
-        padding: '14px 18px',
-        marginBottom: type === 'primary' ? '24px' : '12px',
-        height: '100%',
-        borderRadius: '24px',
-      }}
+      className={`${box} ${type === 'primary' ? boxPrimary : boxSecondary}`}
     >
       {children}
     </div>

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetBox.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetBox.tsx
@@ -2,16 +2,16 @@ import { ReactNode } from 'react';
 import { useChangeSetStyles } from './changeSetStyles.ts';
 
 interface ChangeSetBoxProps {
-  type: 'primary' | 'secondary'
+  type: 'primary' | 'secondary';
   children: ReactNode[] | ReactNode;
 }
 
 export function ChangeSetBox({ children, type }: ChangeSetBoxProps) {
-  const {box, boxPrimary, boxSecondary} = useChangeSetStyles()
+  const styles = useChangeSetStyles();
 
   return (
     <div
-      className={`${box} ${type === 'primary' ? boxPrimary : boxSecondary}`}
+      className={`${styles.box} ${type === 'primary' ? styles.boxPrimary : styles.boxSecondary}`}
     >
       {children}
     </div>

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetBox.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetBox.tsx
@@ -12,7 +12,7 @@ export function ChangeSetBox({ children, type }: ChangeSetBoxProps) {
         backgroundColor: type === 'primary' ? '#FCEBCD' : '#FFFFFF',
         color: '#333333',
         padding: '14px 18px',
-        marginBottom: type === 'primary' ? '24px' : '0',
+        marginBottom: type === 'primary' ? '24px' : '12px',
         height: '100%',
         borderRadius: '24px',
       }}

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetBoxTitle.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetBoxTitle.tsx
@@ -1,0 +1,18 @@
+interface ChangeSetBoxTitleProps {
+  title: string;
+}
+
+export function ChangeSetBoxTitle({ title }: ChangeSetBoxTitleProps) {
+  return (
+    <div
+      style={{
+        fontSize: '18px',
+        fontWeight: '700',
+        lineHeight: '26px',
+        marginBottom: '12px',
+      }}
+    >
+      {title}
+    </div>
+  );
+}

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetBoxTitle.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetBoxTitle.tsx
@@ -5,6 +5,6 @@ interface ChangeSetBoxTitleProps {
 }
 
 export function ChangeSetBoxTitle({ title }: ChangeSetBoxTitleProps) {
-  const { boxTitle } = useChangeSetStyles();
-  return <div className={boxTitle}>{title}</div>;
+  const styles = useChangeSetStyles();
+  return <div className={styles.boxTitle}>{title}</div>;
 }

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetBoxTitle.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetBoxTitle.tsx
@@ -1,18 +1,10 @@
+import { useChangeSetStyles } from './changeSetStyles.ts';
+
 interface ChangeSetBoxTitleProps {
   title: string;
 }
 
 export function ChangeSetBoxTitle({ title }: ChangeSetBoxTitleProps) {
-  return (
-    <div
-      style={{
-        fontSize: '18px',
-        fontWeight: '700',
-        lineHeight: '26px',
-        marginBottom: '12px',
-      }}
-    >
-      {title}
-    </div>
-  );
+  const { boxTitle } = useChangeSetStyles();
+  return <div className={boxTitle}>{title}</div>;
 }

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetChangedValue.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetChangedValue.tsx
@@ -1,5 +1,5 @@
 interface ChangeSetChangedValueProps {
-  property: string;
+  property?: string;
   oldValue: string;
   newValue: string;
   denominator?: string;
@@ -13,9 +13,11 @@ export function ChangeSetChangedValue({
 }: ChangeSetChangedValueProps) {
   return (
     <div style={{ color: '#333333' }}>
-      <span style={{ fontWeight: '700' }}>
-        {property}:
-      </span>{' '}
+      {property && (
+        <>
+          <span style={{ fontWeight: '700' }}>{property}:</span>{' '}
+        </>
+      )}
       <span
         style={{
           fontWeight: '700',

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetChangedValue.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetChangedValue.tsx
@@ -13,20 +13,16 @@ export function ChangeSetChangedValue({
   newValue,
   denominator,
 }: ChangeSetChangedValueProps) {
-  const {
-    changedProperty: changedPropertyStyle,
-    oldValue: oldValueStyle,
-    newValue: newValueStyle,
-  } = useChangeSetStyles();
+  const styles = useChangeSetStyles();
   return (
     <div>
       {propertyName && (
         <>
-          <span className={changedPropertyStyle}>{propertyName}:</span>{' '}
+          <span className={styles.changedProperty}>{propertyName}:</span>{' '}
         </>
       )}
-      <span className={oldValueStyle}>{oldValue}</span>{' '}
-      <span className={newValueStyle}>{newValue}</span>
+      <span className={styles.oldValue}>{oldValue}</span>{' '}
+      <span className={styles.newValue}>{newValue}</span>
       {denominator && (
         <>
           {' '}

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetChangedValue.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetChangedValue.tsx
@@ -1,0 +1,37 @@
+interface ChangeSetChangedValueProps {
+  property: string;
+  oldValue: string;
+  newValue: string;
+  denominator?: string;
+}
+
+export function ChangeSetChangedValue({
+  property,
+  oldValue,
+  newValue,
+  denominator,
+}: ChangeSetChangedValueProps) {
+  return (
+    <div style={{ color: '#333333' }}>
+      <span style={{ fontWeight: '700' }}>
+        {property}:
+      </span>{' '}
+      <span
+        style={{
+          fontWeight: '700',
+          color: '#D04A14',
+          textDecoration: 'line-through',
+        }}
+      >
+        {oldValue}
+      </span>{' '}
+      <span style={{ fontWeight: '700', color: '#156630' }}>{newValue}</span>
+      {denominator && (
+        <>
+          {' '}
+          <span>{denominator}</span>
+        </>
+      )}
+    </div>
+  );
+}

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetChangedValue.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetChangedValue.tsx
@@ -1,33 +1,32 @@
+import { useChangeSetStyles } from './changeSetStyles.ts';
+
 interface ChangeSetChangedValueProps {
-  property?: string;
+  propertyName?: string;
   oldValue: string;
   newValue: string;
   denominator?: string;
 }
 
 export function ChangeSetChangedValue({
-  property,
+  propertyName,
   oldValue,
   newValue,
   denominator,
 }: ChangeSetChangedValueProps) {
+  const {
+    changedProperty: changedPropertyStyle,
+    oldValue: oldValueStyle,
+    newValue: newValueStyle,
+  } = useChangeSetStyles();
   return (
-    <div style={{ color: '#333333' }}>
-      {property && (
+    <div>
+      {propertyName && (
         <>
-          <span style={{ fontWeight: '700' }}>{property}:</span>{' '}
+          <span className={changedPropertyStyle}>{propertyName}:</span>{' '}
         </>
       )}
-      <span
-        style={{
-          fontWeight: '700',
-          color: '#D04A14',
-          textDecoration: 'line-through',
-        }}
-      >
-        {oldValue}
-      </span>{' '}
-      <span style={{ fontWeight: '700', color: '#156630' }}>{newValue}</span>
+      <span className={oldValueStyle}>{oldValue}</span>{' '}
+      <span className={newValueStyle}>{newValue}</span>
       {denominator && (
         <>
           {' '}

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetRemovedProperty.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetRemovedProperty.tsx
@@ -1,0 +1,24 @@
+interface ChangeSetRemovedPropertyProps {
+  propertyName: string;
+  value: string;
+}
+
+export function ChangeSetRemovedProperty({
+  propertyName,
+  value,
+}: ChangeSetRemovedPropertyProps) {
+  return (
+    <div
+      style={{
+        color: '#D04A14',
+        textDecoration: 'line-through',
+        marginBottom: '8px',
+      }}
+    >
+      <div style={{ fontWeight: '700', fontSize: '18px', lineHeight: '26px' }}>
+        {propertyName}
+      </div>
+      <div style={{ fontWeight: '500', fontSize: '14px' }}>{value}</div>
+    </div>
+  );
+}

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetRemovedProperty.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetRemovedProperty.tsx
@@ -9,15 +9,11 @@ export function ChangeSetRemovedProperty({
   propertyName,
   value,
 }: ChangeSetRemovedPropertyProps) {
-  const {
-    removedPropertyContainer,
-    removedProperty: removedPropertyStyle,
-    removedValue: removedValueStyle,
-  } = useChangeSetStyles();
+  const styles = useChangeSetStyles();
   return (
-    <div className={removedPropertyContainer} >
-      <div className={removedPropertyStyle}>{propertyName}</div>
-      <div className={removedValueStyle}>{value}</div>
+    <div className={styles.removedPropertyContainer}>
+      <div className={styles.removedProperty}>{propertyName}</div>
+      <div className={styles.removedValue}>{value}</div>
     </div>
   );
 }

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetRemovedProperty.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetRemovedProperty.tsx
@@ -1,3 +1,5 @@
+import { useChangeSetStyles } from './changeSetStyles.ts';
+
 interface ChangeSetRemovedPropertyProps {
   propertyName: string;
   value: string;
@@ -7,18 +9,15 @@ export function ChangeSetRemovedProperty({
   propertyName,
   value,
 }: ChangeSetRemovedPropertyProps) {
+  const {
+    removedPropertyContainer,
+    removedProperty: removedPropertyStyle,
+    removedValue: removedValueStyle,
+  } = useChangeSetStyles();
   return (
-    <div
-      style={{
-        color: '#D04A14',
-        textDecoration: 'line-through',
-        marginBottom: '8px',
-      }}
-    >
-      <div style={{ fontWeight: '700', fontSize: '18px', lineHeight: '26px' }}>
-        {propertyName}
-      </div>
-      <div style={{ fontWeight: '500', fontSize: '14px' }}>{value}</div>
+    <div className={removedPropertyContainer} >
+      <div className={removedPropertyStyle}>{propertyName}</div>
+      <div className={removedValueStyle}>{value}</div>
     </div>
   );
 }

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetTag.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetTag.tsx
@@ -1,21 +1,14 @@
+import { useChangeSetStyles } from './changeSetStyles.ts';
+
 interface ChangeSetTagProps {
   text: string;
-  type: 'primary' | 'delete'
+  type: 'primary' | 'delete';
 }
 
 export function ChangeSetTag({ text, type }: ChangeSetTagProps) {
+  const { tag, tagPrimary, tagDelete } = useChangeSetStyles();
   return (
-    <div
-      style={{
-        backgroundColor: type === 'primary' ? '#FFDD9D' : '#FF6E60',
-        borderRadius: '24px',
-        width: 'fit-content',
-        padding: '1px 8px',
-        border: '1px solid',
-        borderColor: type === 'primary' ? '#333333' : '#C43631',
-        color: "#333333"
-      }}
-    >
+    <div className={`${tag} ${type === 'primary' ? tagPrimary : tagDelete}`}>
       {text}
     </div>
   );

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetTag.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetTag.tsx
@@ -1,17 +1,19 @@
 interface ChangeSetTagProps {
   text: string;
+  type: 'primary' | 'delete'
 }
 
-export function ChangeSetTag({ text }: ChangeSetTagProps) {
+export function ChangeSetTag({ text, type }: ChangeSetTagProps) {
   return (
     <div
       style={{
-        backgroundColor: '#FFDD9D',
+        backgroundColor: type === 'primary' ? '#FFDD9D' : '#FF6E60',
         borderRadius: '24px',
         width: 'fit-content',
         padding: '1px 8px',
-        border: '1px solid #333',
-        marginBottom: '4px',
+        border: '1px solid',
+        borderColor: type === 'primary' ? '#333333' : '#C43631',
+        color: "#333333"
       }}
     >
       {text}

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetTag.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetTag.tsx
@@ -6,9 +6,11 @@ interface ChangeSetTagProps {
 }
 
 export function ChangeSetTag({ text, type }: ChangeSetTagProps) {
-  const { tag, tagPrimary, tagDelete } = useChangeSetStyles();
+  const styles = useChangeSetStyles();
   return (
-    <div className={`${tag} ${type === 'primary' ? tagPrimary : tagDelete}`}>
+    <div
+      className={`${styles.tag} ${type === 'primary' ? styles.tagPrimary : styles.tagDelete}`}
+    >
       {text}
     </div>
   );

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetTag.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetTag.tsx
@@ -1,0 +1,20 @@
+interface ChangeSetTagProps {
+  text: string;
+}
+
+export function ChangeSetTag({ text }: ChangeSetTagProps) {
+  return (
+    <div
+      style={{
+        backgroundColor: '#FFDD9D',
+        borderRadius: '24px',
+        width: 'fit-content',
+        padding: '1px 8px',
+        border: '1px solid #333',
+        marginBottom: '4px',
+      }}
+    >
+      {text}
+    </div>
+  );
+}

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetTags.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetTags.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+
+interface ChangeSetTagsProps {
+  children: ReactNode[] | ReactNode;
+}
+
+export function ChangeSetTags({ children }: ChangeSetTagsProps) {
+  return (
+    <div
+      style={{
+        marginBottom: '4px',
+        display: 'flex',
+        gap: '4px',
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetTags.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetTags.tsx
@@ -6,6 +6,6 @@ interface ChangeSetTagsProps {
 }
 
 export function ChangeSetTags({ children }: ChangeSetTagsProps) {
-  const { tags } = useChangeSetStyles();
-  return <div className={tags}>{children}</div>;
+  const styles = useChangeSetStyles();
+  return <div className={styles.tags}>{children}</div>;
 }

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetTags.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetTags.tsx
@@ -1,19 +1,11 @@
 import { ReactNode } from 'react';
+import { useChangeSetStyles } from './changeSetStyles.ts';
 
 interface ChangeSetTagsProps {
   children: ReactNode[] | ReactNode;
 }
 
 export function ChangeSetTags({ children }: ChangeSetTagsProps) {
-  return (
-    <div
-      style={{
-        marginBottom: '4px',
-        display: 'flex',
-        gap: '4px',
-      }}
-    >
-      {children}
-    </div>
-  );
+  const { tags } = useChangeSetStyles();
+  return <div className={tags}>{children}</div>;
 }

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetText.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetText.tsx
@@ -5,6 +5,6 @@ interface ChangeSetTextProps {
 }
 
 export function ChangeSetText({ text }: ChangeSetTextProps) {
-  const { text: textStyle } = useChangeSetStyles();
-  return <p className={textStyle}>{text}</p>;
+  const styles = useChangeSetStyles();
+  return <p className={styles.text}>{text}</p>;
 }

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetText.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetText.tsx
@@ -1,7 +1,10 @@
+import { useChangeSetStyles } from './changeSetStyles.ts';
+
 interface ChangeSetTextProps {
   text: string;
 }
 
 export function ChangeSetText({ text }: ChangeSetTextProps) {
-  return <p style={{ fontWeight: '500', color: "#333333" }}>{text}</p>;
+  const { text: textStyle } = useChangeSetStyles();
+  return <p className={textStyle}>{text}</p>;
 }

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetText.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetText.tsx
@@ -1,0 +1,7 @@
+interface ChangeSetTextProps {
+  text: string;
+}
+
+export function ChangeSetText({ text }: ChangeSetTextProps) {
+  return <p style={{ fontWeight: '500', color: "#333333" }}>{text}</p>;
+}

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetTitle.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetTitle.tsx
@@ -1,0 +1,20 @@
+interface ChangeSetTitleProps {
+  text: string;
+}
+
+export function ChangeSetTitle({ text }: ChangeSetTitleProps) {
+  return (
+    <div
+      style={{
+        textTransform: 'uppercase',
+        letterSpacing: '1px',
+        color: '#333333',
+        fontWeight: '700',
+        fontSize: '14px',
+        marginBottom: '12px',
+      }}
+    >
+      {text}
+    </div>
+  );
+}

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetTitle.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetTitle.tsx
@@ -1,20 +1,10 @@
+import { useChangeSetStyles } from './changeSetStyles.ts';
+
 interface ChangeSetTitleProps {
   text: string;
 }
 
 export function ChangeSetTitle({ text }: ChangeSetTitleProps) {
-  return (
-    <div
-      style={{
-        textTransform: 'uppercase',
-        letterSpacing: '1px',
-        color: '#333333',
-        fontWeight: '700',
-        fontSize: '14px',
-        marginBottom: '12px',
-      }}
-    >
-      {text}
-    </div>
-  );
+  const { title } = useChangeSetStyles();
+  return <div className={title}>{text}</div>;
 }

--- a/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetTitle.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/ChangeSetTitle.tsx
@@ -5,6 +5,6 @@ interface ChangeSetTitleProps {
 }
 
 export function ChangeSetTitle({ text }: ChangeSetTitleProps) {
-  const { title } = useChangeSetStyles();
-  return <div className={title}>{text}</div>;
+  const styles = useChangeSetStyles();
+  return <div className={styles.title}>{text}</div>;
 }

--- a/plugins/ros/src/components/riScInfo/migrations/components/MigrationTitle.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/MigrationTitle.tsx
@@ -3,6 +3,8 @@ import { IconButton, Tooltip } from '@material-ui/core';
 import Link from '@mui/material/Link';
 import { HelpIcon } from '@backstage/core-components';
 import { useChangeSetStyles } from './changeSetStyles.ts';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { pluginRiScTranslationRef } from '../../../../utils/translations.ts';
 
 interface MigrationTitleProps {
   from: string;
@@ -18,13 +20,14 @@ export function MigrationTitle({
   changelogUrl,
 }: MigrationTitleProps) {
   const { migrationTitle, migrationChangelog } = useChangeSetStyles();
+  const { t } = useTranslationRef(pluginRiScTranslationRef);
   return (
     <div className={migrationTitle}>
-      <ChangeSetTitle text={`Migration from ${from} to ${to}`} />
+      <ChangeSetTitle text={t("migrationDialog.migrationTitle", {to: to, from: from})} />
       <div className={migrationChangelog}>
         <Tooltip title={migrationExplanation}>
           <Link target="_blank" href={changelogUrl} color="inherit">
-            Schema changelog
+            {t('migrationDialog.schemaChangelog')}
             <IconButton color="inherit" size="small">
               <HelpIcon fontSize="small" />
             </IconButton>

--- a/plugins/ros/src/components/riScInfo/migrations/components/MigrationTitle.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/MigrationTitle.tsx
@@ -2,6 +2,7 @@ import { ChangeSetTitle } from './ChangeSetTitle.tsx';
 import { IconButton, Tooltip } from '@material-ui/core';
 import Link from '@mui/material/Link';
 import { HelpIcon } from '@backstage/core-components';
+import { useChangeSetStyles } from './changeSetStyles.ts';
 
 interface MigrationTitleProps {
   from: string;
@@ -16,23 +17,13 @@ export function MigrationTitle({
   migrationExplanation,
   changelogUrl,
 }: MigrationTitleProps) {
+  const { migrationTitle, migrationChangelog } = useChangeSetStyles();
   return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        paddingRight: '4px',
-      }}
-    >
+    <div className={migrationTitle}>
       <ChangeSetTitle text={`Migration from ${from} to ${to}`} />
-      <div style={{ color: '#156630', fontWeight: '700' }}>
+      <div className={migrationChangelog}>
         <Tooltip title={migrationExplanation}>
-          <Link
-            target="_blank"
-            href={changelogUrl}
-            color="inherit"
-          >
+          <Link target="_blank" href={changelogUrl} color="inherit">
             Schema changelog
             <IconButton color="inherit" size="small">
               <HelpIcon fontSize="small" />

--- a/plugins/ros/src/components/riScInfo/migrations/components/MigrationTitle.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/MigrationTitle.tsx
@@ -19,12 +19,14 @@ export function MigrationTitle({
   migrationExplanation,
   changelogUrl,
 }: MigrationTitleProps) {
-  const { migrationTitle, migrationChangelog } = useChangeSetStyles();
+  const styles = useChangeSetStyles();
   const { t } = useTranslationRef(pluginRiScTranslationRef);
   return (
-    <div className={migrationTitle}>
-      <ChangeSetTitle text={t("migrationDialog.migrationTitle", {to: to, from: from})} />
-      <div className={migrationChangelog}>
+    <div className={styles.migrationTitle}>
+      <ChangeSetTitle
+        text={t('migrationDialog.migrationTitle', { to: to, from: from })}
+      />
+      <div className={styles.migrationChangelog}>
         <Tooltip title={migrationExplanation}>
           <Link target="_blank" href={changelogUrl} color="inherit">
             {t('migrationDialog.schemaChangelog')}

--- a/plugins/ros/src/components/riScInfo/migrations/components/MigrationTitle.tsx
+++ b/plugins/ros/src/components/riScInfo/migrations/components/MigrationTitle.tsx
@@ -1,0 +1,45 @@
+import { ChangeSetTitle } from './ChangeSetTitle.tsx';
+import { IconButton, Tooltip } from '@material-ui/core';
+import Link from '@mui/material/Link';
+import { HelpIcon } from '@backstage/core-components';
+
+interface MigrationTitleProps {
+  from: string;
+  to: string;
+  migrationExplanation: string;
+  changelogUrl: string;
+}
+
+export function MigrationTitle({
+  from,
+  to,
+  migrationExplanation,
+  changelogUrl,
+}: MigrationTitleProps) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        paddingRight: '4px',
+      }}
+    >
+      <ChangeSetTitle text={`Migration from ${from} to ${to}`} />
+      <div style={{ color: '#156630', fontWeight: '700' }}>
+        <Tooltip title={migrationExplanation}>
+          <Link
+            target="_blank"
+            href={changelogUrl}
+            color="inherit"
+          >
+            Schema changelog
+            <IconButton color="inherit" size="small">
+              <HelpIcon fontSize="small" />
+            </IconButton>
+          </Link>
+        </Tooltip>
+      </div>
+    </div>
+  );
+}

--- a/plugins/ros/src/components/riScInfo/migrations/components/changeSetStyles.ts
+++ b/plugins/ros/src/components/riScInfo/migrations/components/changeSetStyles.ts
@@ -1,0 +1,129 @@
+import { makeStyles, Theme } from '@material-ui/core';
+
+const removedColor = (theme: Theme) =>
+  theme.palette.type === 'dark' ? '#FFD4C2' : '#D04A14';
+const addedColor = (theme: Theme) =>
+  theme.palette.type === 'dark' ? '#99EFB6' : '#156630';
+
+const interactiveColor = (theme: Theme) =>
+  theme.palette.type === 'dark' ? '#99EFB6' : '#156630';
+
+const fontColorLight = '#FFFFFF';
+const fontColorDark = '#333333';
+
+const fontSizeTitle = '18px';
+const lineHeightTitle = '26px';
+const fontSizeNormal = '14px';
+const fontWeightBold = 700;
+const fontWeightSemiBold = 500;
+
+export const useChangeSetStyles = makeStyles((theme: Theme) => ({
+  // ChangeSetBox
+  box: {
+    padding: '14px 18px',
+    height: '100%',
+    borderRadius: '24px',
+    color: theme.palette.type === 'dark' ? fontColorLight : fontColorDark,
+    fontSize: fontSizeNormal,
+  },
+  boxPrimary: {
+    backgroundColor: theme.palette.type === 'dark' ? '#616161' : '#FCEBCD',
+    marginBottom: '24px',
+  },
+  boxSecondary: {
+    backgroundColor: theme.palette.type === 'dark' ? '#404040' : '#FFFFFF',
+    marginBottom: '12px',
+  },
+
+  // ChangeSetBoxTitle
+  boxTitle: {
+    fontWeight: fontWeightBold,
+    fontSize: fontSizeTitle,
+    lineHeight: '26px',
+    marginBottom: '12px',
+  },
+
+  // ChangeSetChangedValue
+  changedProperty: {
+    fontWeight: fontWeightBold,
+  },
+  oldValue: {
+    fontWeight: fontWeightBold,
+    color: removedColor(theme),
+    textDecoration: 'line-through',
+  },
+  newValue: {
+    fontWeight: fontWeightBold,
+    color: addedColor(theme),
+  },
+
+  // ChangeSetRemovedProperty
+  removedPropertyContainer: {
+    marginBottom: '8px',
+  },
+  removedProperty: {
+    fontWeight: fontWeightBold,
+    color: removedColor(theme),
+    textDecoration: 'line-through',
+    fontSize: fontSizeTitle,
+    lineHeight: lineHeightTitle,
+  },
+  removedValue: {
+    fontWeight: fontWeightSemiBold,
+    color: removedColor(theme),
+    textDecoration: 'line-through',
+    fontSize: fontSizeNormal,
+  },
+
+  // ChangeSetTag
+  tag: {
+    borderRadius: '24px',
+    width: 'fit-content',
+    padding: '1px 8px',
+    border: '1px solid',
+    color: fontColorDark,
+  },
+  tagPrimary: {
+    backgroundColor: '#FFDD9D',
+    borderColor: theme.palette.type === 'dark' ? '#FF9625' : '#333333',
+  },
+  tagDelete: {
+    backgroundColor: '#FF6E60',
+    borderColor: '#C43631',
+  },
+
+  // ChangeSetTags
+  tags: {
+    marginBottom: '4px',
+    display: 'flex',
+    gap: '4px',
+  },
+
+  // ChangeSetText
+  text: {
+    fontWeight: fontWeightSemiBold,
+    color: theme.palette.type === 'dark' ? fontColorLight : fontColorDark,
+  },
+
+  // ChangeSetTitle
+  title: {
+    textTransform: 'uppercase',
+    letterSpacing: '1px',
+    color: theme.palette.type === 'dark' ? fontColorLight : fontColorDark,
+    fontWeight: fontWeightBold,
+    fontSize: fontSizeNormal,
+    marginBottom: '12px',
+  },
+
+  // MigrationTitle
+  migrationTitle: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingRight: '4px',
+  },
+  migrationChangelog: {
+    color: interactiveColor(theme),
+    fontWeight: fontWeightBold,
+  },
+}));

--- a/plugins/ros/src/components/riScInfo/migrations/components/changeSetStyles.ts
+++ b/plugins/ros/src/components/riScInfo/migrations/components/changeSetStyles.ts
@@ -1,15 +1,32 @@
 import { makeStyles, Theme } from '@material-ui/core';
 
+// Retrieved from Kartverket's colour profile
+const white = '#FFFFFF';
+const orange50 = '#FCEBCD';
+const orange100 = '#FFDD9D';
+const orange300 = '#CF914A';
+const red100 = '#FFE2D4';
+const red200 = '#EBB095';
+const red400 = '#D04A14';
+const red500 = '#A32F00';
+const green100 = '#D0ECD6';
+const green200 = '#9FD2AB';
+const green500 = '#156630';
+const gray50 = '#F5F2F2';
+const gray400 = '#706F6E';
+const gray600 = '#4A4848';
+const gray900 = '#212121';
+
 const removedColor = (theme: Theme) =>
-  theme.palette.type === 'dark' ? '#FFD4C2' : '#D04A14';
+  theme.palette.type === 'dark' ? red100 : red500;
 const addedColor = (theme: Theme) =>
-  theme.palette.type === 'dark' ? '#99EFB6' : '#156630';
+  theme.palette.type === 'dark' ? green100 : green500;
 
 const interactiveColor = (theme: Theme) =>
-  theme.palette.type === 'dark' ? '#99EFB6' : '#156630';
+  theme.palette.type === 'dark' ? green200 : green500;
 
-const fontColorLight = '#FFFFFF';
-const fontColorDark = '#333333';
+const fontColorLight = gray50;
+const fontColorDark = gray900;
 
 const fontSizeTitle = '18px';
 const lineHeightTitle = '26px';
@@ -27,11 +44,11 @@ export const useChangeSetStyles = makeStyles((theme: Theme) => ({
     fontSize: fontSizeNormal,
   },
   boxPrimary: {
-    backgroundColor: theme.palette.type === 'dark' ? '#616161' : '#FCEBCD',
+    backgroundColor: theme.palette.type === 'dark' ? gray400 : orange50,
     marginBottom: '24px',
   },
   boxSecondary: {
-    backgroundColor: theme.palette.type === 'dark' ? '#404040' : '#FFFFFF',
+    backgroundColor: theme.palette.type === 'dark' ? gray600 : white,
     marginBottom: '12px',
   },
 
@@ -84,12 +101,12 @@ export const useChangeSetStyles = makeStyles((theme: Theme) => ({
     color: fontColorDark,
   },
   tagPrimary: {
-    backgroundColor: '#FFDD9D',
-    borderColor: theme.palette.type === 'dark' ? '#FF9625' : '#333333',
+    backgroundColor: orange100,
+    borderColor: orange300,
   },
   tagDelete: {
-    backgroundColor: '#FF6E60',
-    borderColor: '#C43631',
+    backgroundColor: red200,
+    borderColor: red400,
   },
 
   // ChangeSetTags

--- a/plugins/ros/src/components/riScInfo/riScStatus/RiScStatusComponent.tsx
+++ b/plugins/ros/src/components/riScInfo/riScStatus/RiScStatusComponent.tsx
@@ -309,7 +309,8 @@ export function RiScStatusComponent({
           )}
         </>
       )}
-      {migration && (
+      {/* Need to include the undefined check here, as TypeScript does not pick up that this check is part of `migration` */}
+      {migration && selectedRiSc.migrationStatus && (
         <Box>
           <Typography paragraph sx={subtitle1}>
             <WarningAmberOutlined
@@ -335,7 +336,7 @@ export function RiScStatusComponent({
             openDialog={migrationDialogIsOpen}
             handleUpdate={handleUpdate}
             handleCancel={() => setMigrationDialogIsOpen(false)}
-            migrationVersions={selectedRiSc.migrationStatus?.migrationVersions}
+            migrationStatus={selectedRiSc.migrationStatus}
           />
         </Box>
       )}

--- a/plugins/ros/src/utils/translations.ts
+++ b/plugins/ros/src/utils/translations.ts
@@ -656,15 +656,24 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
           'migrationDialog.migration40.deadline': 'Frist',
           'migrationDialog.migration40.existingActions': 'Eksisterende tiltak',
           'migrationDialog.migration40.vulnerabilitiesTitle': 'Sårbarheter',
-          'migrationDialog.migration40.vulnerabilities.Compromised admin user': 'Kompromittert adminbruker',
-          'migrationDialog.migration40.vulnerabilities.Denial of service': 'Tjenestenekt',
-          'migrationDialog.migration40.vulnerabilities.Disclosed secret': 'Lekket hemmelighet',
-          'migrationDialog.migration40.vulnerabilities.Escalation of rights': 'Rettighetseskalering',
-          'migrationDialog.migration40.vulnerabilities.Excessive use': 'Overdreven bruk',
-          'migrationDialog.migration40.vulnerabilities.Information leak': 'Informasjonslekkasje',
-          'migrationDialog.migration40.vulnerabilities.Unauthorized access': 'Uautorisert tilgang',
-          'migrationDialog.migration40.vulnerabilities.Unmonitored use': 'Uovervåket bruk',
-          'migrationDialog.migration40.vulnerabilities.User repudiation': 'Benekte brukerhandling',
+          'migrationDialog.migration40.vulnerabilities.Compromised admin user':
+            'Kompromittert adminbruker',
+          'migrationDialog.migration40.vulnerabilities.Denial of service':
+            'Tjenestenekt',
+          'migrationDialog.migration40.vulnerabilities.Disclosed secret':
+            'Lekket hemmelighet',
+          'migrationDialog.migration40.vulnerabilities.Escalation of rights':
+            'Rettighetseskalering',
+          'migrationDialog.migration40.vulnerabilities.Excessive use':
+            'Overdreven bruk',
+          'migrationDialog.migration40.vulnerabilities.Information leak':
+            'Informasjonslekkasje',
+          'migrationDialog.migration40.vulnerabilities.Unauthorized access':
+            'Uautorisert tilgang',
+          'migrationDialog.migration40.vulnerabilities.Unmonitored use':
+            'Uovervåket bruk',
+          'migrationDialog.migration40.vulnerabilities.User repudiation':
+            'Benekte brukerhandling',
 
           'scenarioTable.title': 'Risikoscenarioer',
           'scenarioTable.addScenarioButton': 'Legg til scenario',

--- a/plugins/ros/src/utils/translations.ts
+++ b/plugins/ros/src/utils/translations.ts
@@ -134,14 +134,33 @@ export const pluginRiScMessages = {
   },
   migrationDialog: {
     description:
-      'The changes have been done to adhere to the latest schema version. In this case, the RiSc was update to ',
-    description2: 'from',
-    description3: '. Review the ',
-    description4: 'for more information.',
-    changelog: 'schema changelog',
+      'The changes have been made to adhere to the latest schema version.',
+    migrationTitle: 'Migration from {{from}} to {{to}}',
+    schemaVersion: 'Schema version',
+    schemaChangelog: 'Schema changelog',
+    tagRemoved: 'Removed',
+    tagScenario: 'Risk scenario',
+    tagAction: 'Action',
     title: 'Save changes', // Lagre ROS migrering
     checkboxLabel:
       'I confirm that I have reviewed and wish to save the changes made during the migration.',
+    migration40: {
+      owner: 'Responsible',
+      deadline: 'Deadline',
+      existingActions: 'Existing actions',
+      vulnerabilitiesTitle: 'Vulnerabilities',
+      vulnerabilities: {
+        'Compromised admin user': 'Compromised admin user',
+        'Denial of service': 'Denial of service',
+        'Disclosed secret': 'Disclosed secret',
+        'Escalation of rights': 'Escalation of rights',
+        'Excessive use': 'Excessive use',
+        'Information leak': 'Information leak',
+        'User repudiation': 'User repudiation',
+        'Unauthorized access': 'Unauthorized use',
+        'Unmonitored use': 'Unmonitored use',
+      },
+    },
   },
   scenarioTable: {
     title: 'Risk scenarios',
@@ -624,14 +643,28 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
 
           'migrationDialog.title': 'Lagre endringer',
           'migrationDialog.description':
-            'Endringene er gjort for å følge den nyeste skjema versjonen. I dette tilfellet ble ROS-analysen oppdatert til ',
-          'migrationDialog.description2': 'fra',
-          'migrationDialog.description3': '. Se ',
-          'migrationDialog.description4': 'for mer informasjon.',
-          'migrationDialog.changelog': 'endringslogg for skjema',
-
+            'Endringene er gjort for å følge den nyeste skjemaversjonen.',
+          'migrationDialog.migrationTitle': 'Migrering fra {{from}} til {{to}}',
+          'migrationDialog.schemaVersion': 'Skjemaversjon',
+          'migrationDialog.schemaChangelog': 'Endringslogg for skjema',
+          'migrationDialog.tagRemoved': 'Fjernet',
+          'migrationDialog.tagScenario': 'Riskscenario',
+          'migrationDialog.tagAction': 'Tiltak',
           'migrationDialog.checkboxLabel':
             'Jeg bekrefter at jeg har gjennomgått og ønsker å lagre endringene som er gjort under migreringen.',
+          'migrationDialog.migration40.owner': 'Ansvarlig',
+          'migrationDialog.migration40.deadline': 'Frist',
+          'migrationDialog.migration40.existingActions': 'Eksisterende tiltak',
+          'migrationDialog.migration40.vulnerabilitiesTitle': 'Sårbarheter',
+          'migrationDialog.migration40.vulnerabilities.Compromised admin user': 'Kompromittert adminbruker',
+          'migrationDialog.migration40.vulnerabilities.Denial of service': 'Tjenestenekt',
+          'migrationDialog.migration40.vulnerabilities.Disclosed secret': 'Lekket hemmelighet',
+          'migrationDialog.migration40.vulnerabilities.Escalation of rights': 'Rettighetseskalering',
+          'migrationDialog.migration40.vulnerabilities.Excessive use': 'Overdreven bruk',
+          'migrationDialog.migration40.vulnerabilities.Information leak': 'Informasjonslekkasje',
+          'migrationDialog.migration40.vulnerabilities.Unauthorized access': 'Uautorisert tilgang',
+          'migrationDialog.migration40.vulnerabilities.Unmonitored use': 'Uovervåket bruk',
+          'migrationDialog.migration40.vulnerabilities.User repudiation': 'Benekte brukerhandling',
 
           'scenarioTable.title': 'Risikoscenarioer',
           'scenarioTable.addScenarioButton': 'Legg til scenario',

--- a/plugins/ros/src/utils/translations.ts
+++ b/plugins/ros/src/utils/translations.ts
@@ -145,6 +145,8 @@ export const pluginRiScMessages = {
     checkboxLabel:
       'I confirm that I have reviewed and wish to save the changes made during the migration.',
     migration40: {
+      changeExplanation:
+        'This migration changes preset values for consequence and probability.',
       owner: 'Responsible',
       deadline: 'Deadline',
       existingActions: 'Existing actions',
@@ -160,6 +162,12 @@ export const pluginRiScMessages = {
         'Unauthorized access': 'Unauthorized use',
         'Unmonitored use': 'Unmonitored use',
       },
+    },
+    migration41: {
+      changeExplanation:
+        'This migration removes the owner and deadline fields from actions, removes existing actions and updates values for vulnerabilities.',
+      nokPerIncident: 'NOK/incident',
+      occurrencesPerYear: 'occurrences/year',
     },
   },
   scenarioTable: {
@@ -652,6 +660,8 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
           'migrationDialog.tagAction': 'Tiltak',
           'migrationDialog.checkboxLabel':
             'Jeg bekrefter at jeg har gjennomgått og ønsker å lagre endringene som er gjort under migreringen.',
+          'migrationDialog.migration40.changeExplanation':
+            'Denne migreringen endrer standard verdiene for konsekvens og sannsynlighet.',
           'migrationDialog.migration40.owner': 'Ansvarlig',
           'migrationDialog.migration40.deadline': 'Frist',
           'migrationDialog.migration40.existingActions': 'Eksisterende tiltak',
@@ -674,6 +684,10 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
             'Uovervåket bruk',
           'migrationDialog.migration40.vulnerabilities.User repudiation':
             'Benekte brukerhandling',
+          'migrationDialog.migration41.changeExplanation':
+            'Denne migreringen fjerner ansvarlig («owner») og frist («deadline») feltene fra tiltak, fjerner eksisterende tiltak feltet og oppdaterer verdier for sårbarheter.',
+          'migrationDialog.migration41.nokPerIncident': 'NOK/hendelse',
+          'migrationDialog.migration41.occurrencesPerYear': 'hendelser/år',
 
           'scenarioTable.title': 'Risikoscenarioer',
           'scenarioTable.addScenarioButton': 'Legg til scenario',

--- a/plugins/ros/src/utils/types.ts
+++ b/plugins/ros/src/utils/types.ts
@@ -33,12 +33,58 @@ export type MigrationStatus = {
   migrationChanges: boolean;
   migrationRequiresNewApproval: boolean;
   migrationVersions?: MigrationVersions;
+  migrationChanges40?: MigrationChanges40;
+  migrationChanges41?: MigrationChanges41;
 };
 
 export type MigrationVersions = {
   fromVersion: string;
   toVersion: string;
 };
+
+export type MigrationChanges41 = {
+  scenarios: MigrationChanges41Scenario[];
+}
+
+export type MigrationChanges41Scenario = {
+  title: string;
+  id: string;
+  changedRiskConsequence?: MigrationChangedValue<number>
+  changedRiskProbability?: MigrationChangedValue<number>
+  changedRemainingRiskConsequence?: MigrationChangedValue<number>
+  changedRemainingRiskProbability?: MigrationChangedValue<number>
+}
+
+export type MigrationChanges40 = {
+  scenarios: MigrationChanges40Scenario[];
+}
+
+export type MigrationChanges40Scenario = {
+  title: string;
+  id: string;
+  removedExistingActions: MigrationChanges40ExistingAction[];
+  changedVulnerabilities: MigrationChangedValue<string>[];
+  changedActions: MigrationChanges40Action[];
+}
+
+export type MigrationChanges40ExistingAction = {
+  title: string;
+  id: string;
+  description: string;
+  status: string;
+}
+
+export type MigrationChanges40Action = {
+  title: string;
+  id: string;
+  removedOwner?: string;
+  removedDeadline?: string;
+}
+
+export type MigrationChangedValue<T> = {
+  oldValue: T;
+  newValue: T;
+}
 
 export type SopsConfig = {
   shamirThreshold: number;

--- a/plugins/ros/src/utils/types.ts
+++ b/plugins/ros/src/utils/types.ts
@@ -44,20 +44,20 @@ export type MigrationVersions = {
 
 export type MigrationChanges41 = {
   scenarios: MigrationChanges41Scenario[];
-}
+};
 
 export type MigrationChanges41Scenario = {
   title: string;
   id: string;
-  changedRiskConsequence?: MigrationChangedValue<number>
-  changedRiskProbability?: MigrationChangedValue<number>
-  changedRemainingRiskConsequence?: MigrationChangedValue<number>
-  changedRemainingRiskProbability?: MigrationChangedValue<number>
-}
+  changedRiskConsequence?: MigrationChangedValue<number>;
+  changedRiskProbability?: MigrationChangedValue<number>;
+  changedRemainingRiskConsequence?: MigrationChangedValue<number>;
+  changedRemainingRiskProbability?: MigrationChangedValue<number>;
+};
 
 export type MigrationChanges40 = {
   scenarios: MigrationChanges40Scenario[];
-}
+};
 
 export type MigrationChanges40Scenario = {
   title: string;
@@ -65,19 +65,19 @@ export type MigrationChanges40Scenario = {
   removedExistingActions?: string;
   changedVulnerabilities: MigrationChangedValue<string>[];
   changedActions: MigrationChanges40Action[];
-}
+};
 
 export type MigrationChanges40Action = {
   title: string;
   id: string;
   removedOwner?: string;
   removedDeadline?: string;
-}
+};
 
 export type MigrationChangedValue<T> = {
   oldValue: T;
   newValue: T;
-}
+};
 
 export type SopsConfig = {
   shamirThreshold: number;

--- a/plugins/ros/src/utils/types.ts
+++ b/plugins/ros/src/utils/types.ts
@@ -62,16 +62,9 @@ export type MigrationChanges40 = {
 export type MigrationChanges40Scenario = {
   title: string;
   id: string;
-  removedExistingActions: MigrationChanges40ExistingAction[];
+  removedExistingActions?: string;
   changedVulnerabilities: MigrationChangedValue<string>[];
   changedActions: MigrationChanges40Action[];
-}
-
-export type MigrationChanges40ExistingAction = {
-  title: string;
-  id: string;
-  description: string;
-  status: string;
 }
 
 export type MigrationChanges40Action = {


### PR DESCRIPTION
Currently, when a RiSc has been migrated, no changes are shown in the migration confirmation dialog:

<img width="630" alt="Screenshot 2025-05-28 at 08 49 05" src="https://github.com/user-attachments/assets/e5a417ed-9f6f-4b53-b077-f12df5792f87" />

This PR adds support for displaying the changes made in migrations.

**Version change field and migrations from 3.3 to 4.0:** 
<img width="930" alt="Screenshot 2025-05-28 at 08 46 29" src="https://github.com/user-attachments/assets/a35ebdb2-9f51-4020-8ca2-a3d7eb2be9cf" />

**Migrations from 4.0 to 4.1:**
<img width="892" alt="Screenshot 2025-05-28 at 08 50 51" src="https://github.com/user-attachments/assets/fb5d2d55-2051-4b90-80fb-b2ad8521d12e" />

For testing, run the changes locally and check out the RiSc at http://localhost:3000/catalog/default/component/componentMedSystemMedGcp/risc/risc-CdTjb for a RiSc migrated from version 3.3 to 4.1. 

Uses the new design based on the profile of Kartverket.