### PR TITLE
Dropdown clarity

### DIFF
--- a/plugins/ros/src/components/riScInfo/RiScInfo.tsx
+++ b/plugins/ros/src/components/riScInfo/RiScInfo.tsx
@@ -2,21 +2,18 @@ import { RiScWithMetadata } from '../../utils/types';
 import { Box, Grid, Typography } from '@material-ui/core';
 import { RiScStatusComponent } from './riScStatus/RiScStatusComponent';
 import { InfoCard } from '@backstage/core-components';
-import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
-import { pluginRiScTranslationRef } from '../../utils/translations';
-import { useFontStyles } from '../../utils/style';
 import EditButton from '../common/EditButton';
 import { useRiScs } from '../../contexts/RiScContext';
 import { Markdown } from '../common/Markdown';
+import { ReactNode } from 'react';
 
 interface RiScInfoProps {
   riScWithMetadata: RiScWithMetadata;
   edit: () => void;
+  topSlot?: ReactNode;
 }
 
-export function RiScInfo({ riScWithMetadata, edit }: RiScInfoProps) {
-  const { t } = useTranslationRef(pluginRiScTranslationRef);
-  const { label } = useFontStyles();
+export function RiScInfo({ riScWithMetadata, edit, topSlot }: RiScInfoProps) {
 
   const { approveRiSc } = useRiScs();
 
@@ -33,6 +30,7 @@ export function RiScInfo({ riScWithMetadata, edit }: RiScInfoProps) {
         }}
       >
         <InfoCard>
+            {topSlot && <Box sx={{ mb: 2 }}>{topSlot}</Box>}
           <Box
             style={{
               display: 'flex',
@@ -45,7 +43,6 @@ export function RiScInfo({ riScWithMetadata, edit }: RiScInfoProps) {
             </Typography>
             <EditButton onClick={edit} />
           </Box>
-          <Typography className={label}>{t('dictionary.scope')}</Typography>
           <Markdown description={riScWithMetadata.content.scope} />
         </InfoCard>
       </Grid>

--- a/plugins/ros/src/components/riScPlugin/RiScPlugin.tsx
+++ b/plugins/ros/src/components/riScPlugin/RiScPlugin.tsx
@@ -115,22 +115,6 @@ export function RiScPlugin() {
           {isFetching && <Spinner size={80} />}
 
           <Grid container spacing={4}>
-            {riScs !== null && riScs.length !== 0 && (
-              <Grid item xs={12} sm={6}>
-                <Select
-                  variant="standard"
-                  value={selectedRiSc?.id ?? ''}
-                  onChange={e => selectRiSc(e.target.value)}
-                  sx={{ width: '100%' }}
-                >
-                  {riScs.map(riSc => (
-                    <MenuItem key={riSc.id} value={riSc.id}>
-                      <ListItemText primary={riSc.content.title} />
-                    </MenuItem>
-                  )) ?? []}
-                </Select>
-              </Grid>
-            )}
 
             {!isFetching && (
               <Grid item xs>
@@ -140,7 +124,7 @@ export function RiScPlugin() {
                   color="success"
                   onClick={openCreateRiScDialog}
                   sx={{
-                    minWidth: '205px',
+                    alignItems: 'right',
                   }}
                 >
                   {t('contentHeader.createNewButton')}
@@ -171,12 +155,33 @@ export function RiScPlugin() {
               </Grid>
             )}
 
+
             {selectedRiSc && (
-              <>
+                <>
                 <Grid item xs={12}>
                   <RiScInfo
                     riScWithMetadata={selectedRiSc}
                     edit={openEditRiScDialog}
+                    topSlot={
+                        riScs !== null && riScs.length !== 0 &&
+                        <>
+                          <Typography variant="h6" sx={{ fontSize: 16, mb: 1 }}>
+                              {t('contentHeader.multipleRiScs')}
+                          </Typography>
+                              <Select
+                                  variant="standard"
+                                  value={selectedRiSc?.id ?? ''}
+                                  onChange={e => selectRiSc(e.target.value)}
+                                  sx={{ width: '100%' }}
+                              >
+                                {riScs.map(riSc => (
+                                    <MenuItem key={riSc.id} value={riSc.id}>
+                                      <ListItemText primary={riSc.content.title} />
+                                    </MenuItem>
+                                )) ?? []}
+                              </Select>
+                        </>
+                    }
                   />
                 </Grid>
                 <Grid item xs md={7} lg={8}>

--- a/plugins/ros/src/utils/translations.ts
+++ b/plugins/ros/src/utils/translations.ts
@@ -9,6 +9,7 @@ export const pluginRiScMessages = {
     createNewButton: 'Create new scorecard',
     editEncryption: 'Edit encryption',
     deleteButton: 'Delete scoreboard',
+    multipleRiScs: 'RiSc scorecards',
   },
   dictionary: {
     click: 'Click',
@@ -572,6 +573,7 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
           'contentHeader.createNewButton': 'Opprett ny analyse',
           'contentHeader.editEncryption': 'Rediger kryptering',
           'contentHeader.deleteButton': 'Slett analyse',
+          'contentHeader.multipleRiScs': 'RoS-analyser',
           'dictionary.rejectedLogin': 'Innlogging avbrutt av bruker.',
           'dictionary.click': 'Klikk',
           'dictionary.here': 'her',

--- a/plugins/ros/test-results/.last-run.json
+++ b/plugins/ros/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "failed",
+  "failedTests": []
+}


### PR DESCRIPTION
Moved dropdown into riscinfo box according to new design.

<img width="1519" height="616" alt="beforedropdown" src="https://github.com/user-attachments/assets/9838834f-891c-4547-b54b-38d4031dc793" />

<img width="1264" height="429" alt="image" src="https://github.com/user-attachments/assets/2b01150a-f852-4f0a-8492-1660c7ab134b" />

(Button(s) positioning will be its own pr)