### PR TITLE
BugFix - optimistic storing

### DIFF
--- a/plugins/ros/src/components/scenarioDrawer/components/ActionsSection.tsx
+++ b/plugins/ros/src/components/scenarioDrawer/components/ActionsSection.tsx
@@ -93,13 +93,26 @@ export function ActionsSection({
       setProcessedActions(
         sorted.map(action => ({
           action,
-          originalIndex: currentActions.findIndex(a => a === action),
+          originalIndex: currentActions.findIndex(a => a.ID === action.ID),
         })),
       );
     }
     // ESLint-ignore: only sort when drawer opens
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isDrawerOpen, sortActionsByRelevance]);
+
+  useEffect(() => {
+    if (isDrawerOpen && processedActions.length) {
+      setProcessedActions(prev =>
+        prev.map(({ action, originalIndex }) => {
+          const updated = currentActions.find(a => a.ID === action.ID);
+          return updated
+            ? { action: updated, originalIndex }
+            : { action, originalIndex };
+        }),
+      );
+    }
+  }, [isDrawerOpen, currentActions, processedActions.length]);
 
   const visibleActions = processedActions.filter(({ action }) =>
     actionFilters.showOnlyRelevant


### PR DESCRIPTION
Fixed bug where updating a second action (after first update) did not display on the UI.

[Notion Card](https://www.notion.so/bekks/Optimistisk-lagring-fungerer-ikke-under-lagringsprosess-2726bd308541804daef1e6ae2ffaeaaa?source=copy_link)
