### PR TITLE
Add scenario button is now black instead of green

### DIFF
--- a/plugins/ros/src/components/scenarioTable/AddScenarioButton.tsx
+++ b/plugins/ros/src/components/scenarioTable/AddScenarioButton.tsx
@@ -13,9 +13,6 @@ export function AddScenarioButton(props: AddScenarioButtonProps) {
       iconStart={<i className="ri-add-line" />}
       variant="secondary"
       onClick={props.onNewScenario}
-      style={{
-        color: '#2E7D32', // Green color from MUI, change when BUI is more mature
-      }}
     >
       {t('scenarioTable.addScenarioButton')}
     </Button>


### PR DESCRIPTION
Before:
<img width="810" height="188" alt="image" src="https://github.com/user-attachments/assets/15bde6bb-f48f-443b-a210-0f821a56e99e" />

After:
<img width="803" height="114" alt="image" src="https://github.com/user-attachments/assets/c3c8549f-b43d-46ed-8f0e-b07883cfb3c6" />
