### PR TITLE
fix: legg til UNKNOWN oversettelse for ukjente SOPS-dekrypteringsfeil

### DIFF
--- a/plugins/ros/src/utils/translations.ts
+++ b/plugins/ros/src/utils/translations.ts
@@ -688,6 +688,8 @@ export const pluginRiScMessages = {
         'Failed to decrypt risk scorecard "{{riScId}}", the provided Age key is invalid.',
       CONNECTION_REFUSED:
         'Failed to decrypt risk scorecard "{{riScId}}", unable to connect to the encryption service.',
+      UNKNOWN:
+        'Failed to decrypt risk scorecard "{{riScId}}" due to an unknown error.',
     },
   },
   infoMessages: {
@@ -1418,6 +1420,8 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
             'Kunne ikke dekryptere risiko- og sårbarhetsanalyse "{{riScId}}", den oppgitte AGE-nøkkelen er ugyldig.',
           'errorMessages.ContentStatusDecryptionFailedMessage.CONNECTION_REFUSED':
             'Kunne ikke dekryptere risiko- og sårbarhetsanalyse "{{riScId}}", kunne ikke koble til krypteringstjenesten.',
+          'errorMessages.ContentStatusDecryptionFailedMessage.UNKNOWN':
+            'Kunne ikke dekryptere risiko- og sårbarhetsanalyse "{{riScId}}" grunnet en ukjent feil.',
 
           'errorMessages.ContentStatusUnknown':
             'Kunne ikke hente risiko- og sårbarhetsanalyse "{{riScId}}" med ukjent status: {{status}}',


### PR DESCRIPTION
# 📝 Beskrivelse

[Oppgave i Notion](https://www.notion.so/bekks/H-ndtere-ukjente-SOPS-dekrypteringsfeil-3436bd3085418082bfb2dff89dcac11f?source=copy_link)

Bytter ut tom streng med UNKNOWN som feilkode når SOPS feiler av en ukjent grunn, slik at feilmeldingen alltid vises korrekt i frontend i stedet for å falle tilbake på en generisk fallback.

---

## ✅ Sjekkliste

- [ ] Branchen er rebaset på `main` eller main er merget inn (Tips: om du bruker grensensittet i GitHub, så kan du velge rebase istedenfor merge. MERK: da må du slette din lokale branch og hente på nytt om du skal gjøre flere endringer).
- [ ] Det er brukt minst en conventional commit med passende prefix **hvis** denne PR'en skal lage en ny release (er det endringer i selve pluginet skal det som hovedregel det).
- [ ] [Test-sjekklisten](../CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig.
