### PR TITLE
feat: Stop user updating RoS marked for deletion

### DIFF
--- a/plugins/ros/src/components/action/ActionRowList.tsx
+++ b/plugins/ros/src/components/action/ActionRowList.tsx
@@ -1,7 +1,4 @@
-import {
-  Action,
-  RiScStatus,
-} from '../../utils/types.ts';
+import { Action, RiScStatus } from '../../utils/types.ts';
 import { ActionRow } from './ActionRow.tsx';
 import { Fragment, useCallback, useEffect, useState } from 'react';
 import { isToday } from '../../utils/date.ts';

--- a/plugins/ros/src/components/action/ActionRowList.tsx
+++ b/plugins/ros/src/components/action/ActionRowList.tsx
@@ -72,7 +72,7 @@ export function ActionRowList(props: ActionRowListProps) {
     actionId: string,
     newStatus: ActionStatusOptions,
   ) => {
-    if (isRiScMarkedForDeletion) {
+    if (isRiScMarkedForDeletion) { //if marked for deletion, stop the user!
       onRiScMarkedForDeletion();
       return;
     }

--- a/plugins/ros/src/components/action/ActionRowList.tsx
+++ b/plugins/ros/src/components/action/ActionRowList.tsx
@@ -1,8 +1,6 @@
 import {
   Action,
-  ProcessingStatus,
   RiScStatus,
-  SubmitResponseObject,
 } from '../../utils/types.ts';
 import { ActionRow } from './ActionRow.tsx';
 import { Fragment, useCallback, useEffect, useState } from 'react';
@@ -20,7 +18,6 @@ import styles from './ActionRowList.module.css';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { pluginRiScTranslationRef } from '../../utils/translations.ts';
 import { getUpdatedStatus } from '../../utils/actions.ts';
-import AlertBar from '../common/AlertBar/AlertBar.tsx';
 
 type ActionRowListProps = {
   scenarioId: string;
@@ -31,7 +28,7 @@ type ActionRowListProps = {
 
 export function ActionRowList(props: ActionRowListProps) {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
-  const { selectedRiSc } = useRiScs();
+  const { selectedRiSc, showBlockedUpdateError } = useRiScs();
   const { submitEditedScenarioToRiSc } = useScenario();
   const { profileInfo } = useBackstageContext();
   const [pendingActionStatusUpdates, setPendingActionStatusUpdates] = useState<
@@ -40,19 +37,9 @@ export function ActionRowList(props: ActionRowListProps) {
   const [pendingActionUpdatesHistory, setPendingActionUpdatesHistory] =
     useState<string[]>([]);
 
-  const [blockedUpdateResponse, setBlockedUpdateResponse] =
-    useState<SubmitResponseObject | null>(null);
-
   const isRiScMarkedForDeletion =
     selectedRiSc?.status === RiScStatus.DeletionDraft ||
     selectedRiSc?.status === RiScStatus.DeletionSentForApproval;
-
-  const onRiScMarkedForDeletion = () => {
-    setBlockedUpdateResponse({
-      status: ProcessingStatus.ErrorWhenUpdatingDeletedRiSc,
-      statusMessage: t('errorMessages.ErrorWhenUpdatingDeletedRiSc'),
-    });
-  };
 
   const onRefreshActionStatus = (action: Action) => {
     if (isToday(action.lastUpdated ?? null)) return;
@@ -73,8 +60,7 @@ export function ActionRowList(props: ActionRowListProps) {
     newStatus: ActionStatusOptions,
   ) => {
     if (isRiScMarkedForDeletion) {
-      // If marked for deletion, stop the user!
-      onRiScMarkedForDeletion();
+      showBlockedUpdateError();
       return;
     }
     setPendingActionUpdatesHistory(prev => prev.filter(id => id !== actionId));
@@ -112,7 +98,7 @@ export function ActionRowList(props: ActionRowListProps) {
         ),
       },
       {
-        profileInfo: profileInfo,
+        profileInfo,
         onSuccess: () => {
           if (setIsEditing) {
             setIsEditing(false);
@@ -147,7 +133,7 @@ export function ActionRowList(props: ActionRowListProps) {
           idsOfActionsToForceUpdateLastUpdatedValue: Object.keys(
             updates[scenarioId],
           ),
-          profileInfo: profileInfo,
+          profileInfo,
           onSuccess: () => {
             const savedActionIds = Object.keys(updates[scenarioId]);
 
@@ -213,45 +199,36 @@ export function ActionRowList(props: ActionRowListProps) {
   }
 
   return (
-    <>
-      {blockedUpdateResponse && (
-        <AlertBar
-          updateStatus={{ isLoading: false, isError: true, isSuccess: false }}
-          response={blockedUpdateResponse}
-          statusText={blockedUpdateResponse.statusMessage}
-        />
-      )}
-      <Flex direction="column">
-        <Divider />
-        {actions.map((action, index) => {
-          const updatedStatus = getUpdatedStatusOfAction(
-            props.scenarioId,
-            action,
-            pendingActionStatusUpdates,
-            pendingActionUpdatesHistory,
-          );
-          return (
-            <Fragment key={`Action-${action.ID}-${index}`}>
-              <ActionRow
-                action={action}
-                index={index}
-                onRefreshActionStatus={onRefreshActionStatus}
-                onNewActionStatus={onNewActionStatus}
-                onDeleteAction={onDeleteAction}
-                onSaveAction={onSaveAction}
-                updatedStatus={updatedStatus}
-                optimisticStatus={
-                  pendingActionStatusUpdates[props.scenarioId]?.[action.ID]
-                }
-                allowDeletion={props.allowDeletion}
-                allowEdit={props.allowEdit}
-              />
-              <Divider />
-            </Fragment>
-          );
-        })}
-      </Flex>
-    </>
+    <Flex direction="column">
+      <Divider />
+      {actions.map((action, index) => {
+        const updatedStatus = getUpdatedStatusOfAction(
+          props.scenarioId,
+          action,
+          pendingActionStatusUpdates,
+          pendingActionUpdatesHistory,
+        );
+        return (
+          <Fragment key={`Action-${action.ID}-${index}`}>
+            <ActionRow
+              action={action}
+              index={index}
+              onRefreshActionStatus={onRefreshActionStatus}
+              onNewActionStatus={onNewActionStatus}
+              onDeleteAction={onDeleteAction}
+              onSaveAction={onSaveAction}
+              updatedStatus={updatedStatus}
+              optimisticStatus={
+                pendingActionStatusUpdates[props.scenarioId]?.[action.ID]
+              }
+              allowDeletion={props.allowDeletion}
+              allowEdit={props.allowEdit}
+            />
+            <Divider />
+          </Fragment>
+        );
+      })}
+    </Flex>
   );
 }
 

--- a/plugins/ros/src/components/action/ActionRowList.tsx
+++ b/plugins/ros/src/components/action/ActionRowList.tsx
@@ -1,4 +1,9 @@
-import { Action } from '../../utils/types.ts';
+import {
+  Action,
+  ProcessingStatus,
+  RiScStatus,
+  SubmitResponseObject,
+} from '../../utils/types.ts';
 import { ActionRow } from './ActionRow.tsx';
 import { Fragment, useCallback, useEffect, useState } from 'react';
 import { isToday } from '../../utils/date.ts';
@@ -15,6 +20,7 @@ import styles from './ActionRowList.module.css';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { pluginRiScTranslationRef } from '../../utils/translations.ts';
 import { getUpdatedStatus } from '../../utils/actions.ts';
+import AlertBar from '../common/AlertBar/AlertBar.tsx';
 
 type ActionRowListProps = {
   scenarioId: string;
@@ -34,6 +40,20 @@ export function ActionRowList(props: ActionRowListProps) {
   const [pendingActionUpdatesHistory, setPendingActionUpdatesHistory] =
     useState<string[]>([]);
 
+  const [blockedUpdateResponse, setBlockedUpdateResponse] =
+    useState<SubmitResponseObject | null>(null);
+
+  const isRiScMarkedForDeletion =
+    selectedRiSc?.status === RiScStatus.DeletionDraft ||
+    selectedRiSc?.status === RiScStatus.DeletionSentForApproval;
+
+  const onRiScMarkedForDeletion = () => {
+    setBlockedUpdateResponse({
+      status: ProcessingStatus.ErrorWhenUpdatingDeletedRiSc,
+      statusMessage: t('errorMessages.ErrorWhenUpdatingDeletedRiSc'),
+    });
+  };
+
   const onRefreshActionStatus = (action: Action) => {
     if (isToday(action.lastUpdated ?? null)) return;
 
@@ -52,6 +72,10 @@ export function ActionRowList(props: ActionRowListProps) {
     actionId: string,
     newStatus: ActionStatusOptions,
   ) => {
+    if (isRiScMarkedForDeletion) {
+      onRiScMarkedForDeletion();
+      return;
+    }
     setPendingActionUpdatesHistory(prev => prev.filter(id => id !== actionId));
 
     setPendingActionStatusUpdates(prev => ({
@@ -188,36 +212,45 @@ export function ActionRowList(props: ActionRowListProps) {
   }
 
   return (
-    <Flex direction="column">
-      <Divider />
-      {actions.map((action, index) => {
-        const updatedStatus = getUpdatedStatusOfAction(
-          props.scenarioId,
-          action,
-          pendingActionStatusUpdates,
-          pendingActionUpdatesHistory,
-        );
-        return (
-          <Fragment key={`Action-${action.ID}-${index}`}>
-            <ActionRow
-              action={action}
-              index={index}
-              onRefreshActionStatus={onRefreshActionStatus}
-              onNewActionStatus={onNewActionStatus}
-              onDeleteAction={onDeleteAction}
-              onSaveAction={onSaveAction}
-              updatedStatus={updatedStatus}
-              optimisticStatus={
-                pendingActionStatusUpdates[props.scenarioId]?.[action.ID]
-              }
-              allowDeletion={props.allowDeletion}
-              allowEdit={props.allowEdit}
-            />
-            <Divider />
-          </Fragment>
-        );
-      })}
-    </Flex>
+    <>
+      {blockedUpdateResponse && (
+        <AlertBar
+          updateStatus={{ isLoading: false, isError: true, isSuccess: false }}
+          response={blockedUpdateResponse}
+          statusText={blockedUpdateResponse.statusMessage}
+        />
+      )}
+      <Flex direction="column">
+        <Divider />
+        {actions.map((action, index) => {
+          const updatedStatus = getUpdatedStatusOfAction(
+            props.scenarioId,
+            action,
+            pendingActionStatusUpdates,
+            pendingActionUpdatesHistory,
+          );
+          return (
+            <Fragment key={`Action-${action.ID}-${index}`}>
+              <ActionRow
+                action={action}
+                index={index}
+                onRefreshActionStatus={onRefreshActionStatus}
+                onNewActionStatus={onNewActionStatus}
+                onDeleteAction={onDeleteAction}
+                onSaveAction={onSaveAction}
+                updatedStatus={updatedStatus}
+                optimisticStatus={
+                  pendingActionStatusUpdates[props.scenarioId]?.[action.ID]
+                }
+                allowDeletion={props.allowDeletion}
+                allowEdit={props.allowEdit}
+              />
+              <Divider />
+            </Fragment>
+          );
+        })}
+      </Flex>
+    </>
   );
 }
 

--- a/plugins/ros/src/components/action/ActionRowList.tsx
+++ b/plugins/ros/src/components/action/ActionRowList.tsx
@@ -72,7 +72,8 @@ export function ActionRowList(props: ActionRowListProps) {
     actionId: string,
     newStatus: ActionStatusOptions,
   ) => {
-    if (isRiScMarkedForDeletion) { //if marked for deletion, stop the user!
+    if (isRiScMarkedForDeletion) {
+      //if marked for deletion, stop the user!
       onRiScMarkedForDeletion();
       return;
     }

--- a/plugins/ros/src/components/action/ActionRowList.tsx
+++ b/plugins/ros/src/components/action/ActionRowList.tsx
@@ -73,7 +73,7 @@ export function ActionRowList(props: ActionRowListProps) {
     newStatus: ActionStatusOptions,
   ) => {
     if (isRiScMarkedForDeletion) {
-      //if marked for deletion, stop the user!
+      // If marked for deletion, stop the user!
       onRiScMarkedForDeletion();
       return;
     }

--- a/plugins/ros/src/contexts/RiScContext.tsx
+++ b/plugins/ros/src/contexts/RiScContext.tsx
@@ -63,6 +63,7 @@ type RiScDrawerProps = {
     onSuccess?: () => void,
     onError?: () => void,
   ) => void;
+  showBlockedUpdateError: () => void;
   approveRiSc: () => void;
   updateStatus: UpdateStatus;
   resetRiScStatus: () => void;
@@ -482,11 +483,32 @@ export function RiScProvider({ children }: { children: ReactNode }) {
     }
   }
 
+  const isRiScMarkedForDeletion =
+    selectedRiSc?.status === RiScStatus.DeletionDraft ||
+    selectedRiSc?.status === RiScStatus.DeletionSentForApproval;
+
+  const showBlockedUpdateError = useCallback(() => {
+    dispatch({
+      type: 'SET_BOTH',
+      updateStatus: { isLoading: false, isError: true, isSuccess: false },
+      response: {
+        status: ProcessingStatus.ErrorWhenUpdatingDeletedRiSc,
+        statusMessage: t('errorMessages.ErrorWhenUpdatingDeletedRiSc'),
+      },
+    });
+  }, [dispatch, t]);
+
   function updateRiSc(
     riSc: RiScWithMetadata,
     onSuccess?: () => void,
     onError?: () => void,
   ) {
+    if (isRiScMarkedForDeletion) {
+      showBlockedUpdateError();
+      onError?.();
+      return;
+    }
+
     if (selectedRiSc && riScs) {
       const isRequiresNewApproval =
         selectedRiSc.migrationStatus?.migrationRequiresNewApproval ||
@@ -617,6 +639,7 @@ export function RiScProvider({ children }: { children: ReactNode }) {
     createNewRiSc,
     deleteRiSc,
     updateRiSc,
+    showBlockedUpdateError,
     approveRiSc,
     updateStatus: localState.updateStatus,
     resetRiScStatus,

--- a/plugins/ros/src/utils/translations.ts
+++ b/plugins/ros/src/utils/translations.ts
@@ -644,6 +644,8 @@ export const pluginRiScMessages = {
     ErrorWhenNoWriteAccessToRepository:
       'Unable to update RiSc. You do not have write access to {{owner}}/{{name}}.',
     ErrorWhenUpdatingRiSc: 'Failed to update risk scorecard',
+    ErrorWhenUpdatingDeletedRiSc:
+      'Failed to update risk scorecard. RiSc is marked for deletion.',
     ErrorWhenDeletingRiSc: 'Failed to delete risk scorecard',
     ErrorWhenCreatingPullRequest: 'Failed to save approval of risk scorecard',
     ErrorWhenCreatingRiSc: 'Failed to create risk scorecard',
@@ -1363,6 +1365,8 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
             'Kunne ikke oppdatere ROS. Du har ikke skrivetilgang til {{owner}}/{{name}}.',
           'errorMessages.ErrorWhenUpdatingRiSc':
             'Kunne ikke lagre risiko- og sårbarhetsanalyse',
+          'errorMessages.ErrorWhenUpdatingDeletedRiSc':
+            'Kunne ikke lagre risiko- og sårbarhetsanalyse. Den har blitt markert for sletting.',
           'errorMessages.ErrorWhenDeletingRiSc':
             'Kunne ikke slette risiko- og sårbarhetsanalyse',
           'errorMessages.ErrorWhenCreatingRiSc':

--- a/plugins/ros/src/utils/types.ts
+++ b/plugins/ros/src/utils/types.ts
@@ -232,6 +232,7 @@ export enum ProcessingStatus {
   CreatedPullRequest = 'CreatedPullRequest',
   ErrorWhenCreatingRiSc = 'ErrorWhenCreatingRiSc',
   ErrorWhenUpdatingRiSc = 'ErrorWhenUpdatingRiSc',
+  ErrorWhenUpdatingDeletedRiSc = 'ErrorWhenUpdatingDeletedRiSc',
   ErrorWhenDeletingRiSc = 'ErrorWhenDeletingRiSc',
   ErrorWhenPublishingRiSc = 'ErrorWhenPublishingRiSc',
   ErrorWhenNoWriteAccessToRepository = 'ErrorWhenNoWriteAccessToRepository',


### PR DESCRIPTION
# 📝 Beskrivelse

[Notion card](https://www.notion.so/bekks/Frontend-Bedre-h-ndtering-av-feil-som-oppst-r-om-en-bruker-pr-ver-endre-en-RoS-som-er-markert-for-32c6bd30854180299137fd16b0de5b39?v=1ac6bd3085418038bde2000cc1778974&source=copy_link)

Previously, users could update a RoS which has been marked for deletion. This is exacerbated by [this backend PR](https://github.com/kartverket/backstage-plugin-risk-scorecard-backend/pull/667) as doing this does not fail. 

This PR fixes this issue, hindering users from updating it, and warning them when they are about to do this (see image below):

<img width="805" height="248" alt="Screenshot 2026-04-09 at 16 16 33" src="https://github.com/user-attachments/assets/e67c7e8d-e931-4243-8de8-646d0a259c58" />

## ✅ Sjekkliste

- [x] Branchen er rebaset på `main` eller main er merget inn (Tips: om du bruker grensensittet i GitHub, så kan du velge rebase istedenfor merge. MERK: da må du slette din lokale branch og hente på nytt om du skal gjøre flere endringer).
- [x] Det er brukt minst en conventional commit med passende prefix **hvis** denne PR'en skal lage en ny release (er det endringer i selve pluginet skal det som hovedregel det).
- [ ] [Test-sjekklisten](../CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig.
