### PR TITLE
Bug initial risc

### DIFF
--- a/plugins/ros/src/components/riScDialog/ConfigInitialRisc.tsx
+++ b/plugins/ros/src/components/riScDialog/ConfigInitialRisc.tsx
@@ -89,7 +89,6 @@ function ConfigInitialRisc({
             </Text>
 
             <RadioGroup
-              defaultValue={String(CreateRiScFrom.Ops)}
               onChange={handleChangeCreateRiScFrom}
               isDisabled={!switchOn}
               aria-label="Select application type"

--- a/plugins/ros/src/components/riScDialog/ConfigInitialRisc.tsx
+++ b/plugins/ros/src/components/riScDialog/ConfigInitialRisc.tsx
@@ -89,10 +89,17 @@ function ConfigInitialRisc({
             </Text>
 
             <RadioGroup
+              defaultValue={String(CreateRiScFrom.Standard)}
               onChange={handleChangeCreateRiScFrom}
               isDisabled={!switchOn}
               aria-label="Select application type"
             >
+              <RadioOption
+                value={String(CreateRiScFrom.Standard)}
+                label="Standard"
+                description={t('rosDialog.generateStandardRiScDescription')}
+                active={!switchOn}
+              />
               <RadioOption
                 value={String(CreateRiScFrom.Ops)}
                 label="Ops"
@@ -103,12 +110,6 @@ function ConfigInitialRisc({
                 value={String(CreateRiScFrom.InternalJob)}
                 label="Internal Job"
                 description={t('rosDialog.generateInternalJobRiScDescription')}
-                active={!switchOn}
-              />
-              <RadioOption
-                value={String(CreateRiScFrom.Standard)}
-                label="Standard"
-                description={t('rosDialog.generateStandardRiScDescription')}
                 active={!switchOn}
               />
             </RadioGroup>


### PR DESCRIPTION
Corrected behavior for initial risc selection.

Previously, if the user selected “Yes” for initial risc but did not actively choose one of the radio options, the Standard initial risc was applied, even when “Ops” was preselected.

The idea is that the Standard initial risc should act as a default initial risc in the MVP solution.