### PR TITLE
Add tooltip to URL in Action

### DIFF
--- a/plugins/ros/src/components/scenarioDrawer/components/ActionFormItem.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionFormItem.tsx
@@ -116,7 +116,7 @@ export function ActionFormItem({
                 message: t('scenarioDrawer.action.urlError'),
               },
             })}
-            label={urlLabel}
+            label={<UrlLabel />}
             helperText={formState.errors.actions?.[index]?.url?.message}
             error={!!formState.errors.actions?.[index]?.url?.message}
           />
@@ -133,24 +133,27 @@ export function ActionFormItem({
   );
 }
 
-export const urlLabel = (
-  <Box
-    sx={{
-      display: 'flex',
-      gap: 1,
-      alignItems: 'center',
-    }}
-  >
-    {t('dictionary.url')}
-    <Tooltip
-      title={
-        <Typography variant="body2">
-          {t('scenarioDrawer.measureTab.urlDescription')}
-        </Typography>
-      }
-      arrow
+export function UrlLabel(): JSX.Element {
+  const { t } = useTranslationRef(pluginRiScTranslationRef);
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        gap: 1,
+        alignItems: 'center',
+      }}
     >
-      <HelpIcon color="primary" />
-    </Tooltip>
-  </Box>
-);
+      {t('dictionary.url')}
+      <Tooltip
+        title={
+          <Typography variant="body2">
+            {t('scenarioDrawer.measureTab.urlDescription')}
+          </Typography>
+        }
+        arrow
+      >
+        <HelpIcon color="primary" />
+      </Tooltip>
+    </Box>
+  );
+}

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionFormItem.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionFormItem.tsx
@@ -19,6 +19,8 @@ import { Input } from '../../common/Input';
 import { MarkdownInput } from '../../common/MarkdownInput';
 import { Select } from '../../common/Select';
 import { heading3 } from '../../common/typography';
+import HelpIcon from '@mui/icons-material/Help';
+import { Tooltip } from '@material-ui/core';
 
 type ActionFormItemProps = {
   formMethods: UseFormReturn<FormScenario>;
@@ -114,7 +116,7 @@ export function ActionFormItem({
                 message: t('scenarioDrawer.action.urlError'),
               },
             })}
-            label={t('dictionary.url')}
+            label={urlLabel}
             helperText={formState.errors.actions?.[index]?.url?.message}
             error={!!formState.errors.actions?.[index]?.url?.message}
           />
@@ -130,3 +132,25 @@ export function ActionFormItem({
     </>
   );
 }
+
+export const urlLabel = (
+  <Box
+    sx={{
+      display: 'flex',
+      gap: 1,
+      alignItems: 'center',
+    }}
+  >
+    {t('dictionary.url')}
+    <Tooltip
+      title={
+        <Typography variant="body2">
+          {t('scenarioDrawer.measureTab.urlDescription')}
+        </Typography>
+      }
+      arrow
+    >
+      <HelpIcon color="primary" />
+    </Tooltip>
+  </Box>
+);

--- a/plugins/ros/src/components/scenarioWizard/steps/ActionsStep.tsx
+++ b/plugins/ros/src/components/scenarioWizard/steps/ActionsStep.tsx
@@ -22,6 +22,9 @@ import { MarkdownInput } from '../../common/MarkdownInput';
 import { Select } from '../../common/Select';
 import { heading2, heading3, label, subtitle2 } from '../../common/typography';
 import { DeleteActionConfirmation } from '../../scenarioDrawer/components/DeleteConfirmation';
+import { Tooltip } from '@material-ui/core';
+import HelpIcon from '@mui/icons-material/Help';
+import { urlLabel } from '../../scenarioDrawer/components/ActionFormItem';
 
 export function ActionsStep({
   formMethods,
@@ -141,7 +144,7 @@ export function ActionsStep({
                         message: t('scenarioDrawer.action.urlError'),
                       },
                     })}
-                    label={t('dictionary.url')}
+                    label={urlLabel}
                     helperText={formState.errors.actions?.[index]?.url?.message}
                     error={!!formState.errors.actions?.[index]?.url?.message}
                   />

