### PR TITLE
Buttons moved according to figma skisse

### DIFF
--- a/plugins/ros/src/components/riScDialog/EditEncryptionButton.tsx
+++ b/plugins/ros/src/components/riScDialog/EditEncryptionButton.tsx
@@ -5,25 +5,25 @@ import { pluginRiScTranslationRef } from '../../utils/translations';
 import { useRiScs } from '../../contexts/RiScContext';
 
 export function EditEncryptionButton({
-                                         onEditEncryption
-                                     }: {
-    onEditEncryption: () => void;
+  onEditEncryption,
+}: {
+  onEditEncryption: () => void;
 }) {
-    const { t } = useTranslationRef(pluginRiScTranslationRef);
-    const { selectedRiSc } = useRiScs();
+  const { t } = useTranslationRef(pluginRiScTranslationRef);
+  const { selectedRiSc } = useRiScs();
 
-    if (!selectedRiSc) {
-        return null;
-    }
+  if (!selectedRiSc) {
+    return null;
+  }
 
-    return (
-        <Button
-            variant="text"
-            startIcon={<Settings />}
-            color="primary"
-            onClick={onEditEncryption}
-        >
-            {t('contentHeader.editEncryption')}
-        </Button>
-    );
+  return (
+    <Button
+      variant="text"
+      startIcon={<Settings />}
+      color="primary"
+      onClick={onEditEncryption}
+    >
+      {t('contentHeader.editEncryption')}
+    </Button>
+  );
 }

--- a/plugins/ros/src/components/riScDialog/EditEncryptionButton.tsx
+++ b/plugins/ros/src/components/riScDialog/EditEncryptionButton.tsx
@@ -1,0 +1,29 @@
+import { Button } from '@mui/material';
+import { Settings } from '@material-ui/icons';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { pluginRiScTranslationRef } from '../../utils/translations';
+import { useRiScs } from '../../contexts/RiScContext';
+
+export function EditEncryptionButton({
+                                         onEditEncryption
+                                     }: {
+    onEditEncryption: () => void;
+}) {
+    const { t } = useTranslationRef(pluginRiScTranslationRef);
+    const { selectedRiSc } = useRiScs();
+
+    if (!selectedRiSc) {
+        return null;
+    }
+
+    return (
+        <Button
+            variant="text"
+            startIcon={<Settings />}
+            color="primary"
+            onClick={onEditEncryption}
+        >
+            {t('contentHeader.editEncryption')}
+        </Button>
+    );
+}

