### PR TITLE
Send action updates in batches on refresh functionality

### DIFF
--- a/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
@@ -119,9 +119,7 @@ export function ActionBox({
     updateActionInScenario({ status: newStatus });
   }
 
-  function isSameDay(): boolean {
-    const currentAction = scenario.actions.find(a => a.ID === action.ID);
-    const lastUpdated = currentAction?.lastUpdated;
+  function isToday(lastUpdated: Date | null): boolean {
     const today = new Date();
 
     if (!lastUpdated) return false;
@@ -228,14 +226,14 @@ export function ActionBox({
               startIcon: <Cached />,
               sx: { padding: '0 0 0 10px', minWidth: '30px' },
               onClick: () => {
+                if (isToday(action.lastUpdated ?? null)) return;
                 formMethods.setValue(
                   `actions.${index}.lastUpdated`,
                   new Date(),
                 );
-                !isSameDay() &&
-                  setCurrentUpdatedActionIDs(prev =>
-                    prev.includes(action.ID) ? prev : [...prev, action.ID],
-                  );
+                setCurrentUpdatedActionIDs(prev =>
+                  prev.includes(action.ID) ? prev : [...prev, action.ID],
+                );
               },
             }}
           />

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
@@ -48,6 +48,7 @@ interface ActionBoxProps {
   formMethods: UseFormReturn<FormScenario>;
   remove: UseFieldArrayRemove;
   onSubmit: () => void;
+  setCurrentUpdatedActionIDs: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
 export function ActionBox({
@@ -56,6 +57,7 @@ export function ActionBox({
   formMethods,
   remove,
   onSubmit,
+  setCurrentUpdatedActionIDs,
 }: ActionBoxProps) {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
 
@@ -115,11 +117,6 @@ export function ActionBox({
 
   function handleStatusChange(newStatus: string) {
     updateActionInScenario({ status: newStatus });
-  }
-
-  function refreshStatus() {
-    if (isSameDay()) return;
-    updateActionInScenario({});
   }
 
   function isSameDay(): boolean {
@@ -230,7 +227,16 @@ export function ActionBox({
             propsRight={{
               startIcon: <Cached />,
               sx: { padding: '0 0 0 10px', minWidth: '30px' },
-              onClick: () => refreshStatus(),
+              onClick: () => {
+                formMethods.setValue(
+                  `actions.${index}.lastUpdated`,
+                  new Date(),
+                );
+                !isSameDay() &&
+                  setCurrentUpdatedActionIDs(prev =>
+                    prev.includes(action.ID) ? prev : [...prev, action.ID],
+                  );
+              },
             }}
           />
           <Menu

--- a/plugins/ros/src/utils/hooks.ts
+++ b/plugins/ros/src/utils/hooks.ts
@@ -386,3 +386,27 @@ export function useIsMounted() {
 
   return useCallback(() => mountedRef.current, []);
 }
+
+export function useDebounce<T>(
+  value: T,
+  delay: number,
+  callback: (value: T) => void,
+) {
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    timeoutRef.current = setTimeout(() => {
+      callback(value);
+    }, delay);
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, [value, delay, callback]);
+}


### PR DESCRIPTION
Har lagt til en generisk hooks for debouncing. Debouncing vil si at timeren resetter seg om man trykker på et annet tiltak. Sender ikke til backend om datoen so man refresher er den samme som i dag