### PR TITLE
Different colors on statuses

### DIFF
--- a/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
@@ -216,16 +216,19 @@ export function ActionBox({
             alignItems: 'center',
           }}
         >
-            <DualButton
-                propsCommon={{
-                    color: (() => {
-                        switch (action.status) {
-                            case ActionStatusOptions.OK: return 'success';
-                            case ActionStatusOptions.NotOK: return 'error';
-                            default: return 'inherit';
-                        }
-                    })(),
-                }}
+          <DualButton
+            propsCommon={{
+              color: (() => {
+                switch (action.status) {
+                  case ActionStatusOptions.OK:
+                    return 'success';
+                  case ActionStatusOptions.NotOK:
+                    return 'error';
+                  default:
+                    return 'inherit';
+                }
+              })(),
+            }}
             propsLeft={{
               children: translatedActionStatus,
               onClick: handleChipClick,


### PR DESCRIPTION
"Not ok" and "Not relevant" had same color (gray). "Not ok" is now red while "Not relevant" is gray.

<img width="716" height="183" alt="image" src="https://github.com/user-attachments/assets/17099059-78e6-4a38-8969-4cecc83ec6ae" />

<img width="727" height="183" alt="image" src="https://github.com/user-attachments/assets/fa3aad7d-b689-4726-9c20-011cb4c3225a" />