--- a/plugins/ros/src/components/riScDialog/RiScDialog.tsx
+++ b/plugins/ros/src/components/riScDialog/RiScDialog.tsx
@@ -264,7 +264,10 @@ export function RiScDialog({
                 variant="text"
                 color="error"
                 onClick={onDelete}
-                sx={{ alignSelf: 'flex-start' }}
+                sx={{
+                    position: 'absolute',
+                    left: 16
+                }}
             >
                 {t('contentHeader.deleteButton')}
             </Button>

--- a/plugins/ros/src/components/riScDialog/RiScDialog.tsx
+++ b/plugins/ros/src/components/riScDialog/RiScDialog.tsx
@@ -17,6 +17,7 @@ import ConfigEncryptionDialog from './ConfigEncryptionDialog';
 import ConfigRiscInfo from './ConfigRiscInfo';
 import { Delete } from '@material-ui/icons';
 
+
 export enum RiScDialogStates {
   Closed = 0,
   Create = 1,

--- a/plugins/ros/src/components/riScDialog/RiScDialog.tsx
+++ b/plugins/ros/src/components/riScDialog/RiScDialog.tsx
@@ -15,6 +15,7 @@ import Box from '@mui/material/Box';
 import { Step, StepLabel, Stepper } from '@mui/material';
 import ConfigEncryptionDialog from './ConfigEncryptionDialog';
 import ConfigRiscInfo from './ConfigRiscInfo';
+import {Delete} from "@material-ui/icons";
 
 export enum RiScDialogStates {
   Closed = 0,
@@ -27,6 +28,7 @@ export enum RiScDialogStates {
 interface RiScDialogProps {
   onClose: () => void;
   dialogState: RiScDialogStates;
+  onDelete: () => void;
 }
 
 export enum CreateRiScFrom {
@@ -58,7 +60,11 @@ function RiScStepper({
   );
 }
 
-export function RiScDialog({ onClose, dialogState }: RiScDialogProps) {
+export function RiScDialog({
+   onClose,
+   dialogState,
+   onDelete,
+}: RiScDialogProps) {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
   const { selectedRiSc, createNewRiSc, deleteRiSc, updateRiSc, gcpCryptoKeys } =
     useRiScs();
@@ -234,7 +240,11 @@ export function RiScDialog({ onClose, dialogState }: RiScDialogProps) {
   if (dialogState === RiScDialogStates.EditRiscInfo) {
     return (
       <Dialog open={true} onClose={onClose}>
-        <DialogTitle>{t('rosDialog.titleEdit')}</DialogTitle>
+        <DialogTitle>
+            <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+            {t('rosDialog.titleEdit')}
+            </Box>
+        </DialogTitle>
         <DialogContent
           sx={{ display: 'flex', flexDirection: 'column', gap: '16px' }}
         >
@@ -249,6 +259,15 @@ export function RiScDialog({ onClose, dialogState }: RiScDialogProps) {
           />
         </DialogContent>
         <DialogActions sx={dialogActions}>
+            <Button
+                startIcon={<Delete />}
+                variant="text"
+                color="error"
+                onClick={onDelete}
+                sx={{ alignSelf: 'flex-start' }}
+            >
+                {t('contentHeader.deleteButton')}
+            </Button>
           <Button variant="outlined" onClick={onClose}>
             {t('dictionary.cancel')}
           </Button>

--- a/plugins/ros/src/components/riScDialog/RiScDialog.tsx
+++ b/plugins/ros/src/components/riScDialog/RiScDialog.tsx
@@ -17,7 +17,6 @@ import ConfigEncryptionDialog from './ConfigEncryptionDialog';
 import ConfigRiscInfo from './ConfigRiscInfo';
 import { Delete } from '@material-ui/icons';
 
-
 export enum RiScDialogStates {
   Closed = 0,
   Create = 1,

--- a/plugins/ros/src/components/riScDialog/RiScDialog.tsx
+++ b/plugins/ros/src/components/riScDialog/RiScDialog.tsx
@@ -15,7 +15,7 @@ import Box from '@mui/material/Box';
 import { Step, StepLabel, Stepper } from '@mui/material';
 import ConfigEncryptionDialog from './ConfigEncryptionDialog';
 import ConfigRiscInfo from './ConfigRiscInfo';
-import { Delete } from '@material-ui/icons';
+import { Delete as DeleteIcon } from '@material-ui/icons';
 
 export enum RiScDialogStates {
   Closed = 0,
@@ -260,7 +260,7 @@ export function RiScDialog({
         </DialogContent>
         <DialogActions sx={dialogActions}>
           <Button
-            startIcon={<Delete />}
+            startIcon={<DeleteIcon />}
             variant="text"
             color="error"
             onClick={onDelete}

--- a/plugins/ros/src/components/riScDialog/RiScDialog.tsx
+++ b/plugins/ros/src/components/riScDialog/RiScDialog.tsx
@@ -15,7 +15,7 @@ import Box from '@mui/material/Box';
 import { Step, StepLabel, Stepper } from '@mui/material';
 import ConfigEncryptionDialog from './ConfigEncryptionDialog';
 import ConfigRiscInfo from './ConfigRiscInfo';
-import {Delete} from "@material-ui/icons";
+import { Delete } from '@material-ui/icons';
 
 export enum RiScDialogStates {
   Closed = 0,
@@ -61,9 +61,9 @@ function RiScStepper({
 }
 
 export function RiScDialog({
-   onClose,
-   dialogState,
-   onDelete,
+  onClose,
+  dialogState,
+  onDelete,
 }: RiScDialogProps) {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
   const { selectedRiSc, createNewRiSc, deleteRiSc, updateRiSc, gcpCryptoKeys } =
@@ -241,9 +241,9 @@ export function RiScDialog({
     return (
       <Dialog open={true} onClose={onClose}>
         <DialogTitle>
-            <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+          <Box sx={{ display: 'flex', flexDirection: 'column' }}>
             {t('rosDialog.titleEdit')}
-            </Box>
+          </Box>
         </DialogTitle>
         <DialogContent
           sx={{ display: 'flex', flexDirection: 'column', gap: '16px' }}
@@ -259,18 +259,18 @@ export function RiScDialog({
           />
         </DialogContent>
         <DialogActions sx={dialogActions}>
-            <Button
-                startIcon={<Delete />}
-                variant="text"
-                color="error"
-                onClick={onDelete}
-                sx={{
-                    position: 'absolute',
-                    left: 16
-                }}
-            >
-                {t('contentHeader.deleteButton')}
-            </Button>
+          <Button
+            startIcon={<Delete />}
+            variant="text"
+            color="error"
+            onClick={onDelete}
+            sx={{
+              position: 'absolute',
+              left: 16,
+            }}
+          >
+            {t('contentHeader.deleteButton')}
+          </Button>
           <Button variant="outlined" onClick={onClose}>
             {t('dictionary.cancel')}
           </Button>

--- a/plugins/ros/src/components/riScPlugin/FeedbackDialog.tsx
+++ b/plugins/ros/src/components/riScPlugin/FeedbackDialog.tsx
@@ -14,6 +14,28 @@ import { dialogActions } from '../common/mixins.ts';
 import { AddComment } from '@material-ui/icons';
 import { useAuthenticatedFetch } from '../../utils/hooks.ts';
 import Alert from '@mui/material/Alert';
+import { Settings } from '@material-ui/icons';
+import { useRiScs } from '../../contexts/RiScContext'
+
+export function EditEncryptionButton({ onEditEncryption }: { onEditEncryption: () => void }) {
+  const { t } = useTranslationRef(pluginRiScTranslationRef);
+  const { selectedRiSc } = useRiScs();
+
+  if (!selectedRiSc) {
+    return null;
+  }
+
+  return (
+      <Button
+          variant="text"
+          startIcon={<Settings />}
+          color="primary"
+          onClick={onEditEncryption}
+      >
+        {t('contentHeader.editEncryption')}
+      </Button>
+  );
+}
 
 export function FeedbackDialog() {
   const { t } = useTranslationRef(pluginRiScTranslationRef);

--- a/plugins/ros/src/components/riScPlugin/FeedbackDialog.tsx
+++ b/plugins/ros/src/components/riScPlugin/FeedbackDialog.tsx
@@ -14,32 +14,6 @@ import { dialogActions } from '../common/mixins.ts';
 import { AddComment } from '@material-ui/icons';
 import { useAuthenticatedFetch } from '../../utils/hooks.ts';
 import Alert from '@mui/material/Alert';
-import { Settings } from '@material-ui/icons';
-import { useRiScs } from '../../contexts/RiScContext';
-
-export function EditEncryptionButton({
-  onEditEncryption,
-}: {
-  onEditEncryption: () => void;
-}) {
-  const { t } = useTranslationRef(pluginRiScTranslationRef);
-  const { selectedRiSc } = useRiScs();
-
-  if (!selectedRiSc) {
-    return null;
-  }
-
-  return (
-    <Button
-      variant="text"
-      startIcon={<Settings />}
-      color="primary"
-      onClick={onEditEncryption}
-    >
-      {t('contentHeader.editEncryption')}
-    </Button>
-  );
-}
 
 export function FeedbackDialog() {
   const { t } = useTranslationRef(pluginRiScTranslationRef);

--- a/plugins/ros/src/components/riScPlugin/FeedbackDialog.tsx
+++ b/plugins/ros/src/components/riScPlugin/FeedbackDialog.tsx
@@ -15,9 +15,13 @@ import { AddComment } from '@material-ui/icons';
 import { useAuthenticatedFetch } from '../../utils/hooks.ts';
 import Alert from '@mui/material/Alert';
 import { Settings } from '@material-ui/icons';
-import { useRiScs } from '../../contexts/RiScContext'
+import { useRiScs } from '../../contexts/RiScContext';
 
-export function EditEncryptionButton({ onEditEncryption }: { onEditEncryption: () => void }) {
+export function EditEncryptionButton({
+  onEditEncryption,
+}: {
+  onEditEncryption: () => void;
+}) {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
   const { selectedRiSc } = useRiScs();
 
@@ -26,14 +30,14 @@ export function EditEncryptionButton({ onEditEncryption }: { onEditEncryption: (
   }
 
   return (
-      <Button
-          variant="text"
-          startIcon={<Settings />}
-          color="primary"
-          onClick={onEditEncryption}
-      >
-        {t('contentHeader.editEncryption')}
-      </Button>
+    <Button
+      variant="text"
+      startIcon={<Settings />}
+      color="primary"
+      onClick={onEditEncryption}
+    >
+      {t('contentHeader.editEncryption')}
+    </Button>
   );
 }
 

--- a/plugins/ros/src/components/riScPlugin/RiScPlugin.tsx
+++ b/plugins/ros/src/components/riScPlugin/RiScPlugin.tsx
@@ -12,12 +12,13 @@ import { getAlertSeverity } from '../../utils/utilityfunctions';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { pluginRiScTranslationRef } from '../../utils/translations';
 import { RiScDialog, RiScDialogStates } from '../riScDialog/RiScDialog';
+import { EditEncryptionButton } from '../riScDialog/EditEncryptionButton';
 import { RiScInfo } from '../riScInfo/RiScInfo';
 import { Spinner } from '../common/Spinner';
 import { useRiScs } from '../../contexts/RiScContext';
 import { ScenarioWizardSteps } from '../../contexts/ScenarioContext';
 import { ScenarioTableWrapper } from '../scenarioTable/ScenarioTable';
-import { FeedbackDialog, EditEncryptionButton } from './FeedbackDialog.tsx';
+import { FeedbackDialog } from './FeedbackDialog.tsx';
 
 export function RiScPlugin() {
   const { t } = useTranslationRef(pluginRiScTranslationRef);

--- a/plugins/ros/src/components/riScPlugin/RiScPlugin.tsx
+++ b/plugins/ros/src/components/riScPlugin/RiScPlugin.tsx
@@ -5,7 +5,6 @@ import { ScenarioWizard } from '../scenarioWizard/ScenarioWizard';
 import { ScenarioDrawer } from '../scenarioDrawer/ScenarioDrawer';
 import { RiskMatrix } from '../riskMatrix/RiskMatrix';
 import Alert from '@mui/material/Alert';
-import Button from '@mui/material/Button';
 import Grid from '@mui/material/Grid';
 import LinearProgress from '@mui/material/LinearProgress';
 import Typography from '@mui/material/Typography';
@@ -18,9 +17,7 @@ import { Spinner } from '../common/Spinner';
 import { useRiScs } from '../../contexts/RiScContext';
 import { ScenarioWizardSteps } from '../../contexts/ScenarioContext';
 import { ScenarioTableWrapper } from '../scenarioTable/ScenarioTable';
-import { Delete, Settings } from '@mui/icons-material';
-import { RiScStatus } from '../../utils/types';
-import { FeedbackDialog } from './FeedbackDialog.tsx';
+import { FeedbackDialog, EditEncryptionButton } from './FeedbackDialog.tsx';
 
 export function RiScPlugin() {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
@@ -101,6 +98,7 @@ export function RiScPlugin() {
                 flexDirection: 'row',
               }}
             >
+              <EditEncryptionButton onEditEncryption={openEditEncryptionDialog} />
               <SupportButton />
               <FeedbackDialog />
             </Grid>
@@ -109,34 +107,6 @@ export function RiScPlugin() {
           {isFetching && <Spinner size={80} />}
 
           <Grid container spacing={4}>
-            {!isFetching && (
-              <Grid item xs>
-                {selectedRiSc &&
-                  selectedRiSc.status !== RiScStatus.DeletionDraft &&
-                  selectedRiSc.status !==
-                    RiScStatus.DeletionSentForApproval && (
-                    <>
-                      <Button
-                        startIcon={<Delete />}
-                        variant="text"
-                        color="error"
-                        onClick={openDeleteRiScDialog}
-                      >
-                        {t('contentHeader.deleteButton')}
-                      </Button>
-                      <Button
-                        startIcon={<Settings />}
-                        variant="text"
-                        color="primary"
-                        onClick={openEditEncryptionDialog}
-                      >
-                        {t('contentHeader.editEncryption')}
-                      </Button>
-                    </>
-                  )}
-              </Grid>
-            )}
-
             {selectedRiSc && (
               <>
                 <Grid item xs={12}>
@@ -159,7 +129,11 @@ export function RiScPlugin() {
       )}
 
       {riScDialogState !== RiScDialogStates.Closed && (
-        <RiScDialog onClose={closeRiScDialog} dialogState={riScDialogState} />
+        <RiScDialog
+            onClose={closeRiScDialog}
+            dialogState={riScDialogState}
+            onDelete={openDeleteRiScDialog}
+        />
       )}
 
       {!scenarioWizardStep && <ScenarioDrawer />}

--- a/plugins/ros/src/components/riScPlugin/RiScPlugin.tsx
+++ b/plugins/ros/src/components/riScPlugin/RiScPlugin.tsx
@@ -98,7 +98,9 @@ export function RiScPlugin() {
                 flexDirection: 'row',
               }}
             >
-              <EditEncryptionButton onEditEncryption={openEditEncryptionDialog} />
+              <EditEncryptionButton
+                onEditEncryption={openEditEncryptionDialog}
+              />
               <SupportButton />
               <FeedbackDialog />
             </Grid>
@@ -130,9 +132,9 @@ export function RiScPlugin() {
 
       {riScDialogState !== RiScDialogStates.Closed && (
         <RiScDialog
-            onClose={closeRiScDialog}
-            dialogState={riScDialogState}
-            onDelete={openDeleteRiScDialog}
+          onClose={closeRiScDialog}
+          dialogState={riScDialogState}
+          onDelete={openDeleteRiScDialog}
         />
       )}
 


### PR DESCRIPTION
Buttons moved according to figma skisse:

https://www.figma.com/design/oN4n44sSrjRfiMHDLbVyx1/Skisser?node-id=5379-1730&p=f&t=efBIFXZxioQpuQWU-0

<img width="1264" height="352" alt="Screenshot 2025-09-05 at 15 02 10" src="https://github.com/user-attachments/assets/433fdad0-b0ca-4bd7-8d7d-be6b65f18ebe" />

<img width="674" height="543" alt="image" src="https://github.com/user-attachments/assets/ba8ad1e4-fd34-4f74-ac04-47f13ab1ae3a" />


** er litt usikker på om EditEncryptionButton burde ligge under /common med andre gjenbrukbare komponenter eller under riscDialog der jeg la den nå