### PR TITLE
fix: feature toggle for predefined scenarioes

### DIFF
--- a/plugins/ros/src/components/predefinedScenarios/PredefinedScenariosBanner.tsx
+++ b/plugins/ros/src/components/predefinedScenarios/PredefinedScenariosBanner.tsx
@@ -59,7 +59,10 @@ export function PredefinedScenariosBanner({
     );
   }
 
-  if (hasAnyPredefinedScenario(selectedRiSc, predefinedScenarios)) {
+  if (
+    predefinedScenarios.length === 0 ||
+    hasAnyPredefinedScenario(selectedRiSc, predefinedScenarios)
+  ) {
     return null;
   }
   const newScenarios = buildPredefinedScenarios(


### PR DESCRIPTION
# 📝 Beskrivelse

Oppgave i Notion

Lagt til sjekk for at banneret til predefinerte scenarioer ikke skal dukke opp hvis det ikke finnes noen nye scenarioer. 

---

## ✅ Sjekkliste

- [ ] Branchen er rebaset på `main` eller main er merget inn (Tips: om du bruker grensensittet i GitHub, så kan du velge rebase istedenfor merge. MERK: da må du slette din lokale branch og hente på nytt om du skal gjøre flere endringer).
- [ ] Det er brukt minst en conventional commit med passende prefix **hvis** denne PR'en skal lage en ny release (er det endringer i selve pluginet skal det som hovedregel det).
- [ ] [Test-sjekklisten](../CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig.
