### PR TITLE
Bug fixes - Buttons does not lag and info message does not show error state after update.

### DIFF
--- a/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
@@ -79,7 +79,7 @@ export function ScenarioDrawer() {
   );
   const { flush } = useDebounce(
     currentUpdatedActionIDs,
-    3000,
+    6000,
     debounceCallback,
   );
 

--- a/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
@@ -21,6 +21,8 @@ import RiskFormSection from './components/RiskFormSection';
 import { RiskSection } from './components/RiskSection';
 import ScopeFormSection from './components/ScopeFormSection';
 import { ScopeSection } from './components/ScopeSection';
+import { useCallback } from 'react';
+import { useDebounce } from '../../utils/hooks';
 
 export function ScenarioDrawer() {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
@@ -44,6 +46,42 @@ export function ScenarioDrawer() {
   const [isMatrixDialogOpen, setIsMatrixDialogOpen] = useState<boolean>(false);
 
   const { updateStatus, response } = useRiScs();
+
+  const [currentUpdatedActionIDs, setCurrentUpdatedActionIDs] = useState<
+    string[]
+  >([]);
+
+  const debounceCallback = useCallback(
+    (updatedIDs: string[]) => {
+      const indexOfAction = (ID: string) => {
+        return scenario.actions.findIndex(a => a.ID === ID);
+      };
+      if (updatedIDs.length === 0) return;
+
+      const formValues = formMethods.getValues();
+      const updatedScenario = {
+        ...scenario,
+        actions: scenario.actions.map(a =>
+          updatedIDs.includes(a.ID)
+            ? {
+                ...a,
+                status:
+                  formValues.actions?.[indexOfAction(a.ID)]?.status ?? a.status,
+                lastUpdated: new Date(),
+              }
+            : a,
+        ),
+      };
+      submitEditedScenarioToRiSc(updatedScenario);
+      setCurrentUpdatedActionIDs([]);
+    },
+    [scenario, submitEditedScenarioToRiSc],
+  );
+  const { flush } = useDebounce(
+    currentUpdatedActionIDs,
+    3000,
+    debounceCallback,
+  );
 
   // Used to scroll to the bottom of the drawer when the user deletes a scenario
   // via the quick edit and DeleteConfirmation
@@ -70,6 +108,7 @@ export function ScenarioDrawer() {
     if (formMethods.formState.isDirty) {
       setShowCloseConfirmation(true);
     } else {
+      flush();
       closeScenarioForm();
       setIsEditing(false);
       collapseAllActions();
@@ -80,6 +119,7 @@ export function ScenarioDrawer() {
     submitEditedScenarioToRiSc(mapFormScenarioToScenario(data), () =>
       setIsEditing(false),
     );
+    flush();
   });
 
   function onSubmitAndCloseDialog() {
@@ -159,6 +199,7 @@ export function ScenarioDrawer() {
         formMethods={formMethods}
         isEditing={isEditing}
         onSubmit={onSubmit}
+        setCurrentUpdatedActionIDs={setCurrentUpdatedActionIDs}
       />
       <Box
         sx={{

--- a/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
@@ -119,7 +119,6 @@ export function ScenarioDrawer() {
     submitEditedScenarioToRiSc(mapFormScenarioToScenario(data), () =>
       setIsEditing(false),
     );
-    flush();
   });
 
   function onSubmitAndCloseDialog() {

--- a/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/ScenarioDrawer.tsx
@@ -51,6 +51,15 @@ export function ScenarioDrawer() {
     string[]
   >([]);
 
+  // Used to scroll to the bottom of the drawer when the user deletes a scenario
+  // via the quick edit and DeleteConfirmation
+  const deleteScenarioRef = useRef<HTMLDivElement>(null);
+
+  const formMethods = useForm<FormScenario>({
+    defaultValues: mapScenarioToFormScenario(scenario),
+    mode: 'onChange',
+  });
+
   const debounceCallback = useCallback(
     (updatedIDs: string[]) => {
       const indexOfAction = (ID: string) => {
@@ -75,22 +84,13 @@ export function ScenarioDrawer() {
       submitEditedScenarioToRiSc(updatedScenario);
       setCurrentUpdatedActionIDs([]);
     },
-    [scenario, submitEditedScenarioToRiSc],
+    [scenario, formMethods, submitEditedScenarioToRiSc],
   );
   const { flush } = useDebounce(
     currentUpdatedActionIDs,
     6000,
     debounceCallback,
   );
-
-  // Used to scroll to the bottom of the drawer when the user deletes a scenario
-  // via the quick edit and DeleteConfirmation
-  const deleteScenarioRef = useRef<HTMLDivElement>(null);
-
-  const formMethods = useForm<FormScenario>({
-    defaultValues: mapScenarioToFormScenario(scenario),
-    mode: 'onChange',
-  });
 
   function onCancel() {
     formMethods.reset(mapScenarioToFormScenario(scenario));

--- a/plugins/ros/src/components/scenarioDrawer/components/ActionsSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionsSection.tsx
@@ -4,7 +4,7 @@ import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { pluginRiScTranslationRef } from '../../../utils/translations';
-import { emptyAction, useScenario } from '../../../contexts/ScenarioContext';
+import { emptyAction } from '../../../contexts/ScenarioContext';
 import { section } from '../scenarioDrawerComponents';
 import { emptyState, heading3 } from '../../common/typography';
 import Divider from '@mui/material/Divider';
@@ -16,7 +16,6 @@ import { AddCircle } from '@mui/icons-material';
 import Box from '@mui/material/Box';
 import { ActionStatusOptions } from '../../../utils/constants';
 import Switch from '@mui/material/Switch';
-import { useDebounce } from '../../../utils/hooks';
 
 const FILTER_SETTINGS = {
   SHOW_ALL: false,
@@ -27,6 +26,7 @@ type ActionSectionProps = {
   formMethods: UseFormReturn<FormScenario>;
   isEditing: boolean;
   onSubmit: () => void;
+  setCurrentUpdatedActionIDs: React.Dispatch<React.SetStateAction<string[]>>;
 };
 
 const RelevanceToggle = ({
@@ -57,6 +57,7 @@ export function ActionsSection({
   formMethods,
   isEditing,
   onSubmit,
+  setCurrentUpdatedActionIDs,
 }: ActionSectionProps) {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
 
@@ -109,46 +110,6 @@ export function ActionsSection({
       originalIndex: currentActions.findIndex(a => a === action),
     }));
   }, [currentActions, showOnlyRelevant, filterActions, sortActionsByRelevance]);
-
-  const [currentUpdatedActionIDs, setCurrentUpdatedActionIDs] = useState<
-    string[]
-  >([]);
-
-  const { submitEditedScenarioToRiSc, scenario } = useScenario();
-
-  const debounceCallback = useCallback(
-    (updatedIDs: string[]) => {
-      const indexOfAction = (ID: string) => {
-        return scenario.actions.findIndex(a => a.ID === ID);
-      };
-      if (updatedIDs.length === 0) return;
-
-      const formValues = formMethods.getValues();
-      const updatedScenario = {
-        ...scenario,
-        actions: scenario.actions.map(a =>
-          updatedIDs.includes(a.ID)
-            ? {
-                ...a,
-                status:
-                  formValues.actions?.[indexOfAction(a.ID)]?.status ?? a.status,
-                lastUpdated: new Date(),
-              }
-            : a,
-        ),
-      };
-      submitEditedScenarioToRiSc(updatedScenario);
-      setCurrentUpdatedActionIDs([]);
-    },
-    [
-      scenario,
-      formMethods,
-      setCurrentUpdatedActionIDs,
-      submitEditedScenarioToRiSc,
-    ],
-  );
-
-  useDebounce(currentUpdatedActionIDs, 6000, debounceCallback);
 
   if (isEditing) {
     return (

--- a/plugins/ros/src/utils/hooks.ts
+++ b/plugins/ros/src/utils/hooks.ts
@@ -427,7 +427,7 @@ export function useDebounce<T>(
       timeoutRef.current = null;
     }
     const v = latestValueRef.current;
-    const hasValue = Array.isArray(v) ? v.length > 0 : v != null;
+    const hasValue = Array.isArray(v) ? v.length > 0 : v !== null;
     if (hasValue) {
       latestCallbackRef.current(v);
     }


### PR DESCRIPTION
Moved useDebounce + debounceCallback to a higher level in the component hierarchy - Now the debounce updates can be flushed manually on multiple events, depending on the context. 

Updated the useDebounce hook to ensure it always uses the latest value and callback. Also removed automatic flush on unmount. Now flush is controlled explicitly via the flush() function, e.g. on drawer close or after the timeout.
Should solve both the button-lag after update and wrong error state message.

Please test on your machine!