### PR TITLE
persist the user’s preference for displaying only relevant actions

### DIFF
--- a/plugins/ros/src/components/scenarioDrawer/components/ActionsSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionsSection.tsx
@@ -16,11 +16,7 @@ import { AddCircle } from '@mui/icons-material';
 import Box from '@mui/material/Box';
 import { ActionStatusOptions } from '../../../utils/constants';
 import Switch from '@mui/material/Switch';
-
-const FILTER_SETTINGS = {
-  SHOW_ALL: false,
-  SHOW_ONLY_RELEVANT: true,
-} as const;
+import { useActionFiltersStorage } from '../../../stores/ActionFiltersStore.ts';
 
 type ActionSectionProps = {
   formMethods: UseFormReturn<FormScenario>;
@@ -70,10 +66,7 @@ export function ActionsSection({
 
   const currentActions = watch('actions');
 
-  const [showOnlyRelevant, setShowOnlyRelevant] = useState<boolean>(
-    FILTER_SETTINGS.SHOW_ALL,
-  );
-
+  const { actionFilters, saveOnlyRelevantFilter } = useActionFiltersStorage();
   const [processedActions, setProcessedActions] = useState<
     { action: Action; originalIndex: number }[]
   >([]);
@@ -109,7 +102,9 @@ export function ActionsSection({
   }, [isDrawerOpen, sortActionsByRelevance]);
 
   const visibleActions = processedActions.filter(({ action }) =>
-    showOnlyRelevant ? action.status !== ActionStatusOptions.NotRelevant : true,
+    actionFilters.showOnlyRelevant
+      ? action.status !== ActionStatusOptions.NotRelevant
+      : true,
   );
 
   if (isEditing) {
@@ -153,8 +148,8 @@ export function ActionsSection({
         <Typography sx={heading3}>{t('dictionary.measures')}</Typography>
 
         <RelevanceToggle
-          checked={showOnlyRelevant}
-          onChange={value => setShowOnlyRelevant(value)}
+          checked={actionFilters.showOnlyRelevant}
+          onChange={value => saveOnlyRelevantFilter(value)}
         />
       </Box>
       {visibleActions.length > 0 ? (

--- a/plugins/ros/src/stores/ActionFiltersStore.ts
+++ b/plugins/ros/src/stores/ActionFiltersStore.ts
@@ -13,8 +13,8 @@ const DEFAULT_ACTION_FILTERS: ActionFilters = {
 };
 
 // Functions
-let getActionFilters = (): ActionFilters => {
-  let storage = localStorage.getItem(LOCAL_STORAGE_KEY);
+const getActionFilters = (): ActionFilters => {
+  const storage = localStorage.getItem(LOCAL_STORAGE_KEY);
   if (storage === null) return DEFAULT_ACTION_FILTERS;
 
   const storageJson = JSON.parse(storage);
@@ -25,7 +25,7 @@ let getActionFilters = (): ActionFilters => {
   };
 };
 
-let storeActionFilters = (actionFilters: ActionFilters) => {
+const storeActionFilters = (actionFilters: ActionFilters) => {
   localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(actionFilters));
 };
 
@@ -33,13 +33,13 @@ let storeActionFilters = (actionFilters: ActionFilters) => {
 export function useActionFiltersStorage() {
   const [actionFilters, setActionFilters] = useState(() => getActionFilters());
 
-  let saveOnlyRelevantFilter = (isVisible: boolean) => {
+  const saveOnlyRelevantFilter = (isVisible: boolean) => {
     const newActionFilters = { ...actionFilters, showOnlyRelevant: isVisible };
     storeActionFilters(newActionFilters);
     setActionFilters(newActionFilters);
   };
 
-  let clearActionFilters = () => {
+  const clearActionFilters = () => {
     localStorage.clear();
   };
 

--- a/plugins/ros/src/stores/ActionFiltersStore.ts
+++ b/plugins/ros/src/stores/ActionFiltersStore.ts
@@ -1,0 +1,51 @@
+// Type definitions
+import { useState } from 'react';
+
+type ActionFilters = {
+  showOnlyRelevant: boolean;
+};
+
+// Constants
+const LOCAL_STORAGE_KEY = 'actionFilters';
+
+const DEFAULT_ACTION_FILTERS: ActionFilters = {
+  showOnlyRelevant: false,
+};
+
+// Functions
+let getActionFilters = (): ActionFilters => {
+  let storage = localStorage.getItem(LOCAL_STORAGE_KEY);
+  if (storage === null) return DEFAULT_ACTION_FILTERS;
+
+  const storageJson = JSON.parse(storage);
+
+  return {
+    showOnlyRelevant:
+      storageJson.showOnlyRelevant ?? DEFAULT_ACTION_FILTERS.showOnlyRelevant,
+  };
+};
+
+let storeActionFilters = (actionFilters: ActionFilters) => {
+  localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(actionFilters));
+};
+
+// Exported Hook
+export function useActionFiltersStorage() {
+  const [actionFilters, setActionFilters] = useState(() => getActionFilters());
+
+  let saveOnlyRelevantFilter = (isVisible: boolean) => {
+    const newActionFilters = { ...actionFilters, showOnlyRelevant: isVisible };
+    storeActionFilters(newActionFilters);
+    setActionFilters(newActionFilters);
+  };
+
+  let clearActionFilters = () => {
+    localStorage.clear();
+  };
+
+  return {
+    actionFilters,
+    saveOnlyRelevantFilter,
+    clearActionFilters,
+  };
+}


### PR DESCRIPTION
This PR adds functionality to persist the user’s preference for displaying only relevant actions. When a user toggles the “Show only relevant actions” option, their choice is saved in local storage. On subsequent visits, the preference is loaded automatically.

The PR is also developed to make it easy to add new filtering options in the future.