### PR TITLE
fix: hide broken Card scroll-fade gradient in Firefox

### DIFF
--- a/plugins/ros/css/theme.css
+++ b/plugins/ros/css/theme.css
@@ -173,7 +173,7 @@ Remember to prefix custom styles with 'ros-' to avoid conflicts with other plugi
 }
 
 /* 
-Remove this when backstage-ui hits v0.15 (which contains a fix).
+Remove this when backstage-ui hits v0.15, which contains a fix.
 Fix for Firefox: the @backstage/ui Card component uses a scroll-fade gradient
    (::before on CardBody) controlled by animation-timeline: scroll(). Firefox does
    not support scroll-driven animations, so the gradient becomes permanently visible

--- a/plugins/ros/css/theme.css
+++ b/plugins/ros/css/theme.css
@@ -171,3 +171,15 @@ Remember to prefix custom styles with 'ros-' to avoid conflicts with other plugi
     background-color: var(--ros-gray-dark-card);
   }
 }
+
+/* 
+Remove this when backstage-ui hits v0.15 (which contains a fix).
+Fix for Firefox: the @backstage/ui Card component uses a scroll-fade gradient
+   (::before on CardBody) controlled by animation-timeline: scroll(). Firefox does
+   not support scroll-driven animations, so the gradient becomes permanently visible
+   as a white stripe. Hide it in unsupported browsers. */
+@supports not (animation-timeline: scroll()) {
+  .bui-Card:has(.bui-CardHeader) .bui-CardBody::before {
+    display: none;
+  }
+}

--- a/plugins/ros/css/theme.css
+++ b/plugins/ros/css/theme.css
@@ -173,7 +173,7 @@ Remember to prefix custom styles with 'ros-' to avoid conflicts with other plugi
 }
 
 /* 
-Remove this when backstage-ui hits v0.15, which contains a fix.
+TODO: Remove this when backstage-ui hits v0.15, which contains a fix.
 Fix for Firefox: the @backstage/ui Card component uses a scroll-fade gradient
    (::before on CardBody) controlled by animation-timeline: scroll(). Firefox does
    not support scroll-driven animations, so the gradient becomes permanently visible


### PR DESCRIPTION
# 📝 Beskrivelse

Oppgave i Notion

Som [beskrevet av Ådne på slack](https://bekk.slack.com/archives/C075KCPTURY/p1778491292465139) så vises det i noen tilfeller en hvit gradient i noen Card-komponenter. 

Dette er fordi [firefox ikke støtter animation-timeline](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/animation-timeline#browser_compatibility), som brukes av backstage ui til å legge på en hvit gradient når en Card-body er scrollbar. 

Lagt til fiks for å ikke displaye gradienten ved bruk av nettleser som ikke støtter dette. 

Backstage ui har også en fiks som ikke er ute enda men [kommer i v0.15](https://github.com/backstage/backstage/blob/master/packages/ui/CHANGELOG.md), så dette kan fjernes etter det. 

---

## ✅ Sjekkliste

- [x] Branchen er rebaset på `main` eller main er merget inn (Tips: om du bruker grensensittet i GitHub, så kan du velge rebase istedenfor merge. MERK: da må du slette din lokale branch og hente på nytt om du skal gjøre flere endringer).
- [ ] Det er brukt minst en conventional commit med passende prefix **hvis** denne PR'en skal lage en ny release (er det endringer i selve pluginet skal det som hovedregel det).
- [ ] [Test-sjekklisten](../CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig.
