### PR TITLE
prevent not relevant actions from showing in progress bar

### DIFF
--- a/plugins/ros/src/components/scenarioTable/ScenarioTableRow.tsx
+++ b/plugins/ros/src/components/scenarioTable/ScenarioTableRow.tsx
@@ -145,7 +145,11 @@ export function ScenarioTableRow({
                       a => a.status === ActionStatusOptions.OK,
                     ).length
                   }
-                  totalCount={scenario.actions.length}
+                  totalCount={
+                    scenario.actions.filter(
+                      a => a.status !== ActionStatusOptions.NotRelevant,
+                    ).length
+                  }
                 />
               );
             }


### PR DESCRIPTION
The following actions:

<img width="893" height="421" alt="Screenshot 2025-08-26 at 14 59 20" src="https://github.com/user-attachments/assets/e3c79eaf-cc52-42ab-95ea-e88a22912556" />

Will now display the following progress bar:
<img width="1071" height="71" alt="Screenshot 2025-08-26 at 14 59 28" src="https://github.com/user-attachments/assets/34736e42-56b9-4fa7-8fa2-13688a6fda55" />

An edge case is when all actions are not relevant, this is displayed as following:

<img width="1077" height="86" alt="Screenshot 2025-08-26 at 14 59 57" src="https://github.com/user-attachments/assets/91e7d746-5fea-4f5e-bf09-bdc3aad617ff" />

Worked together @martinbolle 