### PR TITLE
fix: feilmelding ved feil input av url

### DIFF
--- a/plugins/ros/src/utils/utilityfunctions.ts
+++ b/plugins/ros/src/utils/utilityfunctions.ts
@@ -47,6 +47,7 @@ export function generateRandomId(): string {
  * @param path Path to value
  */
 export function getValue(obj: any, path: string) {
+  if (path === '') return obj;
   return path.split('.').reduce((prev, curr) => {
     return prev?.[curr];
   }, obj);


### PR DESCRIPTION
# 📝 Beskrivelse

Oppgave i Notion

`getValue` returnerte `undefined` når `path` var en tom streng, noe som førte til at valideringsfeil for URL-feltet aldri ble vist i inline-redigeringsmodus. Lagt til en early 
return som returnerer objektet direkte når path er tom.

---
Før (ingenting skjer når man trykker lagre): 
<img width="533" height="129" alt="image" src="https://github.com/user-attachments/assets/59edd2bc-630a-4ff0-8376-96eef2141f9e" />

Etter (feilmelding dukker opp):
<img width="221" height="173" alt="image" src="https://github.com/user-attachments/assets/3a941ec6-f451-48f7-b1b6-4e9aea24bac2" />


## ✅ Sjekkliste

- [ ] Branchen er rebaset på `main` eller main er merget inn (Tips: om du bruker grensensittet i GitHub, så kan du velge rebase istedenfor merge. MERK: da må du slette din lokale branch og hente på nytt om du skal gjøre flere endringer).
- [ ] Det er brukt minst en conventional commit med passende prefix **hvis** denne PR'en skal lage en ny release (er det endringer i selve pluginet skal det som hovedregel det).
- [ ] [Test-sjekklisten](../CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig.
