### PR TITLE
feat: replace hardcoded colors with CSS variables and add dark mode alert style

### DIFF
--- a/plugins/ros/css/theme.css
+++ b/plugins/ros/css/theme.css
@@ -88,6 +88,10 @@ Remember to prefix custom styles with 'ros-' to avoid conflicts with other plugi
   --ros-input-text-color: #757575;
   --ros-input-disabledBackground: rgba(0, 0, 0, 0.12);
 
+  --ros-initial-risc-bg: var(--bui-bg-neutral-1);
+  --ros-scenario-highlight: var(--ros-gray-100);
+  --ros-scenario-card-bg: var(--ros-gray-50);
+
   /* -------Button styles------- */
   .ros-button-red {
     background-color: var(--ros-red-bright);
@@ -136,6 +140,10 @@ Remember to prefix custom styles with 'ros-' to avoid conflicts with other plugi
 
   --ros-input-text-color: #ffffff80;
   --ros-input-disabledBackground: rgba(255, 255, 255, 0.12);
+
+  --ros-initial-risc-bg: var(--bui-bg-neutral-3);
+  --ros-scenario-highlight: var(--ros-gray-300);
+  --ros-scenario-card-bg: var(--ros-gray-500);
 
   .bui-Switch:not([data-selected]) .bui-SwitchIndicator {
     background-color: var(--ros-gray-300);

--- a/plugins/ros/css/theme.css
+++ b/plugins/ros/css/theme.css
@@ -92,6 +92,15 @@ Remember to prefix custom styles with 'ros-' to avoid conflicts with other plugi
   --ros-scenario-highlight: var(--ros-gray-100);
   --ros-scenario-card-bg: var(--ros-gray-50);
 
+  --ros-alert-success-bg: var(--ros-green-50);
+  --ros-alert-success-border: var(--ros-green-300);
+  --ros-alert-warning-bg: var(--ros-orange-warm-50);
+  --ros-alert-warning-border: var(--ros-orange-300);
+  --ros-alert-error-bg: var(--ros-red-50);
+  --ros-alert-error-border: var(--ros-red-500);
+  --ros-alert-info-bg: var(--ros-blue-info-50);
+  --ros-alert-info-border: var(--ros-blue-info-400);
+
   /* -------Button styles------- */
   .ros-button-red {
     background-color: var(--ros-red-bright);
@@ -144,6 +153,15 @@ Remember to prefix custom styles with 'ros-' to avoid conflicts with other plugi
   --ros-initial-risc-bg: var(--bui-bg-neutral-3);
   --ros-scenario-highlight: var(--ros-gray-300);
   --ros-scenario-card-bg: var(--ros-gray-500);
+
+  --ros-alert-success-bg: #1a3a2a;
+  --ros-alert-success-border: var(--ros-green-300);
+  --ros-alert-warning-bg: #3a2e1a;
+  --ros-alert-warning-border: var(--ros-orange-300);
+  --ros-alert-error-bg: #3a1a1a;
+  --ros-alert-error-border: var(--ros-red-400);
+  --ros-alert-info-bg: #1a2a3a;
+  --ros-alert-info-border: var(--ros-blue-info-400);
 
   .bui-Switch:not([data-selected]) .bui-SwitchIndicator {
     background-color: var(--ros-gray-300);

--- a/plugins/ros/css/theme.css
+++ b/plugins/ros/css/theme.css
@@ -48,6 +48,14 @@ Remember to prefix custom styles with 'ros-' to avoid conflicts with other plugi
   --ros-gray-800: #2e2e2e;
   --ros-gray-900: #212121;
   --ros-gray-medium: #808080;
+  --ros-gray-light-hover: #e0e0e0;
+  --ros-gray-dark-card: #424242;
+  --ros-gray-dark-hover: #616161;
+
+  --ros-orange-warm-50: #fff7ed;
+
+  --ros-blue-info-50: #eaf6ff;
+  --ros-blue-info-400: #439ccd;
 
   --ros-risc-status-updated: var(--ros-green-500);
   --ros-risc-status-little-outdated: var(--ros-orange-400);
@@ -134,6 +142,6 @@ Remember to prefix custom styles with 'ros-' to avoid conflicts with other plugi
   }
 
   .bui-Card {
-    background-color: #424242;
+    background-color: var(--ros-gray-dark-card);
   }
 }

--- a/plugins/ros/src/components/common/Input.tsx
+++ b/plugins/ros/src/components/common/Input.tsx
@@ -36,11 +36,11 @@ export const Input = forwardRef<HTMLInputElement, Props>(
           variant="outlined"
           inputRef={ref}
           InputProps={{
-            sx: theme => ({
+            sx: {
               '&.Mui-disabled': {
-                color: commonTextColor(theme, true),
+                color: commonTextColor(true),
               },
-            }),
+            },
           }}
           {...props}
         />

--- a/plugins/ros/src/components/common/alertBar.module.css
+++ b/plugins/ros/src/components/common/alertBar.module.css
@@ -12,23 +12,23 @@
 
 /* severity variants */
 .success {
-  background-color: #e9f8eb;
-  border: 1px solid #66b077;
+  background-color: var(--ros-green-50);
+  border: 1px solid var(--ros-green-300);
 }
 
 .warning {
-  background-color: #fff7ed;
-  border: 1px solid #cf914a;
+  background-color: var(--ros-orange-warm-50);
+  border: 1px solid var(--ros-orange-300);
 }
 
 .error {
-  background-color: #fcf1e8;
-  border: 1px solid #a32f00;
+  background-color: var(--ros-red-50);
+  border: 1px solid var(--ros-red-500);
 }
 
 .info {
-  background-color: #eaf6ff;
-  border: 1px solid #439ccd;
+  background-color: var(--ros-blue-info-50);
+  border: 1px solid var(--ros-blue-info-400);
 }
 
 .preLineText {

--- a/plugins/ros/src/components/common/alertBar.module.css
+++ b/plugins/ros/src/components/common/alertBar.module.css
@@ -10,25 +10,25 @@
   margin-bottom: 8px;
 }
 
-/* severity variants */
+/* severity variants — !important needed to override MUI Alert inline styles */
 .success {
-  background-color: var(--ros-green-50);
-  border: 1px solid var(--ros-green-300);
+  background-color: var(--ros-alert-success-bg) !important;
+  border: 1px solid var(--ros-alert-success-border);
 }
 
 .warning {
-  background-color: var(--ros-orange-warm-50);
-  border: 1px solid var(--ros-orange-300);
+  background-color: var(--ros-alert-warning-bg) !important;
+  border: 1px solid var(--ros-alert-warning-border);
 }
 
 .error {
-  background-color: var(--ros-red-50);
-  border: 1px solid var(--ros-red-500);
+  background-color: var(--ros-alert-error-bg) !important;
+  border: 1px solid var(--ros-alert-error-border);
 }
 
 .info {
-  background-color: var(--ros-blue-info-50);
-  border: 1px solid var(--ros-blue-info-400);
+  background-color: var(--ros-alert-info-bg) !important;
+  border: 1px solid var(--ros-alert-info-border);
 }
 
 .preLineText {

--- a/plugins/ros/src/components/riScDialog/ConfigInitialRisc.tsx
+++ b/plugins/ros/src/components/riScDialog/ConfigInitialRisc.tsx
@@ -4,7 +4,6 @@ import { Box, Flex, Radio, RadioGroup, Switch, Text } from '@backstage/ui';
 import { RiScWithMetadata } from '../../utils/types.ts';
 import { useDefaultRiScTypeDescriptors } from '../../contexts/DefaultRiScTypesContext.tsx';
 import { UseFormSetValue } from 'react-hook-form';
-import { useTheme } from '@mui/material/styles';
 import styles from './ConfigInitialRisc.module.css';
 
 type RadioOptionProps = {
@@ -27,7 +26,6 @@ const RadioOption = ({
   recommendedBackstageComponentType,
 }: RadioOptionProps) => {
   const { t } = useTranslationRef(pluginRiScTranslationRef);
-  const theme = useTheme();
   const style = {
     fontSize: '12px',
     border: `1px solid ${active ? 'var(--bui-border-2)' : 'var(--bui-border-1)'}`,
@@ -43,10 +41,7 @@ const RadioOption = ({
         p="12px 16px"
         gap="2"
         style={{
-          backgroundColor:
-            theme.palette.mode === 'dark'
-              ? 'var(--bui-bg-neutral-3)'
-              : 'var(--bui-bg-neutral-1)',
+          backgroundColor: 'var(--ros-initial-risc-bg)',
           borderRadius: '8px',
           opacity: active ? 0.5 : 1,
         }}

--- a/plugins/ros/src/components/riScDialog/RiScDialog.module.css
+++ b/plugins/ros/src/components/riScDialog/RiScDialog.module.css
@@ -4,7 +4,7 @@
 }
 
 .deleteButton {
-  color: #d32f2f;
+  color: var(--ros-red-bright);
   padding-left: 0;
 }
 

--- a/plugins/ros/src/components/riScInfo/changeset/components/changeSet.module.css
+++ b/plugins/ros/src/components/riScInfo/changeset/components/changeSet.module.css
@@ -5,30 +5,26 @@
   padding: 14px 18px;
   height: 100%;
   border-radius: 24px;
-  color: #212121;
+  color: var(--bui-fg-primary);
   font-size: 14px;
 }
 
-[data-theme-mode='dark'] .box {
-  color: #f5f2f2;
-}
-
 .boxPrimary {
-  background-color: #fcebcd;
+  background-color: var(--ros-orange-50);
   margin-bottom: 24px;
 }
 
 [data-theme-mode='dark'] .boxPrimary {
-  background-color: #706f6e;
+  background-color: var(--ros-gray-400);
 }
 
 .boxSecondary {
-  background-color: #ffffff;
+  background-color: var(--bui-white);
   margin-bottom: 12px;
 }
 
 [data-theme-mode='dark'] .boxSecondary {
-  background-color: #4a4848;
+  background-color: var(--ros-gray-600);
 }
 
 /* ChangeSetBoxTitle */
@@ -46,31 +42,27 @@
 
 .propertyTitle {
   font-weight: 700;
-  color: #212121;
-}
-
-[data-theme-mode='dark'] .propertyTitle {
-  color: #f5f2f2;
+  color: var(--bui-fg-primary);
 }
 
 /* ChangeSetChangedValue */
 .oldValue {
   font-weight: 700;
-  color: #a32f00;
+  color: var(--ros-red-500);
   text-decoration: line-through;
 }
 
 [data-theme-mode='dark'] .oldValue {
-  color: #ffe2d4;
+  color: var(--ros-red-100);
 }
 
 .newValue {
   font-weight: 700;
-  color: #156630;
+  color: var(--ros-green-500);
 }
 
 [data-theme-mode='dark'] .newValue {
-  color: #d0ecd6;
+  color: var(--ros-green-100);
 }
 
 /* ChangeSetRemovedProperty */
@@ -80,37 +72,37 @@
 
 .removedProperty {
   font-weight: 700;
-  color: #a32f00;
+  color: var(--ros-red-500);
   text-decoration: line-through;
   font-size: 18px;
   line-height: 26px;
 }
 
 [data-theme-mode='dark'] .removedProperty {
-  color: #ffe2d4;
+  color: var(--ros-red-100);
 }
 
 /* ChangeSetRemovedValue */
 .removedValue {
   font-weight: 500;
-  color: #a32f00;
+  color: var(--ros-red-500);
   text-decoration: line-through;
   font-size: 14px;
 }
 
 [data-theme-mode='dark'] .removedValue {
-  color: #ffe2d4;
+  color: var(--ros-red-100);
 }
 
 /* ChangeSetAddedValue */
 .addedValue {
   font-weight: 500;
-  color: #156630;
+  color: var(--ros-green-500);
   font-size: 14px;
 }
 
 [data-theme-mode='dark'] .addedValue {
-  color: #d0ecd6;
+  color: var(--ros-green-100);
 }
 
 /* ChangeSetTag */
@@ -119,22 +111,22 @@
   width: fit-content;
   padding: 1px 8px;
   border: 1px solid;
-  color: #212121;
+  color: var(--bui-fg-primary);
 }
 
 .tagPrimary {
-  background-color: #ffdd9d;
-  border-color: #cf914a;
+  background-color: var(--ros-orange-100);
+  border-color: var(--ros-orange-300);
 }
 
 .tagDelete {
-  background-color: #ebb095;
-  border-color: #d04a14;
+  background-color: var(--ros-red-200);
+  border-color: var(--ros-red-400);
 }
 
 .tagAdded {
-  background-color: #d0ecd6;
-  border-color: #66b077;
+  background-color: var(--ros-green-100);
+  border-color: var(--ros-green-300);
 }
 
 /* ChangeSetTags */
@@ -147,36 +139,24 @@
 /* ChangeSetText */
 .text {
   font-weight: 500;
-  color: #212121;
-}
-
-[data-theme-mode='dark'] .text {
-  color: #f5f2f2;
+  color: var(--bui-fg-primary);
 }
 
 /* ChangeSetBodyText */
 .bodyText {
-  color: #212121;
+  color: var(--bui-fg-primary);
   margin-top: 0;
   margin-bottom: 4px;
-}
-
-[data-theme-mode='dark'] .bodyText {
-  color: #f5f2f2;
 }
 
 /* ChangeSetTitle */
 .title {
   text-transform: uppercase;
   letter-spacing: 1px;
-  color: #212121;
+  color: var(--bui-fg-primary);
   font-weight: 700;
   font-size: 14px;
   margin-bottom: 12px;
-}
-
-[data-theme-mode='dark'] .title {
-  color: #f5f2f2;
 }
 
 /* ChangeSetTwoColumnSplit */

--- a/plugins/ros/src/components/riScInfo/changeset/components/changeSet.module.css
+++ b/plugins/ros/src/components/riScInfo/changeset/components/changeSet.module.css
@@ -15,7 +15,7 @@
 }
 
 [data-theme-mode='dark'] .boxPrimary {
-  background-color: var(--ros-gray-400);
+  background-color: var(--bui-bg-neutral-3);
 }
 
 .boxSecondary {
@@ -24,7 +24,7 @@
 }
 
 [data-theme-mode='dark'] .boxSecondary {
-  background-color: var(--ros-gray-600);
+  background-color: var(--bui-bg-neutral-4);
 }
 
 /* ChangeSetBoxTitle */
@@ -118,15 +118,28 @@
   background-color: var(--ros-orange-100);
   border-color: var(--ros-orange-300);
 }
+[data-theme-mode='dark'] .tagPrimary {
+  background-color: var(--ros-orange-300);
+  border-color: var(--ros-orange-500);
+}
 
 .tagDelete {
   background-color: var(--ros-red-200);
   border-color: var(--ros-red-400);
 }
 
+[data-theme-mode='dark'] .tagDelete {
+  background-color: var(--ros-red-400);
+  border-color: var(--ros-red-600);
+}
+
 .tagAdded {
   background-color: var(--ros-green-100);
   border-color: var(--ros-green-300);
+}
+[data-theme-mode='dark'] .tagAdded {
+  background-color: var(--ros-green-300);
+  border-color: var(--ros-green-500);
 }
 
 /* ChangeSetTags */

--- a/plugins/ros/src/components/riScInfo/riScStatus/StatusBanner.module.css
+++ b/plugins/ros/src/components/riScInfo/riScStatus/StatusBanner.module.css
@@ -1,5 +1,5 @@
 .boxStyle {
-  background-color: #fcebcd;
+  background-color: var(--ros-orange-50);
   padding: 8px 16px;
   margin-top: 8px;
   border-radius: 4px;

--- a/plugins/ros/src/components/riskMatrix/AggregatedCost.module.css
+++ b/plugins/ros/src/components/riskMatrix/AggregatedCost.module.css
@@ -1,5 +1,5 @@
 .boxStyle {
-  background-color: #fcebcd;
+  background-color: var(--ros-orange-50);
   padding: 8px 16px;
   border-radius: 4px;
 }

--- a/plugins/ros/src/components/riskMatrix/Tabs.module.css
+++ b/plugins/ros/src/components/riskMatrix/Tabs.module.css
@@ -20,7 +20,7 @@
 }
 
 .tabButtonTextBase[data-selected='true'] {
-  color: #ffffff;
+  color: var(--bui-white);
 }
 
 [data-theme-mode='dark'] {

--- a/plugins/ros/src/components/scenarioTable/ScenarioTable.module.css
+++ b/plugins/ros/src/components/scenarioTable/ScenarioTable.module.css
@@ -8,29 +8,29 @@
   border: none;
   margin-bottom: 8px;
   padding: 28px 24px;
-  background-color: #f8f8f8;
+  background-color: var(--ros-gray-50);
 }
 
 .tableCard:hover {
-  background-color: #e0e0e0;
+  background-color: var(--ros-gray-light-hover);
   cursor: pointer;
 }
 
 .tableCard.tableCardNoHover:hover {
-  background-color: #f8f8f8;
+  background-color: var(--ros-gray-50);
   cursor: pointer;
 }
 
 [data-theme-mode='dark'] .tableCard {
-  background-color: #424242;
+  background-color: var(--ros-gray-dark-card);
 }
 
 [data-theme-mode='dark'] .tableCard:hover {
-  background-color: #616161;
+  background-color: var(--ros-gray-dark-hover);
 }
 
 [data-theme-mode='dark'] .tableCard.tableCardNoHover:hover {
-  background-color: #424242;
+  background-color: var(--ros-gray-dark-card);
 }
 
 .tableCardNoHover {

--- a/plugins/ros/src/components/scenarioTable/ScenarioTableRow.tsx
+++ b/plugins/ros/src/components/scenarioTable/ScenarioTableRow.tsx
@@ -106,14 +106,9 @@ export function ScenarioTableRow({
     s => s.ID === scenario.ID,
   );
 
-  const highlightColor =
-    theme.palette.mode === 'dark'
-      ? 'var(--ros-gray-300)'
-      : 'var(--ros-gray-100)';
+  const highlightColor = 'var(--ros-scenario-highlight)';
 
-  // Necessary because the darkmode card color in theme.css overwrites the color defined in ScenarioTableStyles.ts
-  const cardBgColor =
-    theme.palette.mode === 'dark' ? 'var(--ros-gray-500)' : undefined;
+  const cardBgColor = 'var(--ros-scenario-card-bg)';
 
   const isTextColorBlack =
     theme.palette.mode === 'dark' ? isScenarioHoveredFromRiskMatrix : true;

--- a/plugins/ros/src/components/threatActorsAndVulnerabilities/CoverageStatusBox.module.css
+++ b/plugins/ros/src/components/threatActorsAndVulnerabilities/CoverageStatusBox.module.css
@@ -2,7 +2,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  background-color: #fcebcd;
+  background-color: var(--ros-orange-50);
   padding: 8px 16px;
   border-radius: 4px;
 }

--- a/plugins/ros/src/utils/style.ts
+++ b/plugins/ros/src/utils/style.ts
@@ -1,9 +1,7 @@
-import { Theme } from '@mui/material/styles';
-
 // Common styles for Input, MarkdownInput, and Markdown components
-export const commonTextColor = (theme: Theme, disabled: boolean) => {
+export const commonTextColor = (disabled: boolean) => {
   if (disabled) {
-    return theme.palette.mode === 'dark' ? '#FFFFFF80' : '#757575';
+    return 'var(--ros-input-text-color)';
   }
   return 'inherit';
 };


### PR DESCRIPTION
# 📝 Beskrivelse

Oppgave i Notion

 Make CSS variable usage consistent across the RiSc plugin by replacing hardcoded hex 
colors and JS theme checks with `--ros-*` / `--bui-*` CSS variables that auto-switch 
between light and dark mode.

[Notion](https://www.notion.so/bekks/Bruke-riktige-CSS-variabler-i-RoS-plugin-33b6bd308541800c83f9e23e15efa8d7?source=copy_link)

 ## Changes
 
 ### 1. Replace hardcoded hex colors with CSS variables
 - **8 CSS module files** updated (~50 replacements total)
 - `changeSet.module.css` had the most changes — removed 5 redundant 
`[data-theme-mode='dark']` selectors by using `--bui-fg-primary` for text
 - Added 6 new `--ros-*` variables to `theme.css`
 
 ### 2. Replace JS `theme.palette.mode` checks with CSS variables
 - **`style.ts`**: Simplified `commonTextColor` to use `var(--ros-input-text-color)`, 
removed MUI `Theme` dependency
 - **`Input.tsx`**: Simplified `sx` prop (no longer needs theme callback)
 - **`ConfigInitialRisc.tsx`**: Replaced dark/light ternary with 
`var(--ros-initial-risc-bg)`, removed `useTheme`
 - **`ScenarioTableRow.tsx`**: Replaced 2 of 3 theme checks with 
`var(--ros-scenario-highlight)` and `var(--ros-scenario-card-bg)` (kept 1 that depends
 on runtime hover state)
 
 ### 3. Add dark mode colors for alert banners
 - Added semantic `--ros-alert-*-bg` and `--ros-alert-*-border` variables with dark 
mode variants
 - Uses `!important` to override MUI Alert inline styles
 - Dark mode backgrounds: deep muted tones matching each severity (green, amber, red, 
blue)
 
 ## How to test
 1. Toggle between light and dark mode
 2. Verify the **scenario table** cards and hover highlights look correct in both 
modes
 3. Trigger **alert banners** (save a RiSc) — check all severity colors in dark mode
 4. Open **Create new RiSc** dialog with initial RiSc toggle ON — check radio card 
backgrounds
 5. Check **changeset diff view** for correct added/removed colors

---

## ✅ Sjekkliste

- [x] Branchen er rebaset på `main` eller main er merget inn (Tips: om du bruker grensensittet i GitHub, så kan du velge rebase istedenfor merge. MERK: da må du slette din lokale branch og hente på nytt om du skal gjøre flere endringer).
- [x] Det er brukt minst en conventional commit med passende prefix **hvis** denne PR'en skal lage en ny release (er det endringer i selve pluginet skal det som hovedregel det).
- [ ] [Test-sjekklisten](../CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig.

## Bilder: 

Før: 
<img width="694" height="993" alt="image" src="https://github.com/user-attachments/assets/f893d57c-af37-4c33-8dda-c1cb9c291411" />

Etter: 
<img width="693" height="922" alt="image" src="https://github.com/user-attachments/assets/b0133efa-e222-4ac9-ab55-a6ec0222c10e" />

Før: 
<img width="694" height="91" alt="image" src="https://github.com/user-attachments/assets/4b1f4893-0eff-4c10-bbde-aa1f04d0a8cc" />

Etter: 
<img width="694" height="75" alt="image" src="https://github.com/user-attachments/assets/cc7e903e-3651-46e6-adff-16d4484c6900" />

