### PR TITLE
fix: wrong background-colors after mui-migration

### DIFF
--- a/plugins/ros/src/components/scenarioDrawer/scenarioDrawer.module.css
+++ b/plugins/ros/src/components/scenarioDrawer/scenarioDrawer.module.css
@@ -18,6 +18,11 @@
   box-shadow: none !important;
 }
 
+:global([data-theme-mode='dark']) .section,
+:global([data-theme-mode='dark']) .riscSection {
+  background-color: #424242;
+}
+
 .headerSection {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION




# 📝 Beskrivelse

Oppgave i Notion: https://www.notion.so/Fikse-sort-farge-etter-mui-migrering-32e6bd30854180e1a611efdef09155f1?source=copy_link 

 The section containers (Scope, Risk, Actions) inside the scenario drawer were
  showing an almost-black background (#1e1e1e) in dark mode instead of a proper
  gray. This happened because the MUI <Paper> components inherited the default MUI
  v5 dark theme Paper color (#121212 + elevation overlay), while the drawer itself
  explicitly set #333333.

  Changes

   - Added background-color: #424242 for dark mode on .section and .riscSection in 
  the drawer CSS module

**Før:**
<img width="839" height="979" alt="image" src="https://github.com/user-attachments/assets/8c4a1753-aef3-41b6-9835-d8b5a1665905" />


**Etter:**
<img width="811" height="802" alt="image" src="https://github.com/user-attachments/assets/257c7792-0b8d-4576-8820-721c3192ec2d" />
---

## ✅ Sjekkliste

- [ ] Branchen er rebaset på `main` eller main er merget inn (Tips: om du bruker grensensittet i GitHub, så kan du velge rebase istedenfor merge. MERK: da må du slette din lokale branch og hente på nytt om du skal gjøre flere endringer).
- [ ] Det er brukt minst en conventional commit med passende prefix **hvis** denne PR'en skal lage en ny release (er det endringer i selve pluginet skal det som hovedregel det).
- [ ] [Test-sjekklisten](../CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig.
