### PR TITLE
fix: update Confluence link for RISC documentation

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -23,7 +23,7 @@ app:
       - title: RISC Documentation
         icon: article
         links:
-          - url: https://kartverket.atlassian.net/wiki/spaces/SIK/pages/1176142023/Koden+r+RoS
+          - url: https://kartverket.atlassian.net/wiki/x/FAAWYg
             title: Confluence - RISC
       - title: Sikkerhetsmetrikker Feedback Channel
         icon: chat


### PR DESCRIPTION
# 📝 Beskrivelse

[Oppgave i Notion](https://www.notion.so/bekks/Oppdatere-Confluence-sider-til-benytte-nytt-Operasjonell-RoS-navn-3596bd30854180f78687f8653cd9339d?source=copy_link)

<!-- Beskriv kort hva som er endret og gjerne legg ved link til Notion oppgave Pro-tip: marker teksten over og lim inn lenken til oppgavekortet 😉. -->
<!-- PS: Legg gjerne lenken til PR'en i Notion kortet også :) -->

Oppdaterer Confluence lenke

<!-- Legg til skjermbilder eller GIF-er som viser endringene visuelt (spesielt ved UI-endringer). -->
<!-- Eventuelt linker til relevante ting (risc.yaml-fil, spesielle RoS'er i dev-miljøet) -->

---

## ✅ Sjekkliste

- [ ] Branchen er rebaset på `main` eller main er merget inn (Tips: om du bruker grensensittet i GitHub, så kan du velge rebase istedenfor merge. MERK: da må du slette din lokale branch og hente på nytt om du skal gjøre flere endringer).
- [ ] Det er brukt minst en conventional commit med passende prefix **hvis** denne PR'en skal lage en ny release (er det endringer i selve pluginet skal det som hovedregel det).
- [ ] [Test-sjekklisten](../CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig.
