### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -3,6 +3,9 @@ name: Lint, test and compile plugin
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   compile_and_lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/security/code-scanning/4](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/security/code-scanning/4)

To fix the issue, add a `permissions` block to the root of the workflow file. This block will explicitly define the permissions required for the workflow, limiting access to the repository contents to read-only. Since the workflow does not perform any write operations, the `contents: read` permission is sufficient.

The `permissions` block should be added at the top level of the workflow file, ensuring it applies to all jobs in the workflow. No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
