### PR TITLE
fix: korriger off-by-one i rad-labels for sannsynlighets- og konsekvenstabeller

### DIFF
--- a/plugins/ros/src/components/scenarioWizard/components/RiskTableBase.tsx
+++ b/plugins/ros/src/components/scenarioWizard/components/RiskTableBase.tsx
@@ -84,7 +84,7 @@ export function createInfoWithHeadersComponent(
     }
     return (
       <Box className={styles.riskTable}>
-        <Box className={styles.consequenceGrid}>
+        <Box className={includeLabel ? styles.consequenceGrid : styles.riskRow}>
           {includeLabel && <Box className={styles.riskLabelCell} />}
           {Array.from({ length: 5 }, (_, i) => getRadioLabel(i + 1))}
         </Box>

--- a/plugins/ros/src/components/scenarioWizard/components/RiskTableBase.tsx
+++ b/plugins/ros/src/components/scenarioWizard/components/RiskTableBase.tsx
@@ -86,7 +86,7 @@ export function createInfoWithHeadersComponent(
       <Box className={styles.riskTable}>
         <Box className={styles.consequenceGrid}>
           {includeLabel && <Box className={styles.riskLabelCell} />}
-          {Array.from({ length: 5 }, (_, i) => getRadioLabel(i))}
+          {Array.from({ length: 5 }, (_, i) => getRadioLabel(i + 1))}
         </Box>
         <InfoComponent />
       </Box>


### PR DESCRIPTION
# 📝 Beskrivelse

## Før
<img width="1088" height="806" alt="Screenshot 2026-03-27 at 12 41 45" src="https://github.com/user-attachments/assets/3f1ffe85-38a8-47ca-8a75-94d8d8f34fc3" />

## Etter
<img width="1094" height="451" alt="Screenshot 2026-03-27 at 12 43 14" src="https://github.com/user-attachments/assets/4523fe9f-cdaa-400f-b469-153002d66f89" />


---

## ✅ Sjekkliste

- [x] Branchen er rebaset på `main` eller main er merget inn.
- [x] Det er brukt minst en conventional commit med passende prefix **hvis** denne PR'en skal lage en ny release.
- [x] [Test-sjekklisten](../CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig.