### PR TITLE
Update drawer bug

### DIFF
--- a/plugins/ros/src/components/scenarioDrawer/components/ActionsSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionsSection.tsx
@@ -120,26 +120,29 @@ export function ActionsSection({
     return scenario.actions.findIndex(a => a.ID === ID);
   }
 
-  const debounceCallback = useCallback((updatedIDs: string[]) => {
-    if (updatedIDs.length === 0) return;
+  const debounceCallback = useCallback(
+    (updatedIDs: string[]) => {
+      if (updatedIDs.length === 0) return;
 
-    const formValues = formMethods.getValues();
-    const updatedScenario = {
-      ...scenario,
-      actions: scenario.actions.map(a =>
-        updatedIDs.includes(a.ID)
-          ? {
-              ...a,
-              status:
-                formValues.actions?.[indexOfAction(a.ID)]?.status ?? a.status,
-              lastUpdated: new Date(),
-            }
-          : a,
-      ),
-    };
-    submitEditedScenarioToRiSc(updatedScenario);
-    setCurrentUpdatedActionIDs([]);
-  }, [scenario, formMethods, setCurrentUpdatedActionIDs]);
+      const formValues = formMethods.getValues();
+      const updatedScenario = {
+        ...scenario,
+        actions: scenario.actions.map(a =>
+          updatedIDs.includes(a.ID)
+            ? {
+                ...a,
+                status:
+                  formValues.actions?.[indexOfAction(a.ID)]?.status ?? a.status,
+                lastUpdated: new Date(),
+              }
+            : a,
+        ),
+      };
+      submitEditedScenarioToRiSc(updatedScenario);
+      setCurrentUpdatedActionIDs([]);
+    },
+    [scenario, formMethods, setCurrentUpdatedActionIDs],
+  );
 
   useDebounce(currentUpdatedActionIDs, 6000, debounceCallback);
 

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionsSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionsSection.tsx
@@ -116,12 +116,11 @@ export function ActionsSection({
 
   const { submitEditedScenarioToRiSc, scenario } = useScenario();
 
-  function indexOfAction(ID: string) {
-    return scenario.actions.findIndex(a => a.ID === ID);
-  }
-
   const debounceCallback = useCallback(
     (updatedIDs: string[]) => {
+      const indexOfAction = (ID: string) => {
+        return scenario.actions.findIndex(a => a.ID === ID);
+      };
       if (updatedIDs.length === 0) return;
 
       const formValues = formMethods.getValues();
@@ -141,7 +140,7 @@ export function ActionsSection({
       submitEditedScenarioToRiSc(updatedScenario);
       setCurrentUpdatedActionIDs([]);
     },
-    [scenario, formMethods, setCurrentUpdatedActionIDs],
+    [scenario, formMethods, setCurrentUpdatedActionIDs, submitEditedScenarioToRiSc],
   );
 
   useDebounce(currentUpdatedActionIDs, 6000, debounceCallback);

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionsSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionsSection.tsx
@@ -140,7 +140,12 @@ export function ActionsSection({
       submitEditedScenarioToRiSc(updatedScenario);
       setCurrentUpdatedActionIDs([]);
     },
-    [scenario, formMethods, setCurrentUpdatedActionIDs, submitEditedScenarioToRiSc],
+    [
+      scenario,
+      formMethods,
+      setCurrentUpdatedActionIDs,
+      submitEditedScenarioToRiSc,
+    ],
   );
 
   useDebounce(currentUpdatedActionIDs, 6000, debounceCallback);

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionsSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionsSection.tsx
@@ -120,7 +120,7 @@ export function ActionsSection({
     return scenario.actions.findIndex(a => a.ID === ID);
   }
 
-  useDebounce(currentUpdatedActionIDs, 6000, updatedIDs => {
+  const debounceCallback = useCallback((updatedIDs: string[]) => {
     if (updatedIDs.length === 0) return;
 
     const formValues = formMethods.getValues();
@@ -139,7 +139,9 @@ export function ActionsSection({
     };
     submitEditedScenarioToRiSc(updatedScenario);
     setCurrentUpdatedActionIDs([]);
-  });
+  }, [scenario, formMethods, setCurrentUpdatedActionIDs]);
+
+  useDebounce(currentUpdatedActionIDs, 6000, debounceCallback);
 
   if (isEditing) {
     return (

--- a/plugins/ros/src/utils/hooks.ts
+++ b/plugins/ros/src/utils/hooks.ts
@@ -393,6 +393,11 @@ export function useDebounce<T>(
   callback: (value: T) => void,
 ) {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const latestValueRef = useRef<T>(value);
+
+  useEffect(() => {
+    latestValueRef.current = value;
+  }, [value]);
 
   useEffect(() => {
     if (timeoutRef.current) {
@@ -409,4 +414,10 @@ export function useDebounce<T>(
       }
     };
   }, [value, delay, callback]);
+
+  useEffect(() => {
+    return () => {
+      callback(latestValueRef.current);
+    };
+  }, [callback]);
 }


### PR DESCRIPTION
Bug fix: If the drawer was closed before the debounce fired, pending changes for an action were discarded. Now all pending changes are submitted when the drawer closes. 