### PR TITLE
Remove double remove call when removing an action

### DIFF
--- a/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
@@ -76,7 +76,6 @@ export function ActionBox({
   }
 
   function confirmDeleteAction(): void {
-    remove(index);
     deleteAction(remove, index, onSubmit);
     setDeleteActionConfirmationIsOpen(false);
   }


### PR DESCRIPTION
Fixes a reported bug. Currently, deletion of an action triggers the `remove` function twice, effectively deleting two actions at once. One of these `remove` calls is removed.