### PR TITLE
feat(action): add exclamation mark for outdated actions

### DIFF
--- a/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
@@ -345,6 +345,7 @@ function Exclamations({
   action: Action;
   lastPublished?: LastPublished;
 }) {
+  const { t } = useTranslationRef(pluginRiScTranslationRef);
   const daysSinceLastUpdate = action.lastUpdated
     ? calculateDaysSince(new Date(action.lastUpdated))
     : null;
@@ -356,7 +357,7 @@ function Exclamations({
   switch (status) {
     case UpdatedStatusEnum.VERY_OUTDATED:
       return (
-        <Tooltip title="Tiltaket er veldig utdatert">
+        <Tooltip title={t('rosStatus.updatedStatus.tooltip.VERY_OUTDATED')}>
           <Box
             sx={{
               display: 'flex',
@@ -371,7 +372,7 @@ function Exclamations({
       );
     case UpdatedStatusEnum.OUTDATED:
       return (
-        <Tooltip title="Tiltaket er utdatert">
+        <Tooltip title={t(t('rosStatus.updatedStatus.tooltip.OUTDATED'))}>
           <Box sx={{ color: '#FF8B38', minWidth: '24px', textAlign: 'right' }}>
             <PriorityHigh sx={{ marginRight: '-6px', marginLeft: '-6px' }} />
           </Box>

--- a/plugins/ros/src/utils/translations.ts
+++ b/plugins/ros/src/utils/translations.ts
@@ -102,6 +102,10 @@ export const pluginRiScMessages = {
       VERY_OUTDATED: 'Very outdated status icon',
       error: 'Error status icon',
       disabled: 'Disabled status icon',
+      tooltip: {
+        OUTDATED: 'This action is outdated',
+        VERY_OUTDATED: 'This action is very outdated',
+      },
     },
     lastModified: 'Last published: ',
     daysSinceLastModified: '{{days}} days and {{numCommits}} commits ago',
@@ -691,6 +695,10 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
           'rosStatus.updatedStatus.VERY_OUTDATED': 'Veldig utdatert statusikon',
           'rosStatus.updatedStatus.error': 'Feil statusikon',
           'rosStatus.updatedStatus.disabled': 'Deaktivert statusikon',
+          'rosStatus.updatedStatus.tooltip.OUTDATED':
+            'Dette tiltaket er utdatert',
+          'rosStatus.updatedStatus.tooltip.VERY_OUTDATED':
+            'Dette tiltaket er veldig utdatert',
           'publishDialog.titleUpdate': 'Godkjenn ROS-analyse',
           'publishDialog.titleDelete': 'Godkjenn sletting',
           'publishDialog.checkboxLabelUpdate':


### PR DESCRIPTION
Show how outdated an action is based on how many days since it has been updated. 
Also moved the edit icon inside of the collapsable since it was too crowded on the heading. 

Right now the calculation of what status the action should have is based on the calculation of how outdated the ROS is. Our calculations is a bit aggressive compared to sikkerhetsmetrikker (often set as VERY_OUTDATED), and  

<img width="906" height="198" alt="image" src="https://github.com/user-attachments/assets/17dc39cf-16b7-49b7-aca2-d88a8f583296" />

<img width="895" height="308" alt="image" src="https://github.com/user-attachments/assets/afb2ed27-cbbb-4687-9fc6-ca379a75bc0b" />
