### PR TITLE
Upgrade koa from 2.15.4 to 2.16.1 to fix security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "resolutions": {
     "@mui/material": "5.16.4",
     "jsonpath-plus": "^10.2.0",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "@module-federation/dts-plugin": "0.9.1",
     "@node-saml/node-saml": "5.0.1",
     "multer": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26537,9 +26537,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"koa@npm:2.15.4":
-  version: 2.15.4
-  resolution: "koa@npm:2.15.4"
+"koa@npm:2.16.1":
+  version: 2.16.1
+  resolution: "koa@npm:2.16.1"
   dependencies:
     accepts: "npm:^1.3.5"
     cache-content-type: "npm:^1.0.0"
@@ -26564,7 +26564,7 @@ __metadata:
     statuses: "npm:^1.5.0"
     type-is: "npm:^1.6.16"
     vary: "npm:^1.1.2"
-  checksum: 10c0/fd2171b4dba706d35244fe60403a61671717a167453349813757999dad280049ddd0dcdba23cda197a5a3538f4c034cf0fd1f9caeb849be1ca1eecaa78db2f99
+  checksum: 10c0/66beb2e4d7968e1081341ea9a9c1f7f3fad4aaa0475c813f1be79ed84c345d9d45de9e34eeee3cdd790fc81ee5efbde2223d49fd5da571e29b0b3bed6baafb8e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Upgraded koa from version 2.15.4 to 2.16.1 via package.json resolution
- Fixes security vulnerability present in 2.15.4
- koa is a transitive dependency via @module-federation/dts-plugin

## Test plan
- [x] Dependencies installed successfully with yarn install
- [ ] Verify application still builds and runs correctly
- [ ] Run full test suite to ensure no regressions