### PR TITLE
User can now toggle the action view for a scenario even when filtering/searching

### DIFF
--- a/plugins/ros/src/components/action/ActionRowList.tsx
+++ b/plugins/ros/src/components/action/ActionRowList.tsx
@@ -169,7 +169,7 @@ export function ActionRowList(props: ActionRowListProps) {
             allowDeletion={props.allowDeletion}
             allowEdit={props.allowEdit}
           />
-          <Divider />
+          {index < actions.length - 1 && <Divider />}
         </Fragment>
       ))}
     </Flex>

--- a/plugins/ros/src/components/scenarioTable/ScenarioTableRow.tsx
+++ b/plugins/ros/src/components/scenarioTable/ScenarioTableRow.tsx
@@ -26,6 +26,7 @@ import {
   getFilteredActions,
 } from '../../utils/actions.ts';
 import { ActionRowList } from '../action/ActionRowList.tsx';
+import { usePrevious } from '../../utils/hooks.ts';
 
 interface ScenarioTableRowProps {
   scenario: Scenario;
@@ -129,6 +130,7 @@ export function ScenarioTableRow({
     actionIdsOfVisibleType,
     visibleType,
   );
+  const prevFilteredActions = usePrevious(filteredActions);
 
   useEffect(() => {
     if (visibleType || isExpanded) {
@@ -163,6 +165,25 @@ export function ScenarioTableRow({
   const textColorAsBuiVariable = isTextColorBlack
     ? 'var(--bui-black)'
     : 'var(--bui-white)';
+
+  useEffect(() => {
+    if (
+      (prevFilteredActions === undefined || prevFilteredActions.length === 0) &&
+      filteredActions.length > 0
+    ) {
+      // User has activated some filter
+      setIsExpanded(true);
+    }
+
+    if (
+      prevFilteredActions &&
+      prevFilteredActions.length > 0 &&
+      filteredActions.length === 0
+    ) {
+      // User has deactivated filter
+      setIsExpanded(false);
+    }
+  }, [filteredActions]);
 
   return (
     <Card
@@ -312,22 +333,16 @@ export function ScenarioTableRow({
       {/* If there are filtered actions (search or updated badge), show them as before.
           If the user expands the row, show all actions for the scenario regardless
           of the current filters. */}
-      {filteredActions.length > 0 && !isExpanded && (
+      <Collapse in={isExpanded} timeout="auto" unmountOnExit>
         <div data-action-root>
           <ActionRowList
             scenarioId={scenario.ID}
-            displayedActions={filteredActions}
+            displayedActions={
+              filteredActions.length > 0 ? filteredActions : scenario.actions
+            }
           />
         </div>
-      )}
-
-      {isExpanded && (
-        <Collapse in={isExpanded} timeout="auto" unmountOnExit>
-          <div data-action-root>
-            <ActionRowList scenarioId={scenario.ID} />
-          </div>
-        </Collapse>
-      )}
+      </Collapse>
     </Card>
   );
 }

--- a/plugins/ros/src/components/scenarioTable/ScenarioTableRow.tsx
+++ b/plugins/ros/src/components/scenarioTable/ScenarioTableRow.tsx
@@ -183,7 +183,7 @@ export function ScenarioTableRow({
       // User has deactivated filter
       setIsExpanded(false);
     }
-  }, [filteredActions]);
+  }, [filteredActions, prevFilteredActions]);
 
   return (
     <Card

--- a/plugins/ros/src/utils/hooks.ts
+++ b/plugins/ros/src/utils/hooks.ts
@@ -542,6 +542,11 @@ export function useSearchActions(
   return { matches: returnedMatches, isDebouncing };
 }
 
+/**
+ * When a value is changed from a to b, usePrevious will return a.
+ * It returns the previous value of some variable.
+ * @param value
+ */
 export function usePrevious<T>(value: T): T | undefined {
   const ref = useRef<T>();
 

--- a/plugins/ros/src/utils/hooks.ts
+++ b/plugins/ros/src/utils/hooks.ts
@@ -541,3 +541,13 @@ export function useSearchActions(
 
   return { matches: returnedMatches, isDebouncing };
 }
+
+export function usePrevious<T>(value: T): T | undefined {
+  const ref = useRef<T>();
+
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+}


### PR DESCRIPTION
## 📝 Beskrivelse

User can now toggle the action view for a scenario even when filtering/searching

Hører til notion oppgavene:
[Rar oppførsel i scenariotabell med funksjonaliteten hvor man kan se tiltak uten noe filter](https://www.notion.so/bekks/Rar-oppf-rsel-i-scenariotabell-med-funksjonaliteten-hvor-man-kan-se-tiltak-uten-noe-filter-2b66bd30854180e2a516d3c873cbf0a9?source=copy_link)

[Feil ikon i scenariotabell når man filtrerer for veldig utdaterte tiltak (se bilde)](https://www.notion.so/bekks/Feil-ikon-i-scenariotabell-n-r-man-filtrerer-for-veldig-utdaterte-tiltak-se-bilde-2b66bd3085418096a4f6d248ff7a8b0e?source=copy_link)


Jeg oppdaget også et par svakheter når jeg jobbet på oppgaven, så jeg lagde et par kort som kan gjøres på et senere tidspunkt:

[Refactor: filtered actions variable in ScenarioTableRow.tsx recalculated very often (see video)](https://www.notion.so/bekks/Refactor-filtered-actions-variable-in-ScenarioTableRow-tsx-recalculated-very-often-see-video-2bc6bd308541806cb004e78a82b46385?source=copy_link)

[Bug: Scenario vises selv om den burde filtreres bort](https://www.notion.so/bekks/Bug-Scenario-vises-selv-om-den-burde-filtreres-bort-2bc6bd30854180ebbf5aefce2a186f8e?source=copy_link)

---

## 📸 Skjermbilder (valgfritt)

_Legg til skjermbilder eller GIF-er som viser endringene visuelt (spesielt ved UI-endringer)._

---

## ✅ Sjekkliste

### Generelt

- [x] Endringene fungerer som forventet lokalt
- [x] `main` (eller tilsvarende) er merget inn i branchen

### Ved endringer i UI / design

- [x] Endringene er verifisert med designer(e)
- [x] Både **light mode** og **dark mode** er håndtert

---
