### PR TITLE
Outdated actions is not displayed if zero

### DIFF
--- a/plugins/ros/src/components/scenarioTable/OutdatedActionsCounts.tsx
+++ b/plugins/ros/src/components/scenarioTable/OutdatedActionsCounts.tsx
@@ -28,11 +28,15 @@ export function OutdatedActionsCounts(props: OutdatedActionsCountsProps) {
   };
   return (
     <Box style={boxStyle}>
-      <OutdatedActionsBadge
-        type="veryOutdated"
-        count={props.veryOutdatedCount}
-      />
-      <OutdatedActionsBadge type="outdated" count={props.outdatedCount} />
+      {props.veryOutdatedCount > 0 && (
+        <OutdatedActionsBadge
+          type="veryOutdated"
+          count={props.veryOutdatedCount}
+        />
+      )}
+      {props.outdatedCount > 0 && (
+        <OutdatedActionsBadge type="outdated" count={props.outdatedCount} />
+      )}
     </Box>
   );
 }

--- a/plugins/ros/src/components/scenarioTable/ScenarioTableCard.tsx
+++ b/plugins/ros/src/components/scenarioTable/ScenarioTableCard.tsx
@@ -37,7 +37,7 @@ export function ScenarioTableCard({
         />
       </CardHeader>
       <CardBody>
-        {veryOutdatedCount + outdatedCount !== 0 && (
+        {(veryOutdatedCount > 0 || outdatedCount > 0) && (
           <OutdatedActionsCounts
             veryOutdatedCount={veryOutdatedCount}
             outdatedCount={outdatedCount}

--- a/plugins/ros/src/utils/utilityfunctions.ts
+++ b/plugins/ros/src/utils/utilityfunctions.ts
@@ -535,10 +535,11 @@ export function computeStatusCount(riScWithMetadata: RiScWithMetadata) {
       if (!action.lastUpdated) {
         return { ...action, status: UpdatedStatusEnum.VERY_OUTDATED };
       }
-      const day = formatDate(action.lastUpdated);
+      const daysSinceLastUpdate = action.lastUpdated
+        ? calculateDaysSince(new Date(action.lastUpdated))
+        : null;
       const commits = riScWithMetadata.lastPublished?.numberOfCommits ?? null;
-      const daysSinceLastUpdated = calculateDaysSince(new Date(day));
-      const status = calculateUpdatedStatus(daysSinceLastUpdated, commits);
+      const status = calculateUpdatedStatus(daysSinceLastUpdate, commits);
 
       return { ...action, status };
     });


### PR DESCRIPTION
Minor update
- Outdated or very outdated actions are now hidden when their count is zero.
- Fixed a bug in the count calculation that caused a mismatch between statusCount and the displayed exclamation marks.

Old:
<img width="984" height="552" alt="Screenshot 2025-09-26 at 09 21 23" src="https://github.com/user-attachments/assets/43eeb7eb-09e5-47a9-b2f0-3d9ae97d9723" />

New:
<img width="630" height="361" alt="Screenshot 2025-09-26 at 09 21 42" src="https://github.com/user-attachments/assets/d3b179e1-948a-4ca0-82ef-b9dccd0b4252" />
