### PR TITLE
OK is no longer selected by default when updating stauts of actions

### DIFF
--- a/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
@@ -244,6 +244,7 @@ export function ActionBox({
             open={open}
             onClose={handleMenuClose}
             onClick={handleMenuClose}
+            autoFocus={false}
           >
             {Object.values(ActionStatusOptions).map(value => (
               <MenuItem key={value} onClick={() => handleStatusChange(value)}>

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
@@ -244,10 +244,13 @@ export function ActionBox({
             open={open}
             onClose={handleMenuClose}
             onClick={handleMenuClose}
-            autoFocus={false}
           >
             {Object.values(ActionStatusOptions).map(value => (
-              <MenuItem key={value} onClick={() => handleStatusChange(value)}>
+              <MenuItem
+                key={value}
+                onClick={() => handleStatusChange(value)}
+                selected={value === action.status}
+              >
                 {
                   /* @ts-ignore Because ts can't typecheck strings against our keys */
                   t(


### PR DESCRIPTION
<img width="173" height="185" alt="Screenshot 2025-08-26 at 15 42 26" src="https://github.com/user-attachments/assets/fd0bf458-21d1-4108-99f2-9fe7587a70e8" />


Worked together with @martinbolle 