### PR TITLE
feat: trigger release for switch to proxy backend for predefinedscenarios

### DIFF
--- a/plugins/ros/src/hooks/usePredefinedScenarios.ts
+++ b/plugins/ros/src/hooks/usePredefinedScenarios.ts
@@ -1,4 +1,3 @@
-import { useQuery } from '@tanstack/react-query';
 import {
   configApiRef,
   fetchApiRef,
@@ -6,12 +5,13 @@ import {
   identityApiRef,
   useApi,
 } from '@backstage/core-plugin-api';
-import { ScenarioDTO } from '../utils/DTOs.ts';
+import { useQuery } from '@tanstack/react-query';
 import { buildNativeBackendUrls } from '../urls/backend.ts';
 import { URLS } from '../urls/index.ts';
-import { useGithubRepositoryInformation } from '../utils/hooks.ts';
 import { latestSupportedVersion } from '../utils/constants.ts';
+import { ScenarioDTO } from '../utils/DTOs.ts';
 import { useNativeRiScBackendFeatureFlag } from '../utils/featureFlags.ts';
+import { useGithubRepositoryInformation } from '../utils/hooks.ts';
 
 const PREDEFINED_SCENARIOS_TEMPLATE_ID = 'web-app-api';
 const PREDEFINED_SCENARIOS_SOURCE_TEST_REF = 'add-scenarios';


### PR DESCRIPTION
# 📝 Beskrivelse

Lenke til oppgave i Notion

Release PR for https://github.com/kartverket/backstage-plugin-risk-scorecard-frontend/pull/993

---

## ✅ Sjekkliste

- [ ] Branchen er rebaset på `main` eller main er merget inn
- [ ] Det er brukt minst en conventional commit med passende prefix hvis denne PR'en skal lage en ny release
- [ ] [Test-sjekklisten](../CONTRIBUTING.md#test-checklist) er gjennomført hensiktsmessig.
