### PR TITLE
Batch update status

### DIFF
--- a/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
@@ -70,7 +70,7 @@ export function ActionBox({
 
   const { updateStatus, selectedRiSc } = useRiScs();
 
-  const { submitEditedScenarioToRiSc, mapFormScenarioToScenario, scenario } =
+  const { submitEditedScenarioToRiSc, mapFormScenarioToScenario } =
     useScenario();
 
   const isActionTitlePresent = action.title !== null && action.title !== '';

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
@@ -105,9 +105,10 @@ export function ActionBox({
 
   function updateActionInScenario(updates: ActionStatusOptions) {
     const actionIndex = scenario.actions.findIndex(a => a.ID === action.ID);
-    const currentStatus = formMethods.getValues()?.actions?.[actionIndex]?.status;
+    const currentStatus =
+      formMethods.getValues()?.actions?.[actionIndex]?.status;
 
-    if(updates === currentStatus){
+    if (updates === currentStatus) {
       handleMenuClose();
       return;
     }

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
@@ -103,20 +103,18 @@ export function ActionBox({
     ? formatDate(action.lastUpdated)
     : t('scenarioDrawer.action.notUpdated');
 
-  function updateActionInScenario(updates: Partial<Action>) {
-    const updatedScenario = {
-      ...scenario,
-      actions: scenario.actions.map(a =>
-        a.ID === action.ID ? { ...a, ...updates, lastUpdated: new Date() } : a,
-      ),
-    };
+  function updateActionInScenario(updates: ActionStatusOptions) {
+    formMethods.setValue(`actions.${index}.status`, updates);
 
-    submitEditedScenarioToRiSc(updatedScenario);
+    setCurrentUpdatedActionIDs(prev =>
+      prev.includes(action.ID) ? prev : [...prev, action.ID],
+    );
+
     if (isMounted()) handleMenuClose();
   }
 
-  function handleStatusChange(newStatus: string) {
-    updateActionInScenario({ status: newStatus });
+  function handleStatusChange(newStatus: ActionStatusOptions) {
+    updateActionInScenario(newStatus);
   }
 
   function isToday(lastUpdated: Date | null): boolean {

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionBox.tsx
@@ -70,7 +70,7 @@ export function ActionBox({
 
   const { updateStatus, selectedRiSc } = useRiScs();
 
-  const { submitEditedScenarioToRiSc, mapFormScenarioToScenario } =
+  const { submitEditedScenarioToRiSc, mapFormScenarioToScenario, scenario } =
     useScenario();
 
   const isActionTitlePresent = action.title !== null && action.title !== '';
@@ -104,6 +104,14 @@ export function ActionBox({
     : t('scenarioDrawer.action.notUpdated');
 
   function updateActionInScenario(updates: ActionStatusOptions) {
+    const actionIndex = scenario.actions.findIndex(a => a.ID === action.ID);
+    const currentStatus = formMethods.getValues()?.actions?.[actionIndex]?.status;
+
+    if(updates === currentStatus){
+      handleMenuClose();
+      return;
+    }
+
     formMethods.setValue(`actions.${index}.status`, updates);
 
     setCurrentUpdatedActionIDs(prev =>

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionsSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionsSection.tsx
@@ -116,13 +116,24 @@ export function ActionsSection({
 
   const { submitEditedScenarioToRiSc, scenario } = useScenario();
 
+  function indexOfAction(ID: string) {
+    return scenario.actions.findIndex(a => a.ID === ID);
+  }
+
   useDebounce(currentUpdatedActionIDs, 6000, updatedIDs => {
     if (updatedIDs.length === 0) return;
+
+    const formValues = formMethods.getValues();
     const updatedScenario = {
       ...scenario,
       actions: scenario.actions.map(a =>
-        updatedIDs.find(id => id === a.ID)
-          ? { ...a, lastUpdated: new Date() }
+        updatedIDs.includes(a.ID)
+          ? {
+              ...a,
+              status:
+                formValues.actions?.[indexOfAction(a.ID)]?.status ?? a.status,
+              lastUpdated: new Date(),
+            }
           : a,
       ),
     };


### PR DESCRIPTION
Added saving in batches for actions (ok, not ok, not relevant). Uses the same debounce hook which is applied to the refresh button. The action status data is sent in batches every 6th second if the status is changed.