### PR TITLE
fix: Bugfix to address new scorecard flow issue

### DIFF
--- a/plugins/ros/src/components/riScDialog/RiScDialog.tsx
+++ b/plugins/ros/src/components/riScDialog/RiScDialog.tsx
@@ -109,8 +109,9 @@ export function RiScDialog({
     },
     // Continue to step 1 even if there are errors, as long as there are no errors in step 0 (the content)
     validationErrors => {
-      if (activeStep === 0 && validationErrors.content === undefined) {
-        setActiveStep(1);
+      if (validationErrors.content === undefined) {
+        if (activeStep === 0) setActiveStep(1);
+        if (activeStep === 1) setActiveStep(2);
       }
     },
   );

--- a/plugins/ros/src/components/riScDialog/RiScDialog.tsx
+++ b/plugins/ros/src/components/riScDialog/RiScDialog.tsx
@@ -117,12 +117,8 @@ export function RiScDialog({
   );
 
   function handleBack() {
-    if (activeStep === 1) {
-      setActiveStep(0);
-    }
-    if (activeStep === 2) {
-      setActiveStep(1);
-    }
+    if (activeStep === 1) setActiveStep(0);
+    if (activeStep === 2) setActiveStep(1);
   }
 
   const handleFinish = handleSubmit((data: RiScWithMetadata) => {


### PR DESCRIPTION
# 📝 Beskrivelse

[See Notion](https://www.notion.so/bekks/Fixa-frontend-bugg-som-blockar-anv-ndaren-fr-n-att-skapa-ny-RoS-om-de-g-r-1-steg-tillbaka-i-processe-3416bd30854180d6ae52d9fb040a6ff0?source=copy_link)

In short, the new RiSc scorecard process had a bug wherein if the user clicked next to the end, but then went back a step, it would not allow them to click on next (so if the user went to steps 0-1-2-1). This was not an issue for steps 0-1-0 as the code had an on ValidationError handler to change the active step from 1 to 0. Thus by adding one for 2-1, this issue is resolved. 

https://github.com/user-attachments/assets/7e2ebfe5-0618-430f-b3c0-530a1204b1bf


## ✅ Sjekkliste

- [x] Branchen er rebaset på `main` eller main er merget inn (Tips: om du bruker grensensittet i GitHub, så kan du velge rebase istedenfor merge. MERK: da må du slette din lokale branch og hente på nytt om du skal gjøre flere endringer).
- [x] Det er brukt minst en conventional commit med passende prefix **hvis** denne PR'en skal lage en ny release (er det endringer i selve pluginet skal det som hovedregel det).
- [ ] [Test-sjekklisten](../CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig.
