### PR TITLE
8 px spacing mellom knapper i header

### DIFF
--- a/plugins/ros/src/components/riScHeader/RiScHeader.tsx
+++ b/plugins/ros/src/components/riScHeader/RiScHeader.tsx
@@ -17,7 +17,7 @@ export function RiScHeader(props: RiScHeaderProps) {
         <Text variant="title-medium" weight="bold">
           {t('contentHeader.title')}
         </Text>
-        <Flex>
+        <Flex style={{ gap: '8px' }}>
           <EditEncryptionButton onEditEncryption={props.onEditEncryption} />
           <SupportDialog />
           <FeedbackDialog />


### PR DESCRIPTION
Før:
<img width="484" height="82" alt="image" src="https://github.com/user-attachments/assets/6101af6b-b7cd-4bd2-8de8-84e9dcebc686" />

Etter:
<img width="474" height="87" alt="image" src="https://github.com/user-attachments/assets/43deb583-7f70-48b3-a6a6-6d999e6d9d2a" />