--- a/plugins/ros/src/components/scenarioWizard/steps/ActionsStep.tsx
+++ b/plugins/ros/src/components/scenarioWizard/steps/ActionsStep.tsx
@@ -22,9 +22,7 @@ import { MarkdownInput } from '../../common/MarkdownInput';
 import { Select } from '../../common/Select';
 import { heading2, heading3, label, subtitle2 } from '../../common/typography';
 import { DeleteActionConfirmation } from '../../scenarioDrawer/components/DeleteConfirmation';
-import { Tooltip } from '@material-ui/core';
-import HelpIcon from '@mui/icons-material/Help';
-import { urlLabel } from '../../scenarioDrawer/components/ActionFormItem';
+import { UrlLabel } from '../../scenarioDrawer/components/ActionFormItem';
 
 export function ActionsStep({
   formMethods,
@@ -144,7 +142,7 @@ export function ActionsStep({
                         message: t('scenarioDrawer.action.urlError'),
                       },
                     })}
-                    label={urlLabel}
+                    label={<UrlLabel />}
                     helperText={formState.errors.actions?.[index]?.url?.message}
                     error={!!formState.errors.actions?.[index]?.url?.message}
                   />

--- a/plugins/ros/src/utils/translations.ts
+++ b/plugins/ros/src/utils/translations.ts
@@ -358,7 +358,7 @@ export const pluginRiScMessages = {
       addMeasureButton: 'Add planned action',
       plannedMeasures: 'Planned actions',
       addMeasureTitleError: 'Action title is required',
-      urlDescription: 'E.g. link to Jira task',
+      urlDescription: 'For example, link to Jira task',
     },
     restRiskTab: {
       subtitle:
@@ -871,7 +871,7 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
           'scenarioDrawer.measureTab.addMeasureTitleError':
             'Tiltak må ha en tittel',
           'scenarioDrawer.measureTab.urlDescription':
-            'F.eks. link til Jira-oppgave',
+            'For eksempel lenke til Jira-oppgave',
           'consequenceTable.rows.1': 'Ubetydelig',
           'consequenceTable.rows.2': 'Liten',
           'consequenceTable.rows.3': 'Moderat',

--- a/plugins/ros/src/utils/translations.ts
+++ b/plugins/ros/src/utils/translations.ts
@@ -358,6 +358,7 @@ export const pluginRiScMessages = {
       addMeasureButton: 'Add planned action',
       plannedMeasures: 'Planned actions',
       addMeasureTitleError: 'Action title is required',
+      urlDescription: 'E.g. link to Jira task',
     },
     restRiskTab: {
       subtitle:
@@ -869,7 +870,8 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
           'scenarioDrawer.closeConfirmation': 'Vil du lagre endringene dine?',
           'scenarioDrawer.measureTab.addMeasureTitleError':
             'Tiltak må ha en tittel',
-
+          'scenarioDrawer.measureTab.urlDescription':
+            'F.eks. link til Jira-oppgave',
           'consequenceTable.rows.1': 'Ubetydelig',
           'consequenceTable.rows.2': 'Liten',
           'consequenceTable.rows.3': 'Moderat',
@@ -955,7 +957,6 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
           'actionStatus.On hold': 'På vent',
           'actionStatus.Completed': 'Fullført',
           'actionStatus.Aborted': 'Avbrutt',
-
           'errorMessages.DefaultErrorMessage': 'Det oppstod en feil',
           'errorMessages.NoWriteAccessToRepository':
             'Kunne ikke oppdatere ROS. Du har ikke skrivetilgang til dette repoet.',


### PR DESCRIPTION
Lagt til en ?-tooltip ved siden av URLen til et tiltak. Grunnen til det er fordi vi vil at det skal bli tydeligere hva URL-feltet er ment som. 

- Det vises når man endrer et tiltak
- Når man oppretter nytt tiltak
- Det vises ikke med mindre man skal redigere

Obs: I utgangspunktet burde det være samme komponent når man legger til/endrer et tiltak, men det har jeg skilt ut i en egen oppgave.

| Etter    | Før |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/bf80bd35-2942-4dde-b2e8-b3d098710bf5)  | ![image](https://github.com/user-attachments/assets/e5b1d9bc-d9f7-45a2-bbff-a262f14e71c9)|
| ![image](https://github.com/user-attachments/assets/509c6a15-19f1-4a70-b018-fb6cf2a64585)  | ![image](https://github.com/user-attachments/assets/4bcde788-8a30-405d-ba07-eddad2d33cea) |



