### PR TITLE
fix: Håndtering av utgåtte github-tokens ved endring på flere RoSer i ulike tabs

### DIFF
--- a/plugins/ros/src/utils/hooks.test.tsx
+++ b/plugins/ros/src/utils/hooks.test.tsx
@@ -44,7 +44,7 @@ describe('useGithubRepositoryInformation', () => {
 
 describe('useAuthenticatedFetch', () => {
   const mockGoogleApi = { getAccessToken: jest.fn() };
-  const mockGithubSessionShouldRefreshFunc = jest.fn(() => false);
+  const mockGithubSessionShouldRefreshFunc = jest.fn(_ => false);
   const mockGithubApi = {
     getAccessToken: jest.fn(),
     sessionManager: {

--- a/plugins/ros/src/utils/hooks.test.tsx
+++ b/plugins/ros/src/utils/hooks.test.tsx
@@ -44,7 +44,18 @@ describe('useGithubRepositoryInformation', () => {
 
 describe('useAuthenticatedFetch', () => {
   const mockGoogleApi = { getAccessToken: jest.fn() };
-  const mockGithubApi = { getAccessToken: jest.fn() };
+  const mockGithubSessionShouldRefreshFunc = jest.fn(() => false);
+  const mockGithubApi = {
+    getAccessToken: jest.fn(),
+    sessionManager: {
+      currentSession: {
+        providerInfo: {
+          accessToken: MOCK_GITHUB_TOKEN,
+        },
+      },
+      sessionShouldRefreshFunc: mockGithubSessionShouldRefreshFunc,
+    },
+  };
   const mockIdentityApi = {
     getCredentials: jest.fn(),
     getProfileInfo: jest.fn(),
@@ -347,6 +358,94 @@ describe('useAuthenticatedFetch', () => {
         false,
       );
       expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it('retries once with a forced GitHub auth refresh when a write returns an access-token validation failure', async () => {
+      const githubAccessTokenCallCount =
+        mockGithubApi.getAccessToken.mock.calls.length;
+      const fetchCallCount = mockFetchApi.fetch.mock.calls.length;
+      mockGithubSessionShouldRefreshFunc.mockClear();
+      mockGithubApi.sessionManager.currentSession = {
+        providerInfo: {
+          accessToken: MOCK_GITHUB_TOKEN,
+        },
+      };
+
+      mockGoogleApi.getAccessToken.mockResolvedValue(MOCK_GCP_TOKEN);
+      mockGithubApi.getAccessToken.mockImplementation(async () => {
+        const session = mockGithubApi.sessionManager.currentSession;
+        if (mockGithubApi.sessionManager.sessionShouldRefreshFunc(session)) {
+          mockGithubApi.sessionManager.currentSession = {
+            providerInfo: {
+              accessToken: '<fresh-github-token>',
+            },
+          };
+        }
+        return mockGithubApi.sessionManager.currentSession.providerInfo
+          .accessToken;
+      });
+      mockIdentityApi.getCredentials.mockResolvedValue({
+        token: MOCK_ID_TOKEN,
+      });
+      mockIdentityApi.getProfileInfo.mockResolvedValue({
+        email: 'email',
+        displayName: 'name',
+      });
+      mockFetchApi.fetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 403,
+          json: async () => ({ status: 'InvalidGitHubAccessToken' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ ID: '1' }),
+        });
+
+      const { result } = renderHook(() => useAuthenticatedFetch(), {
+        wrapper,
+      });
+
+      const onSuccess = jest.fn();
+      const onError = jest.fn();
+
+      const riScWithMetaData = {
+        id: '1',
+        content: {
+          ID: '1',
+          scenarios: [
+            {
+              ID: '1',
+              name: 'test',
+              actions: [{ ID: '1' } as Partial<Action>],
+            } as Partial<Scenario>,
+          ],
+        } as Partial<RiSc> as RiSc,
+      } as Partial<RiScWithMetadata> as RiScWithMetadata;
+
+      await act(async () => {
+        await result.current.putRiScs(riScWithMetaData, onSuccess, onError);
+      });
+
+      const githubAccessTokenCalls =
+        mockGithubApi.getAccessToken.mock.calls.slice(
+          githubAccessTokenCallCount,
+        );
+      expect(githubAccessTokenCalls).toEqual([[['repo']], [['repo']]]);
+      expect(mockGithubSessionShouldRefreshFunc).toHaveBeenCalledTimes(1);
+
+      const fetchCalls = mockFetchApi.fetch.mock.calls.slice(fetchCallCount);
+      expect(fetchCalls).toHaveLength(2);
+
+      const [, retryOptions] = fetchCalls[1];
+      expect(retryOptions.headers).toEqual(
+        expect.objectContaining({
+          'GitHub-Access-Token': '<fresh-github-token>',
+        }),
+      );
+      expect(onSuccess).toHaveBeenCalledWith({ ID: '1' });
+      expect(onError).not.toHaveBeenCalled();
+      mockFetchApi.fetch.mock.calls.splice(fetchCallCount);
     });
   });
 

--- a/plugins/ros/src/utils/hooks.test.tsx
+++ b/plugins/ros/src/utils/hooks.test.tsx
@@ -394,7 +394,7 @@ describe('useAuthenticatedFetch', () => {
       mockFetchApi.fetch
         .mockResolvedValueOnce({
           ok: false,
-          status: 403,
+          status: 401,
           json: async () => ({ status: 'InvalidGitHubAccessToken' }),
         })
         .mockResolvedValueOnce({

--- a/plugins/ros/src/utils/hooks.ts
+++ b/plugins/ros/src/utils/hooks.ts
@@ -42,6 +42,46 @@ export function useGithubRepositoryInformation(): GithubRepoInfo {
   };
 }
 
+/**
+ * Backstage has a bug where multiple tabs using the GitHub access token can each
+ * fetch a new token and invalidate tokens cached in older tabs. To mitigate this
+ * we patch an internal refresh predicate so a token verified as invalid can be
+ * refreshed before retrying the request.
+ */
+let invalidGitHubAccessToken = '';
+function patchGithubApiToEnableForcedRefresh<T>(
+  gitHubApi: T,
+  isDevelopment: boolean,
+): T {
+  const sessionManager = (gitHubApi as any)?.sessionManager;
+  if (!sessionManager?.originalSessionShouldRefreshFunc) {
+    if (typeof sessionManager?.sessionShouldRefreshFunc === 'function') {
+      sessionManager.originalSessionShouldRefreshFunc =
+        sessionManager.sessionShouldRefreshFunc;
+      sessionManager.sessionShouldRefreshFunc =
+        function sessionShouldRefreshFuncOverride(session: any) {
+          const accessToken = session?.providerInfo?.accessToken;
+          if (isDevelopment && invalidGitHubAccessToken && !accessToken) {
+            throw new Error(
+              'The expected location of the accessToken was empty. This workaround is no longer working',
+            );
+          }
+          if (accessToken === invalidGitHubAccessToken) {
+            invalidGitHubAccessToken = '';
+            return true;
+          }
+          return sessionManager.originalSessionShouldRefreshFunc(session);
+        };
+    } else if (isDevelopment) {
+      throw new Error(
+        'The expected function "sessionShouldRefreshFunc" does not exist. This workaround is no longer working',
+      );
+    }
+  }
+
+  return gitHubApi;
+}
+
 export function useAuthenticatedFetch() {
   const configApi = useApi(configApiRef);
   const repoInformation = useGithubRepositoryInformation();
@@ -143,6 +183,7 @@ export function useAuthenticatedFetch() {
       } else {
         onError(error, false);
       }
+      return Promise.resolve(null);
     }
   }
 
@@ -438,43 +479,4 @@ export function useDebounce<T>(
     }
   }, []);
   return { flush };
-}
-
-/**
- * Backstage has a bug where multiple tabs using the GitHub access token can each
- * fetch a new token and invalidate tokens cached in older tabs. To mitigate this
- * we patch an internal refresh predicate so a token verified as invalid can be
- * refreshed before retrying the request.
- */
-let invalidGitHubAccessToken = '';
-function patchGithubApiToEnableForcedRefresh<T>(
-  gitHubApi: T,
-  isDevelopment: boolean,
-): T {
-  const sessionManager = (gitHubApi as any)?.sessionManager;
-  if (!sessionManager?.originalSessionShouldRefreshFunc) {
-    if (typeof sessionManager?.sessionShouldRefreshFunc === 'function') {
-      sessionManager.originalSessionShouldRefreshFunc =
-        sessionManager.sessionShouldRefreshFunc;
-      sessionManager.sessionShouldRefreshFunc = function (session: any) {
-        const accessToken = session?.providerInfo?.accessToken;
-        if (isDevelopment && invalidGitHubAccessToken && !accessToken) {
-          throw new Error(
-            'The expected location of the accessToken was empty. This workaround is no longer working',
-          );
-        }
-        if (accessToken === invalidGitHubAccessToken) {
-          invalidGitHubAccessToken = '';
-          return true;
-        }
-        return sessionManager.originalSessionShouldRefreshFunc(session);
-      };
-    } else if (isDevelopment) {
-      throw new Error(
-        'The expected function "sessionShouldRefreshFunc" does not exist. This workaround is no longer working',
-      );
-    }
-  }
-
-  return gitHubApi;
 }

--- a/plugins/ros/src/utils/hooks.ts
+++ b/plugins/ros/src/utils/hooks.ts
@@ -157,7 +157,7 @@ export function useAuthenticatedFetch() {
 
       if (
         res.status === 403 &&
-        (json as ProcessRiScResultDTO).status ===
+        (json as ProcessRiScResultDTO)?.status ===
           ProcessingStatus.InvalidGitHubAccessToken
       ) {
         invalidGitHubAccessToken = headers['GitHub-Access-Token'];

--- a/plugins/ros/src/utils/hooks.ts
+++ b/plugins/ros/src/utils/hooks.ts
@@ -156,7 +156,7 @@ export function useAuthenticatedFetch() {
       let json = await res.json();
 
       if (
-        res.status === 403 &&
+        res.status === 401 &&
         (json as ProcessRiScResultDTO)?.status ===
           ProcessingStatus.InvalidGitHubAccessToken
       ) {

--- a/plugins/ros/src/utils/hooks.ts
+++ b/plugins/ros/src/utils/hooks.ts
@@ -11,20 +11,21 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { URLS } from '../urls';
 import {
   CreateRiScResultDTO,
+  DeleteRiScResultDTO,
   GcpCryptoKeyObject,
   ProcessRiScResultDTO,
+  profileInfoToDTOString,
   PublishRiScResultDTO,
   RiScContentResultDTO,
-  SopsConfigDTO,
-  profileInfoToDTOString,
   riScToDTOString,
-  DeleteRiScResultDTO,
+  SopsConfigDTO,
 } from './DTOs';
 import { latestSupportedVersion } from './constants';
 import {
   DefaultRiScTypeDescriptor,
   DifferenceDTO,
   GithubRepoInfo,
+  ProcessingStatus,
   RiSc,
   RiScWithMetadata,
 } from './types';
@@ -116,7 +117,8 @@ export function useAuthenticatedFetch() {
 
       if (
         res.status === 403 &&
-        (json as ProcessRiScResultDTO).status === 'InvalidGitHubAccessToken'
+        (json as ProcessRiScResultDTO).status ===
+          ProcessingStatus.InvalidGitHubAccessToken
       ) {
         invalidGitHubAccessToken = headers['GitHub-Access-Token'];
         headers['GitHub-Access-Token'] = await gitHubApi.getAccessToken([

--- a/plugins/ros/src/utils/hooks.ts
+++ b/plugins/ros/src/utils/hooks.ts
@@ -116,8 +116,7 @@ export function useAuthenticatedFetch() {
 
       if (
         res.status === 403 &&
-        (json as ProcessRiScResultDTO).status ===
-          'InvalidGitHubAccessToken'
+        (json as ProcessRiScResultDTO).status === 'InvalidGitHubAccessToken'
       ) {
         invalidGitHubAccessToken = headers['GitHub-Access-Token'];
         headers['GitHub-Access-Token'] = await gitHubApi.getAccessToken([

--- a/plugins/ros/src/utils/hooks.ts
+++ b/plugins/ros/src/utils/hooks.ts
@@ -42,12 +42,16 @@ export function useGithubRepositoryInformation(): GithubRepoInfo {
 }
 
 export function useAuthenticatedFetch() {
+  const configApi = useApi(configApiRef);
   const repoInformation = useGithubRepositoryInformation();
   const googleApi = useApi(googleAuthApiRef);
-  const gitHubApi = useApi(githubAuthApiRef);
+  const gitHubApi = patchGithubApiToEnableForcedRefresh(
+    useApi(githubAuthApiRef),
+    isDevelopment(),
+  );
   const identityApi = useApi(identityApiRef);
   const { fetch } = useApi(fetchApiRef);
-  const backendUrl = useApi(configApiRef).getString('backend.baseUrl');
+  const backendUrl = configApi.getString('backend.baseUrl');
   const riScUri = `${backendUrl}${URLS.backend.riScUri_temp}/${repoInformation.owner}/${repoInformation.name}`; // URLS.backend.riScUri
 
   const uriToFetchAllRiScs = `${riScUri}/${latestSupportedVersion}/all`; // URLS.backend.fetchAllRiScs
@@ -73,59 +77,72 @@ export function useAuthenticatedFetch() {
     return `${riScUri}/publish/${id}`;
   }
 
-  const configApi = useApi(configApiRef);
-
   function isDevelopment() {
     return configApi.getString('auth.environment') === 'development';
   }
 
-  function fullyAuthenticatedFetch<T, K>(
+  async function fullyAuthenticatedFetch<T, K>(
     uri: string,
     method: 'GET' | 'POST' | 'PUT' | 'DELETE',
     onSuccess: (response: T) => void,
     onError: (error: K, rejectedLogin: boolean) => void,
     body?: string,
   ) {
-    Promise.all([
-      identityApi.getCredentials(),
-      googleApi.getAccessToken([
-        URLS.external.www_googleapis_com__cloudkms,
-        URLS.external.www_googleapis_com__cloud_platform,
-        URLS.external.www_googleapis_com__cloudplatformprojects_readonly,
-      ]),
-      gitHubApi.getAccessToken(['repo']),
-    ])
-      .then(([idToken, googleAccessToken, gitHubAccessToken]) => {
-        fetch(uri, {
-          method: method,
-          headers: {
-            Authorization: `Bearer ${idToken.token}`,
-            'GCP-Access-Token': googleAccessToken,
-            'GitHub-Access-Token': gitHubAccessToken,
-            'Content-Type': 'application/json',
-          },
-          body: body,
-        }).then(res => {
-          if (!res.ok) {
-            return res
-              .json()
-              .then(json => json as K)
-              .then(typedJson => onError(typedJson, false))
-              .catch(error => onError(error, false));
-          }
-          return res
-            .json()
-            .then(json => json as T)
-            .then(typedJson => onSuccess(typedJson));
-        });
-      })
-      .catch(error => {
-        if (error.name === 'RejectedError') {
-          onError(error, true);
-        } else {
-          onError(error, false);
-        }
+    try {
+      const [idToken, googleAccessToken, gitHubAccessToken] = await Promise.all(
+        [
+          identityApi.getCredentials(),
+          googleApi.getAccessToken([
+            URLS.external.www_googleapis_com__cloudkms,
+            URLS.external.www_googleapis_com__cloud_platform,
+            URLS.external.www_googleapis_com__cloudplatformprojects_readonly,
+          ]),
+          gitHubApi.getAccessToken(['repo']),
+        ],
+      );
+      const headers = {
+        Authorization: `Bearer ${idToken.token}`,
+        'GCP-Access-Token': googleAccessToken,
+        'GitHub-Access-Token': gitHubAccessToken,
+        'Content-Type': 'application/json',
+      };
+      let res = await fetch(uri, {
+        method: method,
+        headers,
+        body: body,
       });
+
+      let json = await res.json();
+
+      if (
+        res.status === 403 &&
+        (json as ProcessRiScResultDTO).status ===
+          'InvalidGitHubAccessToken'
+      ) {
+        invalidGitHubAccessToken = headers['GitHub-Access-Token'];
+        headers['GitHub-Access-Token'] = await gitHubApi.getAccessToken([
+          'repo',
+        ]);
+        res = await fetch(uri, {
+          method: method,
+          headers: headers,
+          body: body,
+        });
+        json = await res.json();
+      }
+
+      if (!res.ok) {
+        return onError(json as K, false);
+      }
+
+      return onSuccess(json as T);
+    } catch (error: any) {
+      if (error.name === 'RejectedError') {
+        onError(error, true);
+      } else {
+        onError(error, false);
+      }
+    }
   }
 
   function googleAuthenticatedFetch<T, K>(
@@ -297,7 +314,7 @@ export function useAuthenticatedFetch() {
     onSuccess?: (response: ProcessRiScResultDTO | PublishRiScResultDTO) => void,
     onError?: (error: ProcessRiScResultDTO, loginRejected: boolean) => void,
   ) {
-    identityApi.getProfileInfo().then(profile =>
+    return identityApi.getProfileInfo().then(profile =>
       fullyAuthenticatedFetch<
         ProcessRiScResultDTO | PublishRiScResultDTO,
         ProcessRiScResultDTO
@@ -420,4 +437,43 @@ export function useDebounce<T>(
     }
   }, []);
   return { flush };
+}
+
+/**
+ * Backstage has a bug where multiple tabs using the GitHub access token can each
+ * fetch a new token and invalidate tokens cached in older tabs. To mitigate this
+ * we patch an internal refresh predicate so a token verified as invalid can be
+ * refreshed before retrying the request.
+ */
+let invalidGitHubAccessToken = '';
+function patchGithubApiToEnableForcedRefresh<T>(
+  gitHubApi: T,
+  isDevelopment: boolean,
+): T {
+  const sessionManager = (gitHubApi as any)?.sessionManager;
+  if (!sessionManager?.originalSessionShouldRefreshFunc) {
+    if (typeof sessionManager?.sessionShouldRefreshFunc === 'function') {
+      sessionManager.originalSessionShouldRefreshFunc =
+        sessionManager.sessionShouldRefreshFunc;
+      sessionManager.sessionShouldRefreshFunc = function (session: any) {
+        const accessToken = session?.providerInfo?.accessToken;
+        if (isDevelopment && invalidGitHubAccessToken && !accessToken) {
+          throw new Error(
+            'The expected location of the accessToken was empty. This workaround is no longer working',
+          );
+        }
+        if (accessToken === invalidGitHubAccessToken) {
+          invalidGitHubAccessToken = '';
+          return true;
+        }
+        return sessionManager.originalSessionShouldRefreshFunc(session);
+      };
+    } else if (isDevelopment) {
+      throw new Error(
+        'The expected function "sessionShouldRefreshFunc" does not exist. This workaround is no longer working',
+      );
+    }
+  }
+
+  return gitHubApi;
 }

--- a/plugins/ros/src/utils/translations.ts
+++ b/plugins/ros/src/utils/translations.ts
@@ -676,6 +676,8 @@ export const pluginRiScMessages = {
       'Risk scorecard "{{riScId}}" cannot be automatically migrated to the latest version.',
     ContentStatusUnknown:
       'Failed to fetch risk scorecard "{{riScId}}" with unknown status: {{status}}',
+    InvalidGitHubAccessToken:
+      'Github-token was not valid. Try refreshing the page or logging out and in of github in backstage.',
     ContentStatusSchemaValidationFailed:
       'Failed to fetch risk scorecard "{{riScId}}". Its content does not match the expected format. It may have been manually edited or corrupted.',
     ContentStatusDecryptionFailedMessage: {
@@ -1450,6 +1452,8 @@ export const pluginRiScNorwegianTranslation = createTranslationResource({
 
           'errorMessages.ContentStatusUnknown':
             'Kunne ikke hente ROS-analyse "{{riScId}}" med ukjent status: {{status}}',
+          'errorMessages.InvalidGitHubAccessToken':
+            'Github-tokenet var ikke gyldig. Prøv en refresh av siden eller å logge ut og inn av github i backstage.',
           'infoMessages.OpenedPullRequest': 'Åpnet pull request',
           'infoMessages.CreatedPullRequest':
             'Godkjenning av risiko- og sårbarhetsanalysen ble lagret',

--- a/plugins/ros/src/utils/types.ts
+++ b/plugins/ros/src/utils/types.ts
@@ -245,6 +245,7 @@ export enum ProcessingStatus {
   ErrorWhenCreatingPullRequest = 'ErrorWhenCreatingPullRequest',
   ErrorWhenFetchingGcpCryptoKeys = 'ErrorWhenFetchingGcpCryptoKeys',
   FailedToFetchGcpProjectIds = 'Failed to fetch GCP project IDs',
+  InvalidGitHubAccessToken = 'InvalidGitHubAccessToken',
 }
 
 export enum ContentStatus {


### PR DESCRIPTION
Workaround som lar oss invalidere github access-token om vi ser at det er ugyldig. Dette vil da fortsette påbegynt handling og være usynlig for bruker. En konsekvens er at om man veksler mellom å skrive i ulike tabs vil det bli generert ny access-token hver gang, men tror ikke det er spesielt ille.

Ikke den peneste løsningen, men kommer ikke på noe bedre som løser selve problemet på en god måte for bruker uten å få backstage til å fikse. Har også forsøkt å legge inn litt feil for utvikler som skal plukke opp om dette begynner å feile.

En veldig tilsvarende feil rapportert til backstage er denne, så ikke veldig sannsynlig at de fikser: https://github.com/backstage/backstage/issues/24815
