### PR TITLE
removed sikkerhetsmetrikker-tilbakemelding slack channel from support

### DIFF
--- a/plugins/ros/src/components/riScDialog/SupportDialog.tsx
+++ b/plugins/ros/src/components/riScDialog/SupportDialog.tsx
@@ -52,18 +52,6 @@ export function SupportDialog() {
                 'supportDialog.entries.riscDocumentation.description',
               )}
             />
-            <SupportEntry
-              label={t(
-                'supportDialog.entries.securityMetricsFeedbackChannel.title',
-              )}
-              url="https://kartverketgroup.slack.com/archives/C07RNB2LPUZ"
-              icon={
-                <i className="ri-slack-fill" style={{ fontSize: 'x-large' }} />
-              }
-              description={t(
-                'supportDialog.entries.securityMetricsFeedbackChannel.description',
-              )}
-            />
           </div>
         </DialogContent>
       </Dialog>

--- a/plugins/ros/src/utils/translations.ts
+++ b/plugins/ros/src/utils/translations.ts
@@ -232,10 +232,6 @@ export const pluginRiScMessages = {
         title: 'RISC Documentation',
         description: 'Confluence - RISC',
       },
-      securityMetricsFeedbackChannel: {
-        title: 'Sikkerhetsmetrikker Feedback Channel',
-        description: '#sikkerhetsmetrikker-tilbakemelding',
-      },
     },
   },
   scenarioTable: {
@@ -834,10 +830,6 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
           'supportDialog.entries.riscDocumentation.title': 'RoS dokumentasjon',
           'supportDialog.entries.riscDocumentation.description':
             'Confluence - RISC',
-          'supportDialog.entries.securityMetricsFeedbackChannel.title':
-            'Sikkerhetsmetrikker tilbakemeldingskanal',
-          'supportDialog.entries.securityMetricsFeedbackChannel.description':
-            '#sikkerhetsmetrikker-tilbakemelding',
           'scenarioTable.title': 'Risikoscenarioer',
           'scenarioTable.addScenarioButton': 'Legg til scenario',
           'scenarioTable.noActions': 'Ingen tiltak',


### PR DESCRIPTION
Before:
<img width="1228" height="634" alt="image" src="https://github.com/user-attachments/assets/7e99e66a-e5e5-412f-a238-c599920a5438" />


After:
<img width="1226" height="480" alt="image" src="https://github.com/user-attachments/assets/f0ee32bd-a630-48cb-a457-9a1976d58b51" />
