### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Publish RiSc plugin to npmjs
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/security/code-scanning/3](https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the `GITHUB_TOKEN`. Since the workflow does not appear to use the `GITHUB_TOKEN` for write operations, we can set `contents: read` as the minimal permission. This ensures that the token cannot be used for unintended write actions while still allowing read access to repository contents if needed.

The `permissions` block should be added at the root level of the workflow, so it applies to all jobs. This change does not affect the functionality of the workflow but improves its security posture.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
